### PR TITLE
Add fixes for tos (sea surface temperature) for some cmip5 models

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
@@ -1,5 +1,6 @@
-
 """Fixes for EC-Earth model."""
+from dask import array as da
+
 from ..fix import Fix
 
 
@@ -48,4 +49,26 @@ class Sftlf(Fix):
         metadata = cube.metadata
         cube *= 100
         cube.metadata = metadata
+        return cube
+
+
+class Tos(Fix):
+    """Fixes for tos."""
+
+    def fix_data(self, cube):
+        """
+        Fix tos data.
+
+        Fixes mask
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        cube.data = da.ma.masked_equal(cube.core_data(), 273.15)
         return cube

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
@@ -71,5 +71,6 @@ class Tos(Fix):
         iris.cube.Cube
 
         """
-        self.get_cube_from_list(cubes).standard_name = 'sea_surface_temperature'
+        cube = self.get_cube_from_list(cubes)
+        cube.standard_name = 'sea_surface_temperature'
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
@@ -1,5 +1,6 @@
-
 """Fixes for GFDL CM2p1 model."""
+from copy import deepcopy
+
 from ..fix import Fix
 from ..cmip5.gfdl_esm2g import AllVars as BaseAllVars
 
@@ -30,3 +31,45 @@ class Sftof(Fix):
         cube *= 100
         cube.metadata = metadata
         return cube
+
+
+class Tos(Fix):
+    """Fixes for tos"""
+
+    def fix_data(self, cube):
+        """
+        Fix data.
+
+        Fixes discrepancy between declared units and real units
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        metadata = deepcopy(cube.metadata)
+        cube += 273.15
+        cube.metadata = metadata
+        return cube
+
+    def fix_metadata(self, cubes):
+        """
+        Fix metadata.
+
+        Fixes wrong standard_name.
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        self.get_cube_from_list(cubes).standard_name = 'sea_surface_temperature'
+        return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_cm3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_cm3.py
@@ -1,4 +1,3 @@
-
 """Fixes for GFDL CM3 model."""
 from ..fix import Fix
 
@@ -31,3 +30,25 @@ class Sftof(Fix):
         cube *= 100
         cube.metadata = metadata
         return cube
+
+
+class Tos(Fix):
+    """Fixes for tos"""
+
+    def fix_metadata(self, cubes):
+        """
+        Fix metadata.
+
+        Fixes wrong standard_name.
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        self.get_cube_from_list(cubes).standard_name = 'sea_surface_temperature'
+        return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_cm3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_cm3.py
@@ -50,5 +50,6 @@ class Tos(Fix):
         iris.cube.Cube
 
         """
-        self.get_cube_from_list(cubes).standard_name = 'sea_surface_temperature'
+        cube = self.get_cube_from_list(cubes)
+        cube.standard_name = 'sea_surface_temperature'
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_esm2m.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_esm2m.py
@@ -75,5 +75,6 @@ class Tos(Fix):
         iris.cube.Cube
 
         """
-        self.get_cube_from_list(cubes).standard_name = 'sea_surface_temperature'
+        cube = self.get_cube_from_list(cubes)
+        cube.standard_name = 'sea_surface_temperature'
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_esm2m.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_esm2m.py
@@ -55,3 +55,25 @@ class Co2(Fix):
         cube *= 1e6
         cube.metadata = metadata
         return cube
+
+
+class Tos(Fix):
+    """Fixes for tos."""
+
+    def fix_metadata(self, cubes):
+        """
+        Fix metadata.
+
+        Fixes wrong standard_name.
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        self.get_cube_from_list(cubes).standard_name = 'sea_surface_temperature'
+        return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/miroc5.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc5.py
@@ -128,3 +128,25 @@ class Tas(Fix):
 
         """
         return round_coordinates(cubes)
+
+
+class Tos(Fix):
+    """Fixes for tos."""
+
+    def fix_data(self, cube):
+        """
+        Fix tos data.
+
+        Fixes mask
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        cube.data = da.ma.masked_equal(cube.core_data(), 0.)
+        return cube


### PR DESCRIPTION
This adds fixes for tos (temperature ocean surface, sst) for a couple of cmip5 models.
One thing that surprised me was that our common
```
metadata = cube.metadata
do_something(cube)
cube.metadata = metadata
```
trope did not work for me when adding a scalar to a cube. I had to add a `deepcopy(metadata)` to avoid the loss of important metadata.

Maybe in these cases it is better to work on the data directly like
```
cube.data = cube.core_data() + 273.15
```
so?