### PR TITLE
Making ESMValTool available for CORDEX (Regional) Data

### DIFF
--- a/esmvalcore/cmor/_fixes/CORDEX/Cordex_boundaries_guessing.py
+++ b/esmvalcore/cmor/_fixes/CORDEX/Cordex_boundaries_guessing.py
@@ -6,7 +6,7 @@ from scipy.ndimage import map_coordinates
 from ..fix import Fix
 
 
-class Tos(Fix):
+class CordexFix(Fix):
     """Fixes for tos."""
 
     def fix_data(self, cube):
@@ -31,8 +31,8 @@ class Tos(Fix):
             rlat, np.arange(len(rlat)), k=1)
         rlon_to_idx = InterpolatedUnivariateSpline(
             rlon, np.arange(len(rlon)), k=1)
-        rlat_idx_bnds = rlat_to_idx(cube.coord('grid_latitude').bounds())
-        rlon_idx_bnds = rlon_to_idx(cube.coord('grid_longitude').bounds())
+        rlat_idx_bnds = rlat_to_idx(cube.coord('grid_latitude')._guess_bounds())
+        rlon_idx_bnds = rlon_to_idx(cube.coord('grid_longitude')._guess_bounds())
 
         # Calculate latitude/longitude vertices by interpolation
         lat_vertices = []

--- a/esmvalcore/cmor/_fixes/cmip5/bcc_csm1_1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/bcc_csm1_1.py
@@ -31,8 +31,8 @@ class Tos(Fix):
             rlat, np.arange(len(rlat)), k=1)
         rlon_to_idx = InterpolatedUnivariateSpline(
             rlon, np.arange(len(rlon)), k=1)
-        rlat_idx_bnds = rlat_to_idx(cube.coord('grid_latitude').bounds)
-        rlon_idx_bnds = rlon_to_idx(cube.coord('grid_longitude').bounds)
+        rlat_idx_bnds = rlat_to_idx(cube.coord('grid_latitude')._guess_bounds())
+        rlon_idx_bnds = rlon_to_idx(cube.coord('grid_longitude')._guess_bounds())
 
         # Calculate latitude/longitude vertices by interpolation
         lat_vertices = []

--- a/esmvalcore/cmor/_fixes/cmip5/bcc_csm1_1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/bcc_csm1_1.py
@@ -31,8 +31,8 @@ class Tos(Fix):
             rlat, np.arange(len(rlat)), k=1)
         rlon_to_idx = InterpolatedUnivariateSpline(
             rlon, np.arange(len(rlon)), k=1)
-        rlat_idx_bnds = rlat_to_idx(cube.coord('grid_latitude').bounds())
-        rlon_idx_bnds = rlon_to_idx(cube.coord('grid_longitude').bounds())
+        rlat_idx_bnds = rlat_to_idx(cube.coord('grid_latitude').bounds)
+        rlon_idx_bnds = rlon_to_idx(cube.coord('grid_longitude').bounds)
 
         # Calculate latitude/longitude vertices by interpolation
         lat_vertices = []

--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -234,7 +234,7 @@ CMIP5:
 OBS:
   cmor_strict: false
   input_dir:
-    default: '/'
+    default: 'Tier[tier]/[dataset]'
     BSC: '[type]/[institute.lower]/[dataset.lower]/[freq_folder]/[short_name][freq_base]'
   input_file:
     default: '[project]_[dataset]_[type]_[version]_[mip]_[short_name]_*.nc'
@@ -262,7 +262,7 @@ obs4mips:
 ana4mips:
   cmor_strict: false
   input_dir:
-    default: '/'
+    default: 'Tier[tier]/[dataset]'
   input_file: '[short_name]_[mip]_[type]_[dataset]_*.nc'
   output_file: '[project]_[mip]_[type]_[dataset]_[short_name]_[start_year]-[end_year]'
   cmor_type: 'CMIP5'

--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -234,7 +234,7 @@ CMIP5:
 OBS:
   cmor_strict: false
   input_dir:
