### PR TITLE
CMIP6 updates for variable derivation (lwp)

### DIFF
--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -72,8 +72,6 @@ class DerivedVariable(DerivedVariableBase):
             'GISS-E2-1-G',
             'GISS-E2-1-H',
         ]
-        logger.info("*** dataset = %s", dataset)
-        logger.info("*** project = %s", project)
         affected_projects = ["CMIP5", "CMIP5_ETHZ", "CMIP6"]
         if (project in affected_projects and dataset in bad_datasets):
             logger.info(

--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -41,11 +41,11 @@ class DerivedVariable(DerivedVariableBase):
         #   - CMIP5: model_id and project_id
         #   - CMIP6: source_id and mip_era
         project = clwvi_cube.attributes.get('project_id')
-        if project: # CMIP5
-          dataset = clwvi_cube.attributes.get('model_id')
-        else: # CMIP6
-          project = clwvi_cube.attributes.get('mip_era')
-          dataset = clwvi_cube.attributes.get('source_id')
+        if project:
+            dataset = clwvi_cube.attributes.get('model_id')
+        else:
+            project = clwvi_cube.attributes.get('mip_era')
+            dataset = clwvi_cube.attributes.get('source_id')
 
         # Should we check that the model_id/project_id are the same on both
         # cubes?

--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -36,8 +36,17 @@ class DerivedVariable(DerivedVariableBase):
         clwvi_cube = cubes.extract_strict(_var_name_constraint('clwvi'))
         clivi_cube = cubes.extract_strict(_var_name_constraint('clivi'))
 
-        dataset = clwvi_cube.attributes.get('model_id')
+        # CMIP5 and CMIP6 have different global attributes that we use
+        # to determine model name and project name:
+        #   - CMIP5: model_id and project_id
+        #   - CMIP6: source_id and mip_era
         project = clwvi_cube.attributes.get('project_id')
+        if project: # CMIP5
+          dataset = clwvi_cube.attributes.get('model_id')
+        else: # CMIP6
+          project = clwvi_cube.attributes.get('mip_era')
+          dataset = clwvi_cube.attributes.get('source_id')
+
         # Should we check that the model_id/project_id are the same on both
         # cubes?
 
@@ -59,8 +68,14 @@ class DerivedVariable(DerivedVariableBase):
             'MPI-ESM-MR',
             'MPI-ESM-LR',
             'MPI-ESM-P',
+            'CAMS-CSM1-0',
+            'GISS-E2-1-G',
+            'GISS-E2-1-H',
         ]
-        if (project in ["CMIP5", "CMIP5_ETHZ"] and dataset in bad_datasets):
+        logger.info("*** dataset = %s", dataset)
+        logger.info("*** project = %s", project)
+        affected_projects = ["CMIP5", "CMIP5_ETHZ", "CMIP6"]
+        if (project in affected_projects and dataset in bad_datasets):
             logger.info(
                 "Assuming that variable clwvi from %s dataset %s "
                 "contains only liquid water", project, dataset)

--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -2,8 +2,6 @@
 
 import logging
 
-from iris import Constraint
-
 from ._baseclass import DerivedVariableBase
 from ._shared import _var_name_constraint
 

--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -5,6 +5,7 @@ import logging
 from iris import Constraint
 
 from ._baseclass import DerivedVariableBase
+from ._shared import _var_name_constraint
 
 logger = logging.getLogger(__name__)
 
@@ -32,10 +33,10 @@ class DerivedVariable(DerivedVariableBase):
         these cases, the input `clwvi` cube is just returned.
 
         """
-        clwvi_cube = cubes.extract_strict(
-            Constraint(name='atmosphere_cloud_condensed_water_content'))
-        clivi_cube = cubes.extract_strict(
-            Constraint(name='atmosphere_cloud_ice_content'))
+        # CMIP5 and CMIP6 names are slightly different, so use
+        # variable name instead to extract cubes
+        clwvi_cube = cubes.extract_strict(_var_name_constraint('clwvi'))
+        clivi_cube = cubes.extract_strict(_var_name_constraint('clivi'))
 
         dataset = clwvi_cube.attributes.get('model_id')
         project = clwvi_cube.attributes.get('project_id')


### PR DESCRIPTION
Updates the variable derivation script lwp.py to allow for processing of CMIP6 data:

- CMIP6 cubes cannot be extracted with constraint "name" because of differences in the name between CMIP5 and CMIP5 --> using variable name instead (function _var_name_constraint from _shared.py)
- attribute "project_id" does not exist in CMIP6 --> using attribute "mip_era" in case of CMIP6 data
- attribute "model_id" is defined differently in CMIP5 and CMIP5 --> using attribute "source_id" in case of CMIP6
- added CMIP6 models that provide lwp only instead of lwp+iwp for variable clwvi to list of "bad" models