### PR TITLE
add hourly support for regrid_time

### DIFF
--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -304,8 +304,9 @@ See also :func:`esmvalcore.preprocessor.annual_mean`.
 This function aligns the time points of each component dataset to allow the
 subtraction of two Iris cubes from different datasets. The operation makes the
 datasets time points common and sets common calendars; it also resets the time
-bounds and auxiliary coordinates to reflect the artifically shifted time
-points. The current implementation works only for monthly and daily data.
+bounds and auxiliary coordinates to reflect the artificially shifted time
+points. The current implementation works for monthly, daily, 6 hourly, 3
+hourly and hourly data.
         
 See also :func:`esmvalcore.preprocessor.regrid_time`.
 

--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -306,7 +306,9 @@ subtraction of two Iris cubes from different datasets. The operation makes the
 datasets time points common and sets common calendars; it also resets the time
 bounds and auxiliary coordinates to reflect the artificially shifted time
 points. The current implementation works for monthly, daily, 6 hourly, 3
-hourly and hourly data.
+hourly and hourly data. It takes a string representing the data frequency as
+an input argument:
+* frequency: mon, day, 1hr, 3hr, or 6hr 
         
 See also :func:`esmvalcore.preprocessor.regrid_time`.
 

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -260,7 +260,7 @@ def regrid_time(cube, frequency):
     cube: iris.cube.Cube
         input cube.
     frequency: str
-        data frequency: mon or day
+        data frequency: mon, day, 1hr, 3hr or 6hr
 
     Returns
     -------
@@ -283,6 +283,26 @@ def regrid_time(cube, frequency):
         cube.coord('time').cells = [
             datetime.datetime(t.year, t.month, t.day, 0, 0, 0) for t in time_c
         ]
+    elif frequency == '1hr':
+        cube.coord('time').cells = [
+            datetime.datetime(t.year, t.month, t.day, t.hour, 0, 0)
+            for t in time_c
+        ]
+    elif frequency == '3hr':
+        cube.coord('time').cells = [
+            datetime.datetime(
+                t.year, t.month, t.day, t.hour - t.hour % 3, 0, 0
+            )
+            for t in time_c
+        ]
+    elif frequency == '6hr':
+        cube.coord('time').cells = [
+            datetime.datetime(
+                t.year, t.month, t.day, t.hour - t.hour % 6, 0, 0
+            )
+            for t in time_c
+        ]
+
     # TODO add correct handling of hourly data
     # this is a bit more complicated since it can be 3h, 6h etc
     cube.coord('time').points = [

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -252,8 +252,9 @@ def regrid_time(cube, frequency):
 
     Operations on time units, calendars, time points and auxiliary
     coordinates so that any cube from cubes can be subtracted from any
-    other cube from cubes. Currently this function supports only monthly
-    (frequency=mon) and daily (frequency=day) data time frequencies.
+    other cube from cubes. Currently this function supports monthly
+    (frequency=mon), daily (frequency=day), 6-hourly (frequency=6hr),
+    3-hourly (frequency=3hr) and hourly (frequency=1hr) data time frequencies.
 
     Parameters
     ----------

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -303,8 +303,6 @@ def regrid_time(cube, frequency):
             for t in time_c
         ]
 
-    # TODO add correct handling of hourly data
-    # this is a bit more complicated since it can be 3h, 6h etc
     cube.coord('time').points = [
         cube.coord('time').units.date2num(cl)
         for cl in cube.coord('time').cells

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -277,6 +277,53 @@ class TestRegridTimeDaily(tests.Test):
         self.assertArrayEqual(diff_cube.data, expected)
 
 
+class TestRegridTime1Hourly(tests.Test):
+    """Tests for regrid_time with hourly frequency."""
+
+    def setUp(self):
+        """Prepare tests"""
+        self.cube_1 = _create_sample_cube()
+        self.cube_2 = _create_sample_cube()
+        self.cube_2.data = self.cube_2.data * 2.
+        self.cube_1.remove_coord('time')
+        self.cube_2.remove_coord('time')
+        self.cube_1.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(14. * 60. + 6., 38. * 60. + 6., 60.),
+                standard_name='time',
+                units=Unit(
+                    'minutes since 1950-01-01 00:00:00', calendar='360_day'),
+            ),
+            0,
+        )
+        self.cube_2.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(14. * 60. + 34., 38. * 60. + 34., 60.),
+                standard_name='time',
+                units=Unit(
+                    'minutes since 1950-01-01 00:00:00', calendar='360_day'),
+            ),
+            0,
+        )
+        add_auxiliary_coordinate([self.cube_1, self.cube_2])
+
+    def test_regrid_time_day(self):
+        """Test changes to cubes."""
+        # test daily
+        newcube_1 = regrid_time(self.cube_1, frequency='1hr')
+        newcube_2 = regrid_time(self.cube_2, frequency='1hr')
+        # no changes to core data
+        self.assertArrayEqual(newcube_1.data, self.cube_1.data)
+        self.assertArrayEqual(newcube_2.data, self.cube_2.data)
+        # no changes to number of coords and aux_coords
+        assert len(newcube_1.coords()) == len(self.cube_1.coords())
+        assert len(newcube_1.aux_coords) == len(self.cube_1.aux_coords)
+        # test difference; also diff is zero
+        expected = self.cube_1.data
+        diff_cube = newcube_2 - newcube_1
+        self.assertArrayEqual(diff_cube.data, expected)
+
+
 def make_time_series(number_years=2):
     """Make a cube with time only dimension."""
     times = np.array([i * 30 + 15 for i in range(0, 12 * number_years, 1)])

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -277,6 +277,102 @@ class TestRegridTimeDaily(tests.Test):
         self.assertArrayEqual(diff_cube.data, expected)
 
 