-    default: 'Tier[tier]/[dataset]'
+    default: '/'
     BSC: '[type]/[institute.lower]/[dataset.lower]/[freq_folder]/[short_name][freq_base]'
   input_file:
     default: '[project]_[dataset]_[type]_[version]_[mip]_[short_name]_*.nc'
@@ -262,7 +262,7 @@ obs4mips:
 ana4mips:
   cmor_strict: false
   input_dir:
-    default: 'Tier[tier]/[dataset]'
+    default: '/'
   input_file: '[short_name]_[mip]_[type]_[dataset]_*.nc'
   output_file: '[project]_[mip]_[type]_[dataset]_[short_name]_[start_year]-[end_year]'
   cmor_type: 'CMIP5'
@@ -272,4 +272,12 @@ EMAC:
     default: '[dataset]'
   input_file: ''
   output_file: '[dataset]_[ensemble]_[short_name]_[start_year]-[end_year]'
+  cmor_type: 'CMIP5'
+
+CORDEX:
+  input_dir:
+    default: '/'
+    drs1: '[project]/[product]/[Domain]/[Institution]/[GCMModelName]/[CMIP5ExperimentName]/[CMIP5EnsembleMember]/[RCMModelName]/[RCMVersionID]/[Frequency]/[VariableName]'
+  input_file: '[short_name]_[dataset]_[gcminstitute]_[exp]_[ensemble]_[rcmmodelname]_[version]_[mip]_*.nc'
+  output_file: '[short_name]_[dataset]_[exp]_[ensemble]_[version]_[mip]_[start_year]-[end_year]'
   cmor_type: 'CMIP5'

--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -42,7 +42,7 @@ rootpath:
   OBS: ~/obs_inputpath
   RAWOBS: ~/rawobs_inputpath
   default: ~/default_inputpath
-  CORDEX: /predictia/Data/c3s512/data/era5
+  CORDEX: ~/default_inputpath
 
 # Directory structure for input data: [default]/BADC/DKRZ/ETHZ/etc
 # See config-developer.yml for definitions.

--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -42,8 +42,11 @@ rootpath:
   OBS: ~/obs_inputpath
   RAWOBS: ~/rawobs_inputpath
   default: ~/default_inputpath
+  CORDEX: /predictia/Data/c3s512/data/era5
 
 # Directory structure for input data: [default]/BADC/DKRZ/ETHZ/etc
 # See config-developer.yml for definitions.
 drs:
   CMIP5: default
+  CORDEX: default
+  OBS: default

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -8,6 +8,7 @@ import iris
 import numpy as np
 import stratify
 from iris.analysis import AreaWeighted, Linear, Nearest, UnstructuredNearest
+from iris import coord_systems
 
 from ..cmor.fix import fix_file, fix_metadata
 from ..cmor.table import CMOR_TABLES
@@ -249,6 +250,20 @@ def regrid(cube, target_grid, scheme, lat_offset=True, lon_offset=True):
             if coords:
                 [coord] = coords
                 cube.remove_coord(coord)
+
+    # we first define the name of the coordinate system for the target grid in order to avoid iris problems with the
+    # coordinate system given by WGS84.
+    if target_grid.coord_system() == None:
+        target_grid.coord('latitude').coord_system =  iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
+                                                                         semi_minor_axis=6356752.31424)
+        target_grid.coord('longitude').coord_system = iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
+                                                                         semi_minor_axis=6356752.31424)
+
+    if cube.coord_system() == None:
+        cube.coord('latitude').coord_system =  iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
+                                                                         semi_minor_axis=6356752.31424)
+        cube.coord('longitude').coord_system = iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
+                                                                         semi_minor_axis=6356752.31424)
 
     # Perform the horizontal regridding.
     if _attempt_irregular_regridding(cube, scheme):

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -254,13 +254,13 @@ def regrid(cube, target_grid, scheme, lat_offset=True, lon_offset=True):
     # we first define the name of the coordinate system for the target grid in order to avoid iris problems with the
     # coordinate system given by WGS84.
     if target_grid.coord_system() == None:
