### PR TITLE
run extract time only on non fx variables

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -314,7 +314,8 @@ def _get_default_settings(variable, config_user, derive=False):
     settings['fix_metadata'] = dict(fix)
 
     # Configure time extraction
-    if 'start_year' in variable and 'end_year' in variable:
+    if 'start_year' in variable and 'end_year' in variable \
+            and variable['frequency'] != 'fx':
         settings['extract_time'] = {
             'start_year': variable['start_year'],
             'end_year': variable['end_year'] + 1,


### PR DESCRIPTION
someone whose name starts with B and is Dutch pulled a Dutch one on the fx variables that actually have `start_` and `end_time`:grin: Closes https://github.com/ESMValGroup/ESMValTool/issues/1469