### PR TITLE
Fix XCO2 units (custom table)

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_xco2.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_xco2.dat
@@ -7,7 +7,7 @@ modeling_realm:    atmos
 ! Variable attributes:
 !----------------------------------
 standard_name:     
-units:             1e-6
+units:             1
 cell_methods:      time: mean
 cell_measures:     area: areacella
 long_name:         Column-average Dry-air Mole Fraction of Atmospheric Carbon Dioxide


### PR DESCRIPTION
Changes the cmor table units from 1e-6 (ppm) to 1.
Cmorized data have been regenerated accordingly.