### PR TITLE
Make obs4mips not cmor strict

### DIFF
--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -130,7 +130,7 @@ OBS6:
   cmor_type: 'CMIP6'
 
 obs4mips:
-  cmor_strict: true
+  cmor_strict: false
   input_dir:
     default: 'Tier{tier}/{dataset}'
     RCAST: '/'

--- a/tests/integration/cmor/test_read_cmor_tables.py
+++ b/tests/integration/cmor/test_read_cmor_tables.py
@@ -13,7 +13,7 @@ def test_read_cmor_tables():
 
     table_path = Path(root).parent / 'tables'
 
-    for project in 'CMIP5', 'CMIP6', 'obs4mips':
+    for project in 'CMIP5', 'CMIP6':
         table = CMOR_TABLES[project]
         assert Path(
             table._cmor_folder) == table_path / project.lower() / 'Tables'
@@ -27,4 +27,9 @@ def test_read_cmor_tables():
     project = 'OBS6'
     table = CMOR_TABLES[project]
     assert Path(table._cmor_folder) == table_path / 'cmip6' / 'Tables'
+    assert table.strict is False
+
+    project = 'obs4mips'
+    table = CMOR_TABLES[project]
+    assert Path(table._cmor_folder) == table_path / 'obs4mips' / 'Tables'
     assert table.strict is False

--- a/tests/integration/cmor/test_table.py
+++ b/tests/integration/cmor/test_table.py
@@ -106,12 +106,12 @@ class Testobs4mipsInfo(unittest.TestCase):
         cls.variables_info = CMIP6Info(
             cmor_tables_path='obs4mips',
             default=CustomInfo(),
-            strict=True,
+            strict=False,
             default_table_prefix='obs4MIPs_'
         )
 
     def setUp(self):
-        self.variables_info.strict = True
+        self.variables_info.strict = False
 
     def test_get_table_frequency(self):
         """Test get table frequency"""
@@ -128,7 +128,7 @@ class Testobs4mipsInfo(unittest.TestCase):
         cmor_tables_path = os.path.abspath(cmor_tables_path)
         CMIP6Info(cmor_tables_path, None, True)
 
-    def test_get_variable_ndvi(self):
+    def test_get_variable_ndvistderr(self):
         """Get ndviStderr variable. Note table name obs4MIPs_[mip]"""
         var = self.variables_info.get_variable('obs4MIPs_monStderr',
                                                'ndviStderr')
@@ -148,6 +148,13 @@ class Testobs4mipsInfo(unittest.TestCase):
         self.assertEqual(var.frequency, 'mon')
 
     def test_get_variable_from_custom(self):
+        """Get prStderr variable. Note table name obs4MIPs_[mip]"""
+        var = self.variables_info.get_variable('obs4MIPs_monStderr',
+                                               'prStderr')
+        self.assertEqual(var.short_name, 'prStderr')
+        self.assertEqual(var.frequency, 'mon')
+
+    def test_get_variable_from_custom_deriving(self):
         """Get a variable from default."""
         var = self.variables_info.get_variable(
             'obs4MIPs_Amon', 'swcre', derived=True
@@ -163,7 +170,7 @@ class Testobs4mipsInfo(unittest.TestCase):
 
     def test_get_bad_variable(self):
         """Get none if a variable is not in the given table."""
-        self.assertIsNone(self.variables_info.get_variable('Omon', 'tas'))
+        self.assertIsNone(self.variables_info.get_variable('Omon', 'tras'))
 
 
 class TestCMIP5Info(unittest.TestCase):


### PR DESCRIPTION
As requested by @axel-lauer  in ESMValGroup/ESMValTool#1011, 'obs4mips' is no longer cmor strict, as some of the error variables provided are not part of the tables
