### PR TITLE
Global Total Integrated primary production derived variable

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_intppgt.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_intppgt.dat
@@ -1,0 +1,21 @@
+SOURCE: CMIP5
+!============
+variable_entry:    intppgt
+!============
+modeling_realm:    ocnBgchem
+!----------------------------------
+! Variable attributes:
+!----------------------------------
+standard_name:
+units:             Pg yr-1
+cell_methods:      time: mean area: where sea
+cell_measures:     area: areacello
+long_name:         Global Total Primary Organic Carbon Production by All Types of Phytoplankton
+comment:           Global Total of Vertically integrated total primary (organic carbon) production by phytoplankton.
+!----------------------------------
+! Additional variable information:
+!----------------------------------
+dimensions:        time
+type:              real
+!----------------------------------
+!

--- a/esmvalcore/preprocessor/_derive/intppgt.py
+++ b/esmvalcore/preprocessor/_derive/intppgt.py
@@ -1,0 +1,89 @@
+"""Derivation of variable `intppgt`."""
+import iris
+import numpy as np
+
+from ._baseclass import DerivedVariableBase
+
+
+def calculate_total_flux(intpp_cube, cube_area):
+    """
+    Calculate the area of unmasked cube cells.
+
+    Requires a cube with two spacial dimensions. (no depth coordinate).
+
+    Parameters
+    ----------
+    cube: iris.cube.Cube
+        Data Cube
+    cube_area: iris.cube.Cube
+        Cell area Cube
+
+    Returns
+    -------
+    numpy.array:
+        An numpy array containing the total flux of CO2.
+    """
+    data = []
+    times = intpp_cube.coord('time')
+
+    intpp_cube.data = np.ma.array(intpp_cube.data)
+    for time_itr in np.arange(len(times.points)):
+
+        total_flux = intpp_cube[time_itr].data * cube_area.data
+
+        total_flux = np.ma.masked_where(intpp_cube[time_itr].data.mask,
+                                        total_flux)
+        data.append(total_flux.sum())
+
+    ######
+    # Create a small dummy output array
+    data = np.array(data)
+    return data
+
+
+class DerivedVariable(DerivedVariableBase):
+    """Derivation of variable `intppgt`."""
+
+    # Required variables
+    required = [
+        {
+            'short_name': 'intpp',
+            # 'mip': 'Omon',
+            'fx_files': [
+                'areacello',
+            ],
+        },
+    ]
+
+    @staticmethod
+    def calculate(cubes):
+        """Compute longwave cloud radiative effect."""
+        intpp_cube = cubes.extract_strict(
+            iris.Constraint(name='net_primary_mole_productivity_of_carbon_by_'
+                                 'phytoplankton'))
+
+        try:
+            cube_area = cubes.extract_strict(iris.Constraint(name='cell_area'))
+        except iris.exceptions.ConstraintMismatchError:
+            pass
+
+        total_flux = calculate_total_flux(intpp_cube, cube_area)
+
+        # Dummy result cube
+        result = intpp_cube.collapsed(
+            ['latitude', 'longitude'],
+            iris.analysis.MEAN,
+        )
+
+        # TODO: Load seconds per year from model calendar.
+        days_per_year = 365.
+        seconds_per_day = 24*60*60.
+        g_per_mol = 12.011
+        total_flux = total_flux * g_per_mol * days_per_year * seconds_per_day
+
+        # Convert to Pg yr-1
+        result.data = total_flux * 1E-15
+
+        # These units are set in the CMOR table.
+        result.units = 'Pg yr-1'
+        return result


### PR DESCRIPTION
This PR brings in the Global Total Integrated primary production derived variable. This variable has appeared in the upcoming ESMValTool Paper - part 2, so it would be nice to get it out there before the publication gets to discussions format. 

This is linked with the ESMValTool PR https://github.com/ESMValGroup/ESMValTool/pull/1331, which uses this derived field.