### PR TITLE
Fix bad parent_time_units for UKESM1-0-LL

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/UKESM1_0_LL.py
+++ b/esmvalcore/cmor/_fixes/cmip6/UKESM1_0_LL.py
@@ -1,0 +1,36 @@
+# pylint: disable=invalid-name, no-self-use, too-few-public-methods
+"""Fixes for UKESM1-0-LL."""
+# import numpy as np
+# import iris
+
+from ..fix import Fix
+
+
+class allvars(Fix):
+    """Fixes for all vars."""
+
+    def fix_metadata(self, cubelist):
+        """
+        Fix non-standard dimension names.
+
+        Parameters
+        ----------
+        cubelist: iris CubeList
+            List of cubes to fix
+
+        Returns
+        -------
+        iris.cube.CubeList
+        """
+        assert 0
+        for cube in cubelist:
+            lats = cube.coord('latitude')
+            lons = cube.coord('longitude')
+            lats.var_name = 'lat'
+            lons.var_name = 'lon'
+
+            time = cube.coord('latitude')
+            if time.units == 'days since 1850-01-01-00-00-00':
+                time.units = 'days since 1850-01-01:00-00-00'
+
+        return cubelist

--- a/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
@@ -29,9 +29,4 @@ class allvars(Fix):
                     cube.attributes[parent_units] = 'days since 1850-01-01'
             except AttributeError:
                 pass
-        for cube in cubelist:
-            lats = cube.coord('latitude')
-            lons = cube.coord('longitude')
-            lats.var_name = 'lat'
-            lons.var_name = 'lon'
         return cubelist

--- a/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
@@ -1,6 +1,4 @@
 """Fixes for UKESM1-0-LL."""
-# import numpy as np
-# import iris
 
 from ..fix import Fix
 

--- a/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name, no-self-use, too-few-public-methods
 """Fixes for UKESM1-0-LL."""
 # import numpy as np
 # import iris

--- a/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
@@ -5,7 +5,6 @@
 
 from ..fix import Fix
 
-
 class allvars(Fix):
     """Fixes for all vars."""
 
@@ -22,15 +21,17 @@ class allvars(Fix):
         -------
         iris.cube.CubeList
         """
-        assert 0
+        parent_units = 'parent_time_units'
+        bad_value = 'days since 1850-01-01-00-00-00'
+        for cube in cubelist:
+            try:
+                if cube.attributes[parent_units] == bad_value:
+                    cube.attributes[parent_units] = 'days since 1850-01-01'
+            except AttributeError:
+                pass
         for cube in cubelist:
             lats = cube.coord('latitude')
             lons = cube.coord('longitude')
             lats.var_name = 'lat'
             lons.var_name = 'lon'
-
-            time = cube.coord('latitude')
-            if time.units == 'days since 1850-01-01-00-00-00':
-                time.units = 'days since 1850-01-01:00-00-00'
-
         return cubelist

--- a/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
@@ -5,6 +5,7 @@
 
 from ..fix import Fix
 
+
 class allvars(Fix):
     """Fixes for all vars."""
 


### PR DESCRIPTION
Added a minor fix for UKESM1 cmip6 model. Literally, I just copied and pasted code from the HadGEM3 fix.

