### PR TITLE
Extract time failing to get 0:00 hours of first day

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -86,7 +86,7 @@ def extract_time(cube, start_year, start_month, start_day, end_year, end_month,
     t_1 = time_units.date2num(start_date)
     t_2 = time_units.date2num(end_date)
     constraint = iris.Constraint(
-        time=lambda t: t_1 < time_units.date2num(t.point) < t_2)
+        time=lambda t: t_1 <= time_units.date2num(t.point) < t_2)
 
     cube_slice = cube.extract(constraint)
     if cube_slice is None:

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -79,6 +79,24 @@ class TestTimeSlice(tests.Test):
             np.arange(1, 13, 1),
             sliced.coord('month_number').points)
 
+    def test_extract_time_limit(self):
+        """Test extract time when limits are included"""
+        cube = Cube(np.arange(0, 720), var_name='co2', units='J')
+        cube.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(0., 720., 1.),
+                standard_name='time',
+                units=Unit(
+                    'days since 1950-01-01 00:00:00', calendar='360_day'
+                ),
+            ),
+            0,
+        )
+        sliced = extract_time(cube, 1950, 1, 1, 1951, 1, 1)
+        assert_array_equal(
+            np.arange(0, 360),
+            sliced.coord('time').points)
+
     def test_extract_time_no_slice(self):
         """Test fail of extract_time."""
         with self.assertRaises(ValueError):


### PR DESCRIPTION
When loading `sfcWind` with mip `day` for the model

```yaml
- {activity: HighResMIP, dataset: CMCC-CM2-HR4, project: CMIP6, exp: highresSST-present, grid: gn, ensemble: r1i1p1f1, start_year: 1950, end_year: 2014}
```

@sloosvel and @nperezzanon found that the first timestep was missing. After investigating, I found that it was due to an error in the `extract_time` function that this pull request fixes, along with a new test case to test it.

The error was using a strict `start < time` in the constraint. It works well for most cases because models usually assign times close the middle of the interval  and not at the edge, but this model was using 0:00 hours at all times