+class TestRegridTime6Hourly(tests.Test):
+    """Tests for regrid_time with 6-hourly frequency."""
+
+    def setUp(self):
+        """Prepare tests"""
+        self.cube_1 = _create_sample_cube()
+        self.cube_2 = _create_sample_cube()
+        self.cube_2.data = self.cube_2.data * 2.
+        self.cube_1.remove_coord('time')
+        self.cube_2.remove_coord('time')
+        self.cube_1.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(10. * 6. + 5., 34. * 6. + 5., 6.),
+                standard_name='time',
+                units=Unit(
+                    'hours since 1950-01-01 00:00:00', calendar='360_day'),
+            ),
+            0,
+        )
+        self.cube_2.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(10. * 6. + 2., 34. * 6. + 2., 6.),
+                standard_name='time',
+                units=Unit(
+                    'hours since 1950-01-01 00:00:00', calendar='360_day'),
+            ),
+            0,
+        )
+        print(self.cube_1)
+        add_auxiliary_coordinate([self.cube_1, self.cube_2])
+
+    def test_regrid_time_6hour(self):
+        """Test changes to cubes."""
+        # test 6-hourly
+        newcube_1 = regrid_time(self.cube_1, frequency='6hr')
+        newcube_2 = regrid_time(self.cube_2, frequency='6hr')
+        # no changes to core data
+        self.assertArrayEqual(newcube_1.data, self.cube_1.data)
+        self.assertArrayEqual(newcube_2.data, self.cube_2.data)
+        # no changes to number of coords and aux_coords
+        assert len(newcube_1.coords()) == len(self.cube_1.coords())
+        assert len(newcube_1.aux_coords) == len(self.cube_1.aux_coords)
+        # test difference; also diff is zero
+        expected = self.cube_1.data
+        diff_cube = newcube_2 - newcube_1
+        self.assertArrayEqual(diff_cube.data, expected)
+
+
+class TestRegridTime3Hourly(tests.Test):
+    """Tests for regrid_time with 3-hourly frequency."""
+
+    def setUp(self):
+        """Prepare tests"""
+        self.cube_1 = _create_sample_cube()
+        self.cube_2 = _create_sample_cube()
+        self.cube_2.data = self.cube_2.data * 2.
+        self.cube_1.remove_coord('time')
+        self.cube_2.remove_coord('time')
+        self.cube_1.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(17. * 180. + 40., 41. * 180. + 40., 180.),
+                standard_name='time',
+                units=Unit(
+                    'minutes since 1950-01-01 00:00:00', calendar='360_day'),
+            ),
+            0,
+        )
+        self.cube_2.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(17. * 180. + 150., 41. * 180. + 150., 180.),
+                standard_name='time',
+                units=Unit(
+                    'minutes since 1950-01-01 00:00:00', calendar='360_day'),
+            ),
+            0,
+        )
+        print(self.cube_1)
+        add_auxiliary_coordinate([self.cube_1, self.cube_2])
+
+    def test_regrid_time_3hour(self):
+        """Test changes to cubes."""
+        # test 3-hourly
+        newcube_1 = regrid_time(self.cube_1, frequency='3hr')
+        newcube_2 = regrid_time(self.cube_2, frequency='3hr')
+        # no changes to core data
+        self.assertArrayEqual(newcube_1.data, self.cube_1.data)
+        self.assertArrayEqual(newcube_2.data, self.cube_2.data)
+        # no changes to number of coords and aux_coords
+        assert len(newcube_1.coords()) == len(self.cube_1.coords())
+        assert len(newcube_1.aux_coords) == len(self.cube_1.aux_coords)
+        # test difference; also diff is zero
+        expected = self.cube_1.data
+        diff_cube = newcube_2 - newcube_1
+        self.assertArrayEqual(diff_cube.data, expected)
+
+
 class TestRegridTime1Hourly(tests.Test):
     """Tests for regrid_time with hourly frequency."""
 
@@ -307,9 +403,9 @@ class TestRegridTime1Hourly(tests.Test):
         )
         add_auxiliary_coordinate([self.cube_1, self.cube_2])
 
-    def test_regrid_time_day(self):
+    def test_regrid_time_hour(self):
         """Test changes to cubes."""
-        # test daily
+        # test hourly
         newcube_1 = regrid_time(self.cube_1, frequency='1hr')
         newcube_2 = regrid_time(self.cube_2, frequency='1hr')
         # no changes to core data


### PR DESCRIPTION
This pull request adds support for 1hr, 3hr and 6hr frequencies in the regrid_time method of the preprocessor.