### PR TITLE
Add observational data with CMIP6 CMOR table (OBS6) project

### DIFF
--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -140,6 +140,21 @@ OBS:
   output_file: '[project]_[dataset]_[type]_[version]_[mip]_[short_name]_[start_year]-[end_year]'
   cmor_type: 'CMIP5'
 
+OBS6:
+  cmor_strict: false
+  input_dir:
+    default: 'Tier[tier]/[dataset]'
+    BSC: '[type]/[institute.lower]/[dataset.lower]/[freq_folder]/[short_name][freq_base]'
+  input_file:
+    default: '[project]_[dataset]_[type]_[version]_[mip]_[short_name]_*.nc'
+    BSC: '[short_name]_*.nc'
+  input_fx_dir:
+    default: 'Tier[tier]/[dataset]'
+  input_fx_file:
+    default: '[project]_[dataset]_[type]_[version]_fx_[fx_var].nc'
+  output_file: '[project]_[dataset]_[type]_[version]_[mip]_[short_name]_[start_year]-[end_year]'
+  cmor_type: 'CMIP6'
+
 obs4mips:
   cmor_strict: false
   input_dir:


### PR DESCRIPTION
This adds an OBS6 project, which is the composed of the CMIP6 CMOR table + custom tables.

This is needed for working with ERA5 data, because CMIP5 does not contain an hourly table.

Also, it would be good to start using this as the default for new CMORizers.