### PR TITLE
exit right out when trying to get fx files for OBS

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -386,6 +386,10 @@ def _add_fxvar_keys(fx_var_dict, variable):
 def _get_correct_fx_file(variable, fx_varname, config_user):
     """Wrapper to standard file getter to recover the correct fx file."""
     var = dict(variable)
+    # return empty if using OBS
+    # TODO what with OBS data that actually have fx files? Are there any?
+    if var['project'] == 'OBS':
+        return None
     if var['project'] == 'CMIP5':
         fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'fx'}, var)
     elif var['project'] == 'CMIP6':

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -388,7 +388,7 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
     var = dict(variable)
     # return empty if using OBS
     # TODO what with OBS data that actually have fx files? Are there any?
-    if var['project'] == 'OBS':
+    if var['project'] in ['OBS', 'OBS6']:
         return None
     if var['project'] == 'CMIP5':
         fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'fx'}, var)


### PR DESCRIPTION
Addresses the issue with OBS datasets not having fx files (well, at least most of them) and reported in #294 

**CAVEAT** this is a guillotine treatment that is not sensitive to the OBS datasets that may have fx files and should also be always used with  `always_use_ne_mask: True` as arg in the masking preprocessor

Up for discussion :floppy_disk:  