### PR TITLE
Add fixes to near-surface uas, vas and tas metadata

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
@@ -20,7 +20,7 @@ class Tas(Fix):
 
         """
         cube = self.get_cube_from_list(cubes)
-        add_scalar_height_coord(cube, 10.0)
+        add_scalar_height_coord(cube, 2.0)
         return cubes
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
@@ -25,7 +25,7 @@ class Tas(Fix):
 
 
 class Uas(Fix):
-    """Fixes for tas."""
+    """Fixes for uas."""
 
     def fix_metadata(self, cubes):
         """
@@ -46,7 +46,7 @@ class Uas(Fix):
 
 
 class Vas(Fix):
-    """Fixes for tas."""
+    """Fixes for vas."""
 
     def fix_metadata(self, cubes):
         """

--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
@@ -1,0 +1,64 @@
+"""Fixes for CESM2 model."""
+from ..fix import Fix
+from ..shared import (add_scalar_height_coord, add_scalar_height_coord_10,
+                      add_scalar_typeland_coord)
+
+
+class Tas(Fix):
+    """Fixes for tas."""
+
+    def fix_metadata(self, cubes):
+        """Add height (2m) coordinate.
+
+        Parameters
+        ----------
+        cube : iris.cube.CubeList
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        cube = self.get_cube_from_list(cubes)
+        add_scalar_height_coord(cube)
+        return cubes
+
+
+class Uas(Fix):
+    """Fixes for tas."""
+
+    def fix_metadata(self, cubes):
+        """Add height (10m) coordinate.
+
+        Parameters
+        ----------
+        cube : iris.cube.CubeList
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        cube = self.get_cube_from_list(cubes)
+        add_scalar_height_coord_10(cube)
+        return cubes
+
+
+class Vas(Fix):
+    """Fixes for tas."""
+
+    def fix_metadata(self, cubes):
+        """Add height (10m) coordinate.
+
+        Parameters
+        ----------
+        cube : iris.cube.CubeList
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        cube = self.get_cube_from_list(cubes)
+        add_scalar_height_coord_10(cube)
+        return cubes

--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
@@ -7,7 +7,8 @@ class Tas(Fix):
     """Fixes for tas."""
 
     def fix_metadata(self, cubes):
-        """Add height (2m) coordinate.
+        """
+        Add height (2m) coordinate.
 
         Parameters
         ----------
@@ -27,7 +28,8 @@ class Uas(Fix):
     """Fixes for tas."""
 
     def fix_metadata(self, cubes):
-        """Add height (10m) coordinate.
+        """
+        Add height (10m) coordinate.
 
         Parameters
         ----------
@@ -47,7 +49,8 @@ class Vas(Fix):
     """Fixes for tas."""
 
     def fix_metadata(self, cubes):
-        """Add height (10m) coordinate.
+        """
+        Add height (10m) coordinate.
 
         Parameters
         ----------

--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
@@ -1,7 +1,6 @@
 """Fixes for CESM2 model."""
 from ..fix import Fix
-from ..shared import (add_scalar_height_coord, add_scalar_height_coord_10,
-                      add_scalar_typeland_coord)
+from ..shared import (add_scalar_height_coord, add_scalar_height_coord_10)
 
 
 class Tas(Fix):

--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
@@ -1,6 +1,6 @@
 """Fixes for CESM2 model."""
 from ..fix import Fix
-from ..shared import (add_scalar_height_coord, add_scalar_height_coord_10)
+from ..shared import add_scalar_height_coord
 
 
 class Tas(Fix):
@@ -19,7 +19,7 @@ class Tas(Fix):
 
         """
         cube = self.get_cube_from_list(cubes)
-        add_scalar_height_coord(cube)
+        add_scalar_height_coord(cube, 10.0)
         return cubes
 
 
@@ -39,7 +39,7 @@ class Uas(Fix):
 
         """
         cube = self.get_cube_from_list(cubes)
-        add_scalar_height_coord_10(cube)
+        add_scalar_height_coord(cube, 10.0)
         return cubes
 
 
@@ -59,5 +59,5 @@ class Vas(Fix):
 
         """
         cube = self.get_cube_from_list(cubes)
-        add_scalar_height_coord_10(cube)
+        add_scalar_height_coord(cube, 10.0)
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
@@ -1,4 +1,4 @@
-"""Fixes for CESM2 model."""
+"""Fixes for GFDL-CM4 model."""
 from ..fix import Fix
 from ..shared import add_scalar_height_coord
 

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -21,19 +21,6 @@ def add_scalar_height_coord(cube, height=2.0):
     return cube
 
 
-def add_scalar_height_coord_10(cube, height=10.0):
-    """Add scalar coordinate 'height' with value of `height`m."""
-    logger.debug("Adding height coordinate (%sm)", height)
-    height_coord = iris.coords.AuxCoord(height,
-                                        var_name='height',
-                                        standard_name='height',
-                                        long_name='height',
-                                        units=Unit('m'),
-                                        attributes={'positive': 'up'})
-    cube.add_aux_coord(height_coord, ())
-    return cube
-
-
 def round_coordinates(cubes, decimals=5):
     """Round all dimensional coordinates of all cubes."""
     for cube in cubes:

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -21,6 +21,19 @@ def add_scalar_height_coord(cube, height=2.0):
     return cube
 
 
+def add_scalar_height_coord_10(cube, height=10.0):
+    """Add scalar coordinate 'height' with value of `height`m."""
+    logger.debug("Adding height coordinate (%sm)", height)
+    height_coord = iris.coords.AuxCoord(height,
+                                        var_name='height',
+                                        standard_name='height',
+                                        long_name='height',
+                                        units=Unit('m'),
+                                        attributes={'positive': 'up'})
+    cube.add_aux_coord(height_coord, ())
+    return cube
+
+
 def round_coordinates(cubes, decimals=5):
     """Round all dimensional coordinates of all cubes."""
     for cube in cubes:


### PR DESCRIPTION
This pull request fixes incomplete GFDL-CM4 metadata for variables uas, vas and tas, by adding the scalar coordinate "height".

Script [shared.py](esmvalcore/cmor/_fixes/shared.py) has been changed accordingly, and the new file [gfdl_cm4.py](esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py) has been created.