### PR TITLE
fix ec_earth: missing_height

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
@@ -94,8 +94,7 @@ class Tas(Fix):
         """
 
         for cube in cubes:
-            coord_names = [coord.var_name for coord in cube.coords()]
-            if 'height' not in coord_names:
+            if not cube.coords(var_name='height'):
                 add_scalar_height_coord(cube)
 
             if cube.coord('time').long_name is None:

--- a/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
@@ -2,6 +2,7 @@
 from dask import array as da
 
 from ..fix import Fix
+from ..shared import add_scalar_height_coord
 
 
 class Sic(Fix):
@@ -72,3 +73,32 @@ class Tos(Fix):
         """
         cube.data = da.ma.masked_equal(cube.core_data(), 273.15)
         return cube
+
+
+class Tas(Fix):
+    """Fixes for tas."""
+
+    def fix_metadata(self, cubes):
+        """
+        Fix potentially missing scalar dimension.
+
+        Parameters
+        ----------
+        cubes: iris CubeList
+            List of cubes to fix
+
+        Returns
+        -------
+        iris.cube.CubeList
+
+        """
+
+        for cube in cubes:
+            coord_names = [coord.var_name for coord in cube.coords()]
+            if 'height' not in coord_names:
+                add_scalar_height_coord(cube)
+
+            if cube.coord('time').long_name is None:
+                cube.coord('time').long_name = 'time'
+
+        return cubes

--- a/tests/integration/cmor/_fixes/cmip5/test_ec_earth.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_ec_earth.py
@@ -2,10 +2,11 @@
 import unittest
 
 from cf_units import Unit
-from iris.cube import Cube
+from iris.coords import DimCoord
+from iris.cube import Cube, CubeList
 
+from esmvalcore.cmor._fixes.cmip5.ec_earth import Sftlf, Sic, Tas
 from esmvalcore.cmor.fix import Fix
-from esmvalcore.cmor._fixes.cmip5.ec_earth import Sftlf, Sic
 
 
 class TestSic(unittest.TestCase):
@@ -46,3 +47,64 @@ class TestSftlf(unittest.TestCase):
         cube = self.fix.fix_data(self.cube)
         self.assertEqual(cube.data[0], 100)
         self.assertEqual(cube.units, Unit('J'))
+
+
+class TestTas(unittest.TestCase):
+    """Test tas fixes."""
+
+    def setUp(self):
+        """Prepare tests."""
+
+        height_coord = DimCoord(
+            2.,
+            standard_name='height',
+            long_name='height',
+            var_name='height',
+            units='m',
+            bounds=None,
+            attributes={'positive': 'up'}
+            )
+
+        time_coord = DimCoord(
+            1.,
+            standard_name='time',
+            var_name='time',
+            units=Unit('days since 2070-01-01 00:00:00', calendar='gregorian'),
+            )
+
+        self.height_coord = height_coord
+
+        self.cube_without = CubeList([Cube([3.0], var_name='tas')])
+        self.cube_without[0].add_aux_coord(time_coord, 0)
+
+        self.cube_with = CubeList([Cube([3.0], var_name='tas')])
+        self.cube_with[0].add_aux_coord(height_coord, ())
+        self.cube_with[0].add_aux_coord(time_coord, 0)
+        self.cube_with[0].coord('time').long_name = 'time'
+
+        self.fix = Tas()
+
+    def test_get(self):
+        """Test fix get"""
+        self.assertListEqual(
+            Fix.get_fixes('CMIP5', 'EC-EARTH', 'tas'), [Tas()])
+
+    def test_tas_fix_metadata(self):
+        """Test metadata fix."""
+
+        out_cube_without = self.fix.fix_metadata(self.cube_without)
+
+        # make sure this does not raise an error
+        out_cube_with = self.fix.fix_metadata(self.cube_with)
+
+        coord = out_cube_without[0].coord('height')
+        assert coord == self.height_coord
+
+        coord = out_cube_without[0].coord('time')
+        assert coord.long_name == "time"
+
+        coord = out_cube_with[0].coord('height')
+        assert coord == self.height_coord
+
+        coord = out_cube_with[0].coord('time')
+        assert coord.long_name == "time"


### PR DESCRIPTION
* In the ETH repository we have some older EC-EARTH files that do not include the height coordinate. This fixes the problem for tas.
* Also some files included `long_name` for time while some did not.
* Only applies the fixes if `height`/ `long_name` is missing.

@ruthlorenz 