### PR TITLE
Fix typo in MIROC-ESM fix

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
@@ -77,7 +77,7 @@ class AllVars(Fix):
                 cube.remove_coord(old)
 
                 plev = DimCoord.from_coord(old)
-                plev.var_name = plev
+                plev.var_name = 'plev'
                 plev.standard_name = 'air_pressure'
                 plev.long_name = 'Pressure '
                 cube.add_dim_coord(plev, dims)

--- a/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
@@ -79,7 +79,7 @@ class AllVars(Fix):
                 plev = DimCoord.from_coord(old)
                 plev.var_name = 'plev'
                 plev.standard_name = 'air_pressure'
-                plev.long_name = 'Pressure '
+                plev.long_name = 'pressure'
                 cube.add_dim_coord(plev, dims)
             except CoordinateNotFoundError:
                 pass


### PR DESCRIPTION
There is a typo in the MIROC-ESM fix, which is corrected in this pull request. Previously this somehow worked, but iris 2.3 appears to be more strict.

**Tasks**

-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

* * *

