### PR TITLE
pinned python lower than 3.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,5 @@ dependencies:
   - graphviz
   - gcc_linux-64
   - libunwind  # Needed for Python3.7+
-  - python>=3.6
+  - python>=3.6,<3.8
   - python-stratify

--- a/meta.yaml
+++ b/meta.yaml
@@ -29,13 +29,13 @@ build:
 requirements:
   build:
     - git
-    - python>=3.6
+    - python>=3.6,<3.8
     # Normally installed via pip:
     - pytest-runner
     - setuptools_scm
   run:
     # esmvaltool
-    - python>=3.6
+    - python>=3.6,<3.8
     - libunwind  # specifically for Python3.7+
     - graphviz
     - iris>=2.2.1


### PR DESCRIPTION
Bunch of packages from our environment are not yet able to deal with `python=3.8` that gets picked up automatically by an `env update` or `update all` (eg `numba` and possible a bunch more). Can we get this in asap, please :beer: