### PR TITLE
Check parent_time_unit format

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -475,21 +475,29 @@ class CMORCheck():
             coord.units = cf_units.Unit(coord.units.origin, simplified_cal)
 
             attrs = self._cube.attributes
-            branch_child = 'branch_time_in_child'
-            if branch_child in attrs:
-                attrs[branch_child] = old_units.convert(attrs[branch_child],
-                                                        coord.units)
+            try:
+                parent_time = 'parent_time_units'
+                if parent_time in attrs:
+                    parent_units = cf_units.Unit(attrs[parent_time],
+                                                 simplified_cal)
+                    attrs[parent_time] = 'days since 1850-1-1 00:00:00'
 
-            parent_time = 'parent_time_units'
-            if parent_time in attrs:
-                parent_units = cf_units.Unit(attrs[parent_time],
-                                             simplified_cal)
-                attrs[parent_time] = 'days since 1850-1-1 00:00:00'
+                    branch_parent = 'branch_time_in_parent'
+                    if branch_parent in attrs:
+                        attrs[branch_parent] = parent_units.convert(
+                            attrs[branch_parent], coord.units)
 
-                branch_parent = 'branch_time_in_parent'
-                if branch_parent in attrs:
-                    attrs[branch_parent] = parent_units.convert(
-                        attrs[branch_parent], coord.units)
+                branch_child = 'branch_time_in_child'
+                if branch_child in attrs:
+                    attrs[branch_child] = old_units.convert(
+                        attrs[branch_child], coord.units)
+            except ValueError:
+                if attrs[parent_time] in 'no parent':
+                    pass
+                else:
+                    self.report_error('Attribute parent_time_unit has ' \
+                        'a wrong format and cannot be read by cf_units')
+
 
         tol = 0.001
         intervals = {'dec': (3600, 3660), 'day': (1, 1)}

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -495,9 +495,9 @@ class CMORCheck():
                 if attrs[parent_time] in 'no parent':
                     pass
                 else:
-                    self.report_error('Attribute parent_time_unit has ' \
-                        'a wrong format and cannot be read by cf_units')
-
+                    self.report_error('Attribute parent_time_unit has '
+                                      'a wrong format and cannot be read by'
+                                      'cf_units')
 
         tol = 0.001
         intervals = {'dec': (3600, 3660), 'day': (1, 1)}

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -475,29 +475,32 @@ class CMORCheck():
             coord.units = cf_units.Unit(coord.units.origin, simplified_cal)
 
             attrs = self._cube.attributes
-            try:
-                parent_time = 'parent_time_units'
-                if parent_time in attrs:
-                    parent_units = cf_units.Unit(attrs[parent_time],
-                                                 simplified_cal)
-                    attrs[parent_time] = 'days since 1850-1-1 00:00:00'
 
-                    branch_parent = 'branch_time_in_parent'
-                    if branch_parent in attrs:
-                        attrs[branch_parent] = parent_units.convert(
-                            attrs[branch_parent], coord.units)
-
-                branch_child = 'branch_time_in_child'
-                if branch_child in attrs:
-                    attrs[branch_child] = old_units.convert(
-                        attrs[branch_child], coord.units)
-            except ValueError:
+            parent_time = 'parent_time_units'
+            if parent_time in attrs:
                 if attrs[parent_time] in 'no parent':
                     pass
                 else:
-                    self.report_error('Attribute parent_time_unit has '
-                                      'a wrong format and cannot be read by'
-                                      'cf_units')
+                    try:
+                        parent_units = cf_units.Unit(attrs[parent_time],
+                                                     simplified_cal)
+                    except ValueError:
+                        self.report_warning('Attribute parent_time_units has '
+                                            'a wrong format and cannot be '
+                                            'read by cf_units. A fix needs to '
+                                            'be added to convert properly '
+                                            'attributes branch_time_in_parent '
+                                            'and branch_time_in_child.')
+                    else:
+                        attrs[parent_time] = 'days since 1850-1-1 00:00:00'
+                        branch_parent = 'branch_time_in_parent'
+                        if branch_parent in attrs:
+                            attrs[branch_parent] = parent_units.convert(
+                                attrs[branch_parent], coord.units)
+                        branch_child = 'branch_time_in_child'
+                        if branch_child in attrs:
+                            attrs[branch_child] = old_units.convert(
+                                attrs[branch_child], coord.units)
 
         tol = 0.001
         intervals = {'dec': (3600, 3660), 'day': (1, 1)}

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -409,6 +409,28 @@ class TestCMORCheck(unittest.TestCase):
         assert self.cube.attributes['branch_time_in_parent'] == 0.
         assert self.cube.attributes['branch_time_in_child'] == 3652.
 
+    def test_time_units_no_parent_exp(self):
+        """Test non-conversion of time units attributes for no parent exps."""
+        self.cube.coord('time').units = 'days since 1860-1-1 00:00:00'
+        self.cube.attributes['parent_time_units'] = 'no parent'
+        self.cube.attributes['branch_time_in_parent'] = 0.
+        self.cube.attributes['branch_time_in_child'] = 0.
+        self._check_cube()
+        assert (self.cube.coord('time').units.origin ==
+                'days since 1850-1-1 00:00:00')
+        assert self.cube.attributes['parent_time_units'] == 'no parent'
+        assert self.cube.attributes['branch_time_in_parent'] == 0.
+        assert self.cube.attributes['branch_time_in_child'] == 0.
+
+    def test_wrong_parent_time_unit(self):
+        """Test fail for wrong parent time units."""
+        self.cube.coord('time').units = 'days since 1860-1-1 00:00:00'
+        self.cube.attributes['parent_time_units'] = 'days since ' \
+                                                    '1860-1-1-00-00-00'
+        self.cube.attributes['branch_time_in_parent'] = 0.
+        self.cube.attributes['branch_time_in_child'] = 0.
+        self._check_fails_in_metadata()
+
     def test_time_automatic_fix_failed(self):
         """Test automatic fix fail for incompatible time units."""
         self.cube.coord('time').units = 'K'

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -429,7 +429,9 @@ class TestCMORCheck(unittest.TestCase):
                                                     '1860-1-1-00-00-00'
         self.cube.attributes['branch_time_in_parent'] = 0.
         self.cube.attributes['branch_time_in_child'] = 0.
-        self._check_fails_in_metadata()
+        self._check_warnings_on_metadata()
+        assert self.cube.attributes['branch_time_in_parent'] == 0.
+        assert self.cube.attributes['branch_time_in_child'] == 0
 
     def test_time_automatic_fix_failed(self):
         """Test automatic fix fail for incompatible time units."""


### PR DESCRIPTION
After several issues with the parent_time_unit format (#194, #209) due to #108 , the checker now considers the non-conversion of the time attributes if there is no parent experiment.   If there is a parent experiment but the format of the parent_time_unit cannot be read, an error message appears.

I tried fixing the no parent case as suggested in [here]( https://github.com/ESMValGroup/ESMValCore/pull/194#issuecomment-518556998) , but maybe this solution is simpler.