### PR TITLE
changed surface albedo calculation from all-sky to clear-sky

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_alb.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_alb.dat
@@ -11,6 +11,7 @@ units:             1
 cell_methods:      time: mean
 cell_measures:     area: areacella
 long_name:         albedo at the surface
+comment:           calculated from clear-sky fluxes
 !----------------------------------
 ! Additional variable information:
 !----------------------------------

--- a/esmvalcore/preprocessor/_derive/alb.py
+++ b/esmvalcore/preprocessor/_derive/alb.py
@@ -5,9 +5,8 @@ authors:
 
 """
 
-from iris import Constraint
-
 from ._baseclass import DerivedVariableBase
+from ._shared import _var_name_constraint
 
 
 class DerivedVariable(DerivedVariableBase):
@@ -18,10 +17,10 @@ class DerivedVariable(DerivedVariableBase):
         """Declare the variables needed for derivation."""
         required = [
             {
-                'short_name': 'rsds'
+                'short_name': 'rsdscs'
             },
             {
-                'short_name': 'rsus'
+                'short_name': 'rsuscs'
             },
         ]
         return required
@@ -29,11 +28,9 @@ class DerivedVariable(DerivedVariableBase):
     @staticmethod
     def calculate(cubes):
         """Compute surface albedo."""
-        rsds_cube = cubes.extract_strict(
-            Constraint(name='surface_downwelling_shortwave_flux_in_air'))
-        rsus_cube = cubes.extract_strict(
-            Constraint(name='surface_upwelling_shortwave_flux_in_air'))
+        rsdscs_cube = cubes.extract_strict(_var_name_constraint('rsdscs'))
+        rsuscs_cube = cubes.extract_strict(_var_name_constraint('rsuscs'))
 
-        rsns_cube = rsus_cube / rsds_cube
+        rsnscs_cube = rsuscs_cube / rsdscs_cube
 
-        return rsns_cube
+        return rsnscs_cube

--- a/tests/integration/preprocessor/_derive/test_interface.py
+++ b/tests/integration/preprocessor/_derive/test_interface.py
@@ -11,10 +11,10 @@ def test_get_required():
 
     reference = [
         {
-            'short_name': 'rsds',
+            'short_name': 'rsdscs',
         },
         {
-            'short_name': 'rsus',
+            'short_name': 'rsuscs',
         },
     ]
 

--- a/tests/integration/preprocessor/_derive/test_interface.py
+++ b/tests/integration/preprocessor/_derive/test_interface.py
@@ -40,13 +40,13 @@ def test_derive_nonstandard_nofx():
     units = 1
     standard_name = ''
 
-    rsds = Cube([2.])
-    rsds.standard_name = 'surface_downwelling_shortwave_flux_in_air'
+    rsdscs = Cube([2.])
+    rsdscs.short_name = 'rsdscs'
 
-    rsus = Cube([1.])
-    rsus.standard_name = 'surface_upwelling_shortwave_flux_in_air'
+    rsuscs = Cube([1.])
+    rsuscs.short_name = 'rsuscs'
 
-    cubes = CubeList([rsds, rsus])
+    cubes = CubeList([rsdscs, rsuscs])
 
     alb = derive(cubes, short_name, long_name, units, standard_name)
 

--- a/tests/integration/preprocessor/_derive/test_interface.py
+++ b/tests/integration/preprocessor/_derive/test_interface.py
@@ -42,9 +42,11 @@ def test_derive_nonstandard_nofx():
 
     rsdscs = Cube([2.])
     rsdscs.short_name = 'rsdscs'
+    rsdscs.var_name = rsdscs.short_name
 
     rsuscs = Cube([1.])
     rsuscs.short_name = 'rsuscs'
+    rsuscs.var_name = rsuscs.short_name
 
     cubes = CubeList([rsdscs, rsuscs])
 


### PR DESCRIPTION
This PR changes calculation of the derived variable "alb" (surface albedo) from using all-sky fluxes to clear-sky fluxes. This method should be a bit closer to how surface albedo is calculated from satellite data.