### PR TITLE
Better concatenation error message

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -87,15 +87,20 @@ def _fix_cube_attributes(cubes):
 def concatenate(cubes):
     """Concatenate all cubes after fixing metadata."""
     _fix_cube_attributes(cubes)
-    try:
-        cube = iris.cube.CubeList(cubes).concatenate_cube()
-        return cube
-    except iris.exceptions.ConcatenateError as ex:
-        logger.error('Can not concatenate cubes: %s', ex)
-        logger.error('Cubes:')
-        for cube in cubes:
-            logger.error(cube)
-        raise ex
+    concatenated = iris.cube.CubeList(cubes).concatenate()
+    if len(concatenated) == 1:
+        return concatenated[0]
+    logger.error('Can not concatenate cubes into a single one.')
+    logger.error('Resulting cubes:')
+    for cube in concatenated:
+        logger.error(cube)
+        try:
+            time = cube.coord('time')
+        except iris.exceptions.CoordinateNotFoundError:
+            pass
+        else:
+            logger.error('From %s to %s', time.cell(0), time.cell(-1))
+    raise ValueError('Can not concatenate cubes.')
 
 
 def save(cubes, filename, optimize_access='', compress=False, **kwargs):

--- a/tests/integration/preprocessor/_io/test_concatenate.py
+++ b/tests/integration/preprocessor/_io/test_concatenate.py
@@ -5,7 +5,6 @@ import unittest
 import numpy as np
 from iris.coords import DimCoord
 from iris.cube import Cube
-from iris.exceptions import ConcatenateError
 
 from esmvalcore.preprocessor import _io
 
@@ -40,13 +39,13 @@ class TestConcatenate(unittest.TestCase):
     def test_fail_with_duplicates(self):
         """Test exception raised if two cubes are overlapping."""
         self.raw_cubes.append(self.raw_cubes[0].copy())
-        with self.assertRaises(ConcatenateError):
+        with self.assertRaises(ValueError):
             _io.concatenate(self.raw_cubes)
 
     def test_fail_metadata_differs(self):
         """Test exception raised if two cubes have different metadata."""
         self.raw_cubes[0].units = 'm'
-        with self.assertRaises(ConcatenateError):
+        with self.assertRaises(ValueError):
             _io.concatenate(self.raw_cubes)
 
     def test_fix_attributes(self):


### PR DESCRIPTION
A small pull request to improve the error message we get when we can not concatenate all cubes in one.

Instead of printing all the cubes definitions, now we just plot the concatenated cubes, adding the start and end time of each ones. This should help finding the offending cube(s), and the differences that prevent concatenating.

In order to be able to do that without performance penalties, I changed the call to `concatenate_cube` with a call to `concatenate` and check manually if we get just one cube. 

Example of the new output:

```
2019-09-04 10:11:09,084 UTC [3152] ERROR   Can not concatenate cubes into a single one.
2019-09-04 10:11:09,084 UTC [3152] ERROR   Resulting cubes:
2019-09-04 10:11:09,085 UTC [3152] ERROR   air_temperature / (K)               (time: 72; latitude: 256; longitude: 512)
     Dimension coordinates:
          time                           x             -               -
          latitude                       -             x               -
          longitude                      -             -               x
     Auxiliary coordinates:
          day_of_month                   x             -               -
          day_of_year                    x             -               -
          month_number                   x             -               -
          year                           x             -               -
     Attributes:
          CDI: Climate Data Interface version 1.6.3 (http://code.zmaw.de/projects/cdi...
          CDO: Climate Data Operators version 1.6.3 (http://code.zmaw.de/projects/cdo...
          Conventions: CF-1.4
          NCO: "4.5.4"
          code: 167
          grid_type: gaussian
          institution: European Centre for Medium-Range Weather Forecasts
          nco_openmp_thread_number: 1
          table: 128
2019-09-04 10:11:09,102 UTC [3152] ERROR   From 1979-01-31 18:00:00 to 1989-12-31 18:00:00
2019-09-04 10:11:09,103 UTC [3152] ERROR   air_temperature / (K)               (time: 60; latitude: 256; longitude: 512)
     Dimension coordinates:
          time                           x             -               -
          latitude                       -             x               -
          longitude                      -             -               x
     Auxiliary coordinates:
          day_of_month                   x             -               -
          day_of_year                    x             -               -
          month_number                   x             -               -
          year                           x             -               -
     Attributes:
          CDI: Climate Data Interface version 1.6.3 (http://code.zmaw.de/projects/cdi...
          CDO: Climate Data Operators version 1.6.3 (http://code.zmaw.de/projects/cdo...
          Conventions: CF-1.4
          NCO: "4.5.4"
          code: 167
          grid_type: gaussian
          institution: European Centre for Medium-Range Weather Forecasts
          nco_openmp_thread_number: 1
          table: 128
     Cell methods:
          mean: ensemble
2019-09-04 10:11:09,120 UTC [3152] ERROR   From 1979-02-28 18:00:00 to 1989-11-30 18:00:00
```