### PR TITLE
Use alias instead of dataset in max datasets log

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -270,7 +270,7 @@ def _limit_datasets(variables, profile, max_datasets=0):
             limited.append(variable)
 
     logger.info("Only considering %s",
-                ', '.join(v['dataset'] for v in limited))
+                ', '.join(v['alias'] for v in limited))
 
     return limited
 


### PR DESCRIPTION
A very small change that will be handy for CMIP6: when using the `--max-datasets` option, log the full `alias` of each one instead of just the `dataset` parameter. 

Why? Well, I limited a CMIP6 recipe that was trying to use all members available from all models and the log I got was like this:

```
Only considering MODEL1, MODEL1, MODEL1, MODEL1, MODEL1 
```

With the new change it will be something like this

```
Only considering MODEL1_r1i1p1f1, MODEL1_r2i1p1f1, MODEL1_r3i1p1f1, MODEL1_r4i1p1f1, MODEL1_r5i1p1f1 
```

