### PR TITLE
Make 2d and 1d region extraction consistent

### DIFF
--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -59,14 +59,16 @@ def extract_region(cube, start_longitude, end_longitude, start_latitude,
     if cube.coord('latitude').ndim == 1:
         region_subset = cube.intersection(
             longitude=(start_longitude, end_longitude),
-            latitude=(start_latitude, end_latitude))
+            latitude=(start_latitude, end_latitude),
+            ignore_bounds=True,
+        )
         region_subset = region_subset.intersection(longitude=(0., 360.))
         return region_subset
     # irregular grids
     lats = cube.coord('latitude').points
     lons = cube.coord('longitude').points
-    select_lats = start_latitude < lats < end_latitude
-    select_lons = start_longitude < lons < end_longitude
+    select_lats = start_latitude <= lats <= end_latitude
+    select_lons = start_longitude <= lons <= end_longitude
     selection = select_lats & select_lons
     data = da.ma.masked_where(~selection, cube.core_data())
     return cube.copy(data)


### PR DESCRIPTION
There were two issues with consistency between regular and irregular grids region extraction

- Regular was being extracted if any point in the cell belonged to the region, 2D only if the center is inside
- Regular was adding points in the boundaries case,  2D was not

Now the behaviour is changed so we always use the center and boundaries are included

Detected by @mwjury 