### PR TITLE
Automatic definition of alias

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -787,7 +787,7 @@ class Recipe:
     """Recipe object."""
 
     info_keys = ('project', 'dataset', 'exp', 'ensemble', 'version')
-    """List of keys to be used to compose the alias, ordered by priority"""
+    """List of keys to be used to compose the alias, ordered by priority."""
 
     def __init__(self,
                  raw_recipe,
@@ -948,7 +948,8 @@ class Recipe:
         return preprocessor_output
 
     def _set_alias(self, preprocessor_output):
-        """Add unique alias for datasets
+        """
+        Add unique alias for datasets.
 
         Generates a unique alias for each dataset that will be shared by all
         variables. Tries to make it as small as possible to make it useful for


### PR DESCRIPTION
Automatic composition of a unique alias for each dataset used by a diagnostic. Should help diagnostics developer, as it can be used as a dictionary key, plot label. Will also help with the compatibility of the diagnostics with different datasets and uses, i.e comparing different datasets or comparing different ensemble members of the same dataset can be done with the same code

Now it takes into account project, dataset, experiment, ensemble and version to compose the alias, but can be extended easily by adding keys to a tuple. Does not fail if any of those keys is missing.

If user adds a custom alias, it is respected but the dataset is taken into account for the purpose of getting the automatic for the others

See #164 