### PR TITLE
Fix regrid

### DIFF
--- a/esmvalcore/preprocessor/_mapping.py
+++ b/esmvalcore/preprocessor/_mapping.py
@@ -120,8 +120,7 @@ def get_associated_coords(cube, dimensions):
     aux_coords = []
     for i in dims:
         coords = cube.coords(contains_dimension=i, dim_coords=False)
-        if coords:
-            aux_coords.append(coords[0])
+        aux_coords.extend(coords)
     return dim_coords, aux_coords
 
 
@@ -221,6 +220,8 @@ def map_slices(src, func, src_rep, dst_rep):
     res_shape = src_keep_spec[0] + dst_rep.shape
     dim_coords = src_keep_spec[1] + dst_rep.coords(dim_coords=True)
     dim_coords_and_dims = [(c, i) for i, c in enumerate(dim_coords)]
+    aux_coords_and_dims = [(c, src.coord_dims(c)) for c in src_keep_spec[2]]
+    aux_coords_and_dims += [(c, src.coord_dims(c)) for c in dst_rep.aux_coords]
     dst = iris.cube.Cube(
         data=get_empty_data(res_shape, dtype=src.dtype),
         standard_name=src.standard_name,
@@ -230,6 +231,7 @@ def map_slices(src, func, src_rep, dst_rep):
         attributes=src.attributes,
         cell_methods=src.cell_methods,
         dim_coords_and_dims=dim_coords_and_dims,
+        aux_coords_and_dims=aux_coords_and_dims,
     )
     for src_ind, dst_ind in index_iterator(src_slice_dims, src.shape):
         res = func(src[src_ind])

--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -277,6 +277,14 @@ def get_grid_representants(src, dst):
     dst_shape += dst_horiz_rep.shape
     dim_coords += dst_horiz_rep.coords(dim_coords=True)
     dim_coords_and_dims = [(c, i) for i, c in enumerate(dim_coords)]
+    aux_coords_and_dims = []
+    for coord in dst_horiz_rep.aux_coords:
+        dims = dst_horiz_rep.coord_dims(coord)
+        if not dims:
+            continue
+        if src_rep.ndim == 3:
+            dims = [dim + 1 for dim in dims]
+        aux_coords_and_dims.append((coord, dims))
     dst_rep = iris.cube.Cube(
         data=get_empty_data(dst_shape, src.dtype),
         standard_name=src.standard_name,
@@ -286,6 +294,7 @@ def get_grid_representants(src, dst):
         attributes=src.attributes,
         cell_methods=src.cell_methods,
         dim_coords_and_dims=dim_coords_and_dims,
+        aux_coords_and_dims=aux_coords_and_dims,
     )
     return src_rep, dst_rep
 

--- a/tests/unit/preprocessor/_mapping/test_mapping.py
+++ b/tests/unit/preprocessor/_mapping/test_mapping.py
@@ -175,9 +175,12 @@ class Test(tests.Test):
                 self.time, self.z, self.src_latitude, self.src_longitude
             ]
             contains_dimension = kwargs.get('contains_dimension', None)
-            if contains_dimension is not None:
-                return [dim_coords_list[contains_dimension]]
             dim_coords = kwargs.get('dim_coords', None)
+            if contains_dimension is not None:
+                if dim_coords:
+                    return [dim_coords_list[contains_dimension]]
+                else:
+                    return []
             if dim_coords:
                 return dim_coords_list
             return [self.scalar_coord] + dim_coords_list
@@ -217,6 +220,7 @@ class Test(tests.Test):
             units=cf_units.Unit('K'),
             attributes={},
             cell_methods={},
+            aux_coords=[],
             __getitem__=lambda a, b: mock.sentinel.src_data,
         )
         self.src_repr = mock.Mock(
@@ -224,12 +228,14 @@ class Test(tests.Test):
             dtype=np.float32,
             coords=src_repr_coords,
             ndim=2,
+            aux_coords=[],
         )
         self.dst_repr = mock.Mock(
             spec=iris.cube.Cube,
             dtype=np.float32,
             coords=dst_repr_coords,
             shape=(2, 2),
+            aux_coords=[],
         )
 
     @mock.patch('esmvalcore.preprocessor._mapping.get_empty_data')
