### PR TITLE
Run multiple recipes, add tmp_dir, disable stack trace for RecipeErrors

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1103,9 +1103,12 @@ class Recipe:
             settings['version'] = __version__
             settings['script'] = script_name
             # Add output dirs to settings
+            subdir = os.path.join(diagnostic_name, script_name)
             for dir_name in ('run_dir', 'plot_dir', 'work_dir'):
-                settings[dir_name] = os.path.join(self._cfg[dir_name],
-                                                  diagnostic_name, script_name)
+                settings[dir_name] = os.path.join(self._cfg[dir_name], subdir)
+            if 'tmp_dir' in self._cfg:
+                settings['tmp_dir'] = os.path.join(self._cfg['tmp_dir'],
+                                                   subdir)
             # Copy other settings
             if self._cfg['write_ncl_interface']:
                 settings['exit_on_ncl_warning'] = self._cfg['exit_on_warning']

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -9,6 +9,7 @@ import yaml
 from mock import create_autospec
 
 import esmvalcore
+from esmvalcore._main import configure_recipe_paths
 from esmvalcore._recipe import TASKSEP, read_recipe_file
 from esmvalcore._recipe_checks import RecipeError
 from esmvalcore._task import DiagnosticTask
@@ -62,7 +63,7 @@ DEFAULT_PREPROCESSOR_STEPS = (
 @pytest.fixture
 def config_user(tmp_path):
     filename = write_config_user_file(tmp_path)
-    cfg = esmvalcore._config.read_config_user_file(filename, 'recipe_test')
+    cfg = esmvalcore._config.read_config_user_file(filename)
     cfg['synda_download'] = False
     return cfg
 
@@ -137,7 +138,8 @@ def get_recipe(tempdir, content, cfg):
     content = str(DEFAULT_DOCUMENTATION + content)
     recipe_file.write_text(content)
 
-    recipe = read_recipe_file(str(recipe_file), cfg)
+    recipe_cfg = configure_recipe_paths(cfg, recipe_file)
+    recipe = read_recipe_file(str(recipe_file), recipe_cfg)
 
     return recipe
 


### PR DESCRIPTION
This pull request
- Adds the possibility to run more than one recipe
- Adds an option to specify a `tmp_dir` in config-user.yml, for use on cluster nodes with local storage attached
- Hides the stack trace if a RecipeError occurs
- Improves the code for reading config-user.yml

Closes {Link to corresponding issue}

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below
