### PR TITLE
Only run installation test on CircleCI if unit tests succeed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,9 @@ workflows:
   commit:
     jobs:
       - test
-      - install
+      - install:
+          requires:
+            - test
       - documentation
   nightly:
     triggers:

--- a/tests/integration/cmor/test_table.py
+++ b/tests/integration/cmor/test_table.py
@@ -83,9 +83,9 @@ class TestCMIP6Info(unittest.TestCase):
         self.assertEqual(var.frequency, 'mon')
 
     def test_get_institute_from_source(self):
-        """Get institution for source ACCESS-1-0"""
-        institute = self.variables_info.institutes['ACCESS-1-0']
-        self.assertListEqual(institute, ['CSIRO-BOM'])
+        """Get institution for source ACCESS-CM2"""
+        institute = self.variables_info.institutes['ACCESS-CM2']
+        self.assertListEqual(institute, ['CSIRO-ARCCSS-BoM'])
 
     def test_get_activity_from_exp(self):
         """Get activity for experiment 1pctCO2"""

--- a/tests/integration/test_diagnostic_run.py
+++ b/tests/integration/test_diagnostic_run.py
@@ -122,7 +122,7 @@ def test_diagnostic_run(tmp_path, script_file, script):
     recipe = dedent("""
         documentation:
           description: Recipe with no data.
-          authors: [ande_bo]
+          authors: [andela_bouwe]
 
         diagnostics:
           diagnostic_name:

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -119,7 +119,7 @@ DEFAULT_DOCUMENTATION = dedent("""
     documentation:
       description: This is a test recipe.
       authors:
-        - ande_bo
+        - andela_bouwe
       references:
         - contact_authors
         - acknow_project
@@ -749,7 +749,7 @@ def simulate_diagnostic_run(diagnostic_task):
         'statistics': ['mean', 'var'],
         'domains': ['trop', 'et'],
         'plot_types': ['zonal'],
-        'authors': ['ande_bo'],
+        'authors': ['andela_bouwe'],
         'references': ['acknow_project'],
         'ancestors': input_files,
     }
@@ -767,7 +767,7 @@ def simulate_diagnostic_run(diagnostic_task):
 
 TAGS = {
     'authors': {
-        'ande_bo': {
+        'andela_bouwe': {
             'name': 'Bouwe Andela',
         },
     },


### PR DESCRIPTION
This will reduce the load on CircleCI, reducing waiting time for us.