### PR TITLE
Added fix for GPP of CESM1-BGC

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
@@ -28,8 +28,8 @@ class Co2(Fix):
         return cube
 
 
-class Nbp(Fix):
-    """Fixes for nbp variable."""
+class Gpp(Fix):
+    """Fixes for gpp variable."""
 
     def fix_data(self, cube):
         """Fix data.
@@ -47,3 +47,7 @@ class Nbp(Fix):
         """
         data = da.ma.masked_equal(cube.core_data(), 1.0e33)
         return cube.copy(data)
+
+
+class Nbp(Gpp):
+    """Fixes for nbp variable."""

--- a/tests/integration/cmor/_fixes/cmip5/test_cesm1_bgc.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_cesm1_bgc.py
@@ -1,16 +1,16 @@
 """Tests for CESM1-BGC fixes."""
 import unittest
 
+import numpy as np
 from cf_units import Unit
 from iris.cube import Cube
 
+from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Co2, Gpp, Nbp
 from esmvalcore.cmor.fix import Fix
-from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Co2
 
 
 class TestCo2(unittest.TestCase):
     """Tests for co2."""
-
     def setUp(self):
         """Prepare tests."""
         self.cube = Cube([1.0], var_name='co2', units='J')
@@ -18,11 +18,46 @@ class TestCo2(unittest.TestCase):
 
     def test_get(self):
         """Test fix get"""
-        self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'CESM1-BGC', 'co2'), [Co2()])
+        self.assertListEqual(Fix.get_fixes('CMIP5', 'CESM1-BGC', 'co2'),
+                             [Co2()])
 
     def test_fix_data(self):
         """Test fix to set units correctly."""
         cube = self.fix.fix_data(self.cube)
         self.assertEqual(cube.data[0], 28.966 / 44.0)
         self.assertEqual(cube.units, Unit('J'))
+
+
+class TestGpp(unittest.TestCase):
+    """Tests for gpp."""
+    def setUp(self):
+        """Prepare tests."""
+        self.cube = Cube([1.0, 1.0e33, 2.0])
+        self.fix = Gpp()
+
+    def test_get(self):
+        """Test fix get"""
+        self.assertListEqual(Fix.get_fixes('CMIP5', 'CESM1-BGC', 'gpp'),
+                             [Gpp()])
+
+    def test_fix_data(self):
+        """Test fix to set missing values correctly."""
+        cube = self.fix.fix_data(self.cube)
+        np.testing.assert_allclose(cube.data[0], 1.0)
+        np.testing.assert_allclose(cube.data[2], 2.0)
+        assert not np.ma.is_masked(cube.data[0])
+        assert np.ma.is_masked(cube.data[1])
+        assert not np.ma.is_masked(cube.data[2])
+
+
+class TestNbp(TestGpp):
+    """Tests for nbp."""
+    def setUp(self):
+        """Prepare tests."""
+        self.cube = Cube([1.0, 1.0e33, 2.0])
+        self.fix = Nbp()
+
+    def test_get(self):
+        """Test fix get"""
+        self.assertListEqual(Fix.get_fixes('CMIP5', 'CESM1-BGC', 'nbp'),
+                             [Nbp()])


### PR DESCRIPTION
Add fix for `gpp` of `CESM1-BGC`.

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

* * *

Closes #352
