### PR TITLE
Development multi model statistics bugfix

### DIFF
--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -116,13 +116,10 @@ def _put_in_cube(template_cube, cube_data, statistic, t_axis):
 
     # no plevs
     if len(template_cube.shape) == 3:
-        lons = template_cube.coord('longitude')
         cspec = [(times, 0), (lats, 1), (lons, 2)]
     # plevs
     elif len(template_cube.shape) == 4:
         plev = template_cube.coord('air_pressure')
-        lats = template_cube.coord('latitude')
-        lons = template_cube.coord('longitude')
         cspec = [(times, 0), (plev, 1), (lats, 2), (lons, 3)]
     elif len(template_cube.shape) == 1:
         cspec = [

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -107,15 +107,22 @@ def _put_in_cube(template_cube, cube_data, statistic, t_axis):
             t_axis,
             standard_name='time',
             units=template_cube.coord('time').units)
-    lats = template_cube.coord('latitude')
-    lons = template_cube.coord('longitude')
+
+    coord_names = [c.long_name for c in template_cube.coords()]
+    if 'latitude' in coord_names:
+        lats = template_cube.coord('latitude')
+    if 'longitude' in coord_names:
+        lats = template_cube.coord('longitude')
 
     # no plevs
     if len(template_cube.shape) == 3:
+        lons = template_cube.coord('longitude')
         cspec = [(times, 0), (lats, 1), (lons, 2)]
     # plevs
     elif len(template_cube.shape) == 4:
         plev = template_cube.coord('air_pressure')
+        lats = template_cube.coord('latitude')
+        lons = template_cube.coord('longitude')
         cspec = [(times, 0), (plev, 1), (lats, 2), (lons, 3)]
     elif len(template_cube.shape) == 1:
         cspec = [

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -109,13 +109,15 @@ def _put_in_cube(template_cube, cube_data, statistic, t_axis):
             units=template_cube.coord('time').units)
 
     coord_names = [c.long_name for c in template_cube.coords()]
+    coord_names.extend([c.standard_name for c in template_cube.coords()])
     if 'latitude' in coord_names:
         lats = template_cube.coord('latitude')
     if 'longitude' in coord_names:
-        lats = template_cube.coord('longitude')
+        lons = template_cube.coord('longitude')
 
     # no plevs
     if len(template_cube.shape) == 3:
+
         cspec = [(times, 0), (lats, 1), (lons, 2)]
     # plevs
     elif len(template_cube.shape) == 4:

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -112,12 +112,15 @@ def _put_in_cube(template_cube, cube_data, statistic, t_axis):
     coord_names.extend([c.standard_name for c in template_cube.coords()])
     if 'latitude' in coord_names:
         lats = template_cube.coord('latitude')
+    else:
+        lats = None
     if 'longitude' in coord_names:
         lons = template_cube.coord('longitude')
+    else:
+        lons = None
 
     # no plevs
     if len(template_cube.shape) == 3:
-
         cspec = [(times, 0), (lats, 1), (lons, 2)]
     # plevs
     elif len(template_cube.shape) == 4:

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -58,11 +58,13 @@ class Test(tests.Test):
                                       attributes={'positive': 'down'})
         lons = iris.coords.DimCoord([1.5, 2.5],
                                     standard_name='longitude',
+                                    long_name='longitude',
                                     bounds=[[1., 2.], [2., 3.]],
                                     units='degrees_east',
                                     coord_system=coord_sys)
         lats = iris.coords.DimCoord([1.5, 2.5],
                                     standard_name='latitude',
+                                    long_name='latitude',
                                     bounds=[[1., 2.], [2., 3.]],
                                     units='degrees_north',
                                     coord_system=coord_sys)


### PR DESCRIPTION
Minor change to address the bug highlighted in #266. (The `multi_model_statistics` preprocessor still assumes that all cubes have latitude and longitude components and this PR hides the loading of `lats` and `lons` arrays behind an if statement.