@@ -237,6 +243,7 @@ class Test(tests.Test):
     def test_map_slices(self, mock_cube, mock_get_empty_data):
         """Test map_slices."""
         mock_get_empty_data.return_value = mock.sentinel.empty_data
+        mock_cube.aux_coords = []
         dst = map_slices(self.src_cube, lambda s: np.ones((2, 2)),
                          self.src_repr, self.dst_repr)
         self.assertEqual(dst, mock_cube.return_value)
@@ -252,4 +259,5 @@ class Test(tests.Test):
             attributes=self.src_cube.attributes,
             cell_methods=self.src_cube.cell_methods,
             dim_coords_and_dims=dim_coords_and_dims,
+            aux_coords_and_dims=[],
         )

--- a/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
+++ b/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
@@ -107,12 +107,12 @@ class TestHelpers(tests.Test):
             lat_2d_pre_bounds[:-1, :-1], lat_2d_pre_bounds[:-1, 1:],
             lat_2d_pre_bounds[1:, 1:], lat_2d_pre_bounds[1:, :-1]
         ],
-                                 axis=2)
+            axis=2)
         lon_2d_bounds = np.stack([
             lon_2d_pre_bounds[:-1, :-1], lon_2d_pre_bounds[:-1, 1:],
             lon_2d_pre_bounds[1:, 1:], lon_2d_pre_bounds[1:, :-1]
         ],
-                                 axis=2)
+            axis=2)
         self.lat_1d = mock.Mock(
             iris.coords.DimCoord,
             standard_name='latitude',
@@ -254,6 +254,7 @@ class TestHelpers(tests.Test):
             coords=coords,
         )
         self.cube.__getitem__ = mock.Mock(return_value=self.cube)
+        self.cube.aux_coords = []
         self.unmasked_cube = mock.Mock(
             spec=iris.cube.Cube,
             dtype=np.float32,
@@ -612,6 +613,7 @@ class TestHelpers(tests.Test):
         mock_get_empty_data.return_value = mock.sentinel.empty_data
         src_rep = get_grid_representants(src, self.cube)[0]
         self.assertEqual(src, src_rep)
+        mock_cube.aux_coords = []
         mock_cube.assert_called_once_with(
             data=mock.sentinel.empty_data,
             standard_name=src.standard_name,
@@ -621,6 +623,7 @@ class TestHelpers(tests.Test):
             attributes=src.attributes,
             cell_methods=src.cell_methods,
             dim_coords_and_dims=[(self.depth, 0)],
+            aux_coords_and_dims=[],
         )
 
     @mock.patch('esmvalcore.preprocessor._regrid_esmpy.get_grid_representant',
@@ -631,6 +634,7 @@ class TestHelpers(tests.Test):
                                            mock_get_empty_data):
         """Test extraction of grid representants from 2 spatial d cube."""
         src = self.cube
+        mock_cube.aux_coords = []
         mock_get_empty_data.return_value = mock.sentinel.empty_data
         src_rep = get_grid_representants(src, self.cube)[0]
         self.assertEqual(src, src_rep)
@@ -643,6 +647,7 @@ class TestHelpers(tests.Test):
             attributes=src.attributes,
             cell_methods=src.cell_methods,
             dim_coords_and_dims=[],
+            aux_coords_and_dims=[],
         )
 
     @mock.patch('esmvalcore.preprocessor._regrid_esmpy.map_slices')


### PR DESCRIPTION
I added a regrid from irregular grid to another irregular grid (from the U points to the T points in NEMO terms) in the computation of the ocean heat transport derived variable.

It worked well but for some auxiliary coordinates that were not added to the new cube. this pull request fix this