### PR TITLE
Fix case when there is a cmip5 or cmip6 dir in CWD

### DIFF
--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -110,8 +110,6 @@ class CMIP6Info(object):
 
     @staticmethod
     def _get_cmor_path(cmor_tables_path):
-        if os.path.isdir(cmor_tables_path):
-            return cmor_tables_path
         cwd = os.path.dirname(os.path.realpath(__file__))
         cmor_tables_path = os.path.join(cwd, 'tables', cmor_tables_path)
         if os.path.isdir(cmor_tables_path):
@@ -560,8 +558,6 @@ class CMIP5Info(object):
 
     @staticmethod
     def _get_cmor_path(cmor_tables_path):
-        if os.path.isdir(cmor_tables_path):
-            return cmor_tables_path
         cwd = os.path.dirname(os.path.realpath(__file__))
         cmor_tables_path = os.path.join(cwd, 'tables', cmor_tables_path)
         return cmor_tables_path


### PR DESCRIPTION
Fixes #316 -> how @bouweandela managed to find this is beyond me, but good find! I guess this is legacy from the cmor tables were in the local cwd? @jvegasbsc 