### PR TITLE
Generalized shapefile mask to account for possible multiple regions

### DIFF
--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -232,7 +232,7 @@ def _get_geometries_from_shp(shapefilename):
     # Index 0 grabs the lowest resolution mask (no zoom)
     geometries = [contour for contour in reader.geometries()]
     if not geometries:
-        msg = "Could not find any geomtery in {}".format(shapefilename)
+        msg = "Could not find any geometry in {}".format(shapefilename)
         raise ValueError(msg)
     geometries = sorted(geometries, key=lambda x: x.area, reverse=True)
     return geometries


### PR DESCRIPTION
Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValTool/blob/version2_development/CONTRIBUTING.md).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes {Link to corresponding issue}


This is a somewhat generalized version of masking with shapefiles to account for multiple regions masking; this has been desired in #246 and the idea there was to restructure the masker to allow for `regions` :beer:

Explained: `_mask_with_shp(cube, shapefilename, max_region_index)` now takes an extra argument `max_region_index` that is currently set to 1 for `mask_landsea` since we want only the first region there but can be cranked to whatever the shapefile demands by the user who'll implement the next masking routine