-        target_grid.coord('latitude').coord_system =  iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
+        target_grid.coord('latitude').coord_system = iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
                                                                          semi_minor_axis=6356752.31424)
         target_grid.coord('longitude').coord_system = iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
                                                                          semi_minor_axis=6356752.31424)
 
     if cube.coord_system() == None:
-        cube.coord('latitude').coord_system =  iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
+        cube.coord('latitude').coord_system = iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
                                                                          semi_minor_axis=6356752.31424)
         cube.coord('longitude').coord_system = iris.coord_systems.GeogCS(semi_major_axis=6378137.0,
                                                                          semi_minor_axis=6356752.31424)

--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -6,17 +6,18 @@ import iris
 import numpy as np
 
 from ._mapping import get_empty_data, map_slices, ref_to_dims_index
+from esmvalcore.cmor._fixes.cmip5.bcc_csm1_1 import Tos
 
 
 ESMF_MANAGER = ESMF.Manager(debug=False)
 
 ESMF_LON, ESMF_LAT = 0, 1
 
-ESMF_REGRID_METHODS = {
-    'linear': ESMF.RegridMethod.BILINEAR,
-    'area_weighted': ESMF.RegridMethod.CONSERVE,
-    'nearest': ESMF.RegridMethod.NEAREST_STOD,
-}
+#ESMF_REGRID_METHODS = {
+#    'linear': ESMF.RegridMethod.BILINEAR,
+#    'area_weighted': ESMF.RegridMethod.CONSERVE,
+#    'nearest': ESMF.RegridMethod.NEAREST_STOD,
+#}
 
 MASK_REGRIDDING_MASK_VALUE = {
     ESMF.RegridMethod.BILINEAR: np.array([1]),
@@ -24,13 +25,13 @@ MASK_REGRIDDING_MASK_VALUE = {
     ESMF.RegridMethod.NEAREST_STOD: np.array([]),
 }
 
-# ESMF_REGRID_METHODS = {
-#     'bilinear': ESMF.RegridMethod.BILINEAR,
-#     'patch': ESMF.RegridMethod.PATCH,
-#     'conserve': ESMF.RegridMethod.CONSERVE,
-#     'nearest_stod': ESMF.RegridMethod.NEAREST_STOD,
-#     'nearest_dtos': ESMF.RegridMethod.NEAREST_DTOS,
-# }
+ESMF_REGRID_METHODS = {
+     'bilinear': ESMF.RegridMethod.BILINEAR,
+     'patch': ESMF.RegridMethod.PATCH,
+     'conserve': ESMF.RegridMethod.CONSERVE,
+     'nearest_stod': ESMF.RegridMethod.NEAREST_STOD,
+     'nearest_dtos': ESMF.RegridMethod.NEAREST_DTOS,
+}
 
 
 def cf_2d_bounds_to_esmpy_corners(bounds, circular):
@@ -101,7 +102,7 @@ def get_grid(esmpy_lat, esmpy_lon,
     return grid
 
 
-def is_lon_circular(lon):
+def is_lon_circular(lon, cube):
     """Determine if longitudes are circular."""
     if isinstance(lon, iris.coords.DimCoord):
         circular = lon.circular
@@ -109,8 +110,15 @@ def is_lon_circular(lon):
         if lon.ndim == 1:
             seam = lon.bounds[-1, 1] - lon.bounds[0, 0]
         elif lon.ndim == 2:
-            seam = (lon.bounds[1:-1, -1, (1, 2)]
-                    - lon.bounds[1:-1, 0, (0, 3)])
+            try:
+                seam = (lon.bounds[1:-1, -1, (1, 2)] - lon.bounds[1:-1, 0, (0, 3)])
+
+            except:
+                object = Tos()
+                cube = object.fix_data(cube)
+                lon = cube.coord('longitude')
+                seam = (lon.bounds[1:-1, -1, (1, 2)] - lon.bounds[1:-1, 0, (0, 3)])
+
         else:
             raise NotImplementedError('AuxCoord longitude is higher '
                                       'dimensional than 2d. Giving up.')
@@ -125,7 +133,7 @@ def cube_to_empty_field(cube):
     """Build an empty ESMF field from a cube."""
     lat = cube.coord('latitude')
     lon = cube.coord('longitude')
-    circular = is_lon_circular(lon)
+    circular = is_lon_circular(lon, cube)
     esmpy_coords = coords_iris_to_esmpy(lat, lon, circular)
     grid = get_grid(*esmpy_coords, circular=circular)
     field = ESMF.Field(grid,

--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -6,7 +6,7 @@ import iris
 import numpy as np
 
 from ._mapping import get_empty_data, map_slices, ref_to_dims_index
-from esmvalcore.cmor._fixes.cmip5.bcc_csm1_1 import Tos
+from esmvalcore.cmor._fixes.CORDEX.Cordex_boundaries_guessing import CordexFix
 
 
 ESMF_MANAGER = ESMF.Manager(debug=False)
@@ -114,7 +114,7 @@ def is_lon_circular(lon, cube):
                 seam = (lon.bounds[1:-1, -1, (1, 2)] - lon.bounds[1:-1, 0, (0, 3)])
 
             except:
-                object = Tos()
+                object = CordexFix()
                 cube = object.fix_data(cube)
                 lon = cube.coord('longitude')
                 seam = (lon.bounds[1:-1, -1, (1, 2)] - lon.bounds[1:-1, 0, (0, 3)])


### PR DESCRIPTION
First of all, I decided to create the esmvalcore/cmor/_fixes/CORDEX/Cordex_boundaries_guessing.py  file. It was created because the CORDEX data has not boundaries for rlat and rlon, so they were guessed with an Iris functionality. This file is really similar to the fix given by "bcc_csm1_1.py", but with the guessing difference.

Secondly, I added the CORDEX project into the "config-developer.yml" file as defined at the head of the file where a template is given. I also changed the input default directory for some of the other projects in order to get simplicity, but it is not necessary. Moreover, I have created the rootpath in the "config-user.yml"

Third, I have created an if statement before performing the regrid to add the coordinate system of the target grid (ERA5 dataset) before entering into Iris functions. That's because Iris does not let to make a regrid between two cubes whose coordinates systems are not given. In the case of the CORDEX data, they are given. However, the ERA5 cubes had not any coord_system associated to their coordinate variables. You can see this mandatory need in the __call__ function for the iris/analysis/_regrid.py

```
        src_x_coord, src_y_coord = get_xy_dim_coords(src)
        grid_x_coord, grid_y_coord = self._tgt_grid
        src_cs = src_x_coord.coord_system
        grid_cs = grid_x_coord.coord_system

        if src_cs is None and grid_cs is None:
            if not (src_x_coord.is_compatible(grid_x_coord) and
                    src_y_coord.is_compatible(grid_y_coord)):
                raise ValueError("The rectilinear grid coordinates of the "
                                 "given cube and target grid have no "
                                 "coordinate system but they do not have "
                                 "matching coordinate metadata.")
        elif src_cs is None or grid_cs is None:
            raise ValueError("The rectilinear grid coordinates of the given "
                             "cube and target grid must either both have "
                             "coordinate systems or both have no coordinate "
                             "system but with matching coordinate metadata.")
```
That's why I changed it from 'None' to 'GeogCS' with the ellipsoid features given by the WGS84.

In the regrid method of the ESMValTool, you have created a function that decided to use Iris or ESMPy depending on the regrid 'scheme' given in the recipe. When I used ESMPy, it did not recognize the temperature values given in the dataset, so I decided to change it to Iris. For changing it, I undo a step that some of the developer did before at the very beginning of preprocessor/_regrid_esmpy.py where some lines are commented in and commented out.
In the same directory, I changed the function is_lon_circular() due the fact that I did not have boundaries in the longitude coordinate. Therefore, I imported the fix file mentioned before, in order to guess the rlat and rlon boundaries and produce with the function, the longitude and latitude boundaries, making the function is_lon_circular() to work. Now, instead of giving only the longitude, we also have to give the function a cube.

If you have any doubts, recommendation on how to do it more clear, or concerns... Let me know!
Thank you in advance.

