### PR TITLE
Fixed a bug and added yearly time regridding.

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -498,14 +498,19 @@ def regrid_time(cube, frequency):
         cube with converted time axis and units.
     """
     # fix calendars
+    # standardize time points
+    time_c = [cell.point for cell in cube.coord('time').cells()]
+
     cube.coord('time').units = cf_units.Unit(
         cube.coord('time').units.origin,
         calendar='gregorian',
     )
 
-    # standardize time points
-    time_c = [cell.point for cell in cube.coord('time').cells()]
-    if frequency == 'mon':
+    if frequency == 'year':
+        cube.coord('time').cells = [
+            datetime.datetime(t.year, 7, 1, 0, 0, 0) for t in time_c
+        ]
+    elif frequency == 'mon':
         cube.coord('time').cells = [
             datetime.datetime(t.year, t.month, 15, 0, 0, 0) for t in time_c
         ]


### PR DESCRIPTION
Fixes bugs described in #339 and adds year resolution time regridding.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #339


