### PR TITLE
Add -i option in rerun message to ignore existing  output directories

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -414,6 +414,8 @@ class DiagnosticTask(BaseTask):
             rerun_msg += ' '.join('{}="{}"'.format(k, env[k]) for k in env
                                   if k not in os.environ)
         rerun_msg += ' ' + ' '.join(cmd)
+        if cmd[1].endswith('.py'):
+            rerun_msg = rerun_msg.replace('.py', '.py -i', 1)
         logger.info("To re-run this diagnostic script, run:\n%s", rerun_msg)
 
         try:


### PR DESCRIPTION
In relation to the error described in issue #136 
I report here a small change to improve the usability of the tool when re-running diagnostics.


**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

* * *

Closes #136 
