### PR TITLE
Support Windows Subsystem for Linux

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -54,6 +54,12 @@ def _get_resource_usage(process, start_time, children=True):
     gigabyte = float(2**30)
     precision = [1, 1, None, 1, None, 3, 3]
     cache = {}
+    try:
+        process.io_counters()
+    except AttributeError:
+        counters_available = False
+    else:
+        counters_available = True
     while process.is_running():
         try:
             if children:
@@ -77,8 +83,10 @@ def _get_resource_usage(process, start_time, children=True):
                     proc.cpu_percent(),
                     proc.memory_info().rss / gigabyte,
                     proc.memory_percent(),
-                    proc.io_counters().read_bytes / gigabyte,
-                    proc.io_counters().write_bytes / gigabyte,
+                    (proc.io_counters().read_bytes / gigabyte
+                        if counters_available else float('nan')),
+                    (proc.io_counters().write_bytes / gigabyte
+                        if counters_available else float('nan')),
                 ]
         except (OSError, psutil.AccessDenied, psutil.NoSuchProcess):
             # Try again if an error occurs because some process died

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -84,9 +84,9 @@ def _get_resource_usage(process, start_time, children=True):
                     proc.memory_info().rss / gigabyte,
                     proc.memory_percent(),
                     (proc.io_counters().read_bytes / gigabyte
-                        if counters_available else float('nan')),
+                     if counters_available else float('nan')),
                     (proc.io_counters().write_bytes / gigabyte
-                        if counters_available else float('nan')),
+                     if counters_available else float('nan')),
                 ]
         except (OSError, psutil.AccessDenied, psutil.NoSuchProcess):
             # Try again if an error occurs because some process died


### PR DESCRIPTION
I am using Ubuntu running on the WSL to run ESMValTool. It works mostly fine, but the resource logger was failing because the `io_counters` are not available.

I adapted the code to work even if they are not available and now it works well

It is not real Windows support, but at least it will be easier for Windows users to run ESMValTool
