### PR TITLE
_regrid.py: guess bounds before regridding if not available: iris regrid requires bounds

### DIFF
--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -254,6 +254,10 @@ def regrid(cube, target_grid, scheme, lat_offset=True, lon_offset=True):
     if _attempt_irregular_regridding(cube, scheme):
         cube = esmpy_regrid(cube, target_grid, scheme)
     else:
+        if not cube.coord('latitude').has_bounds():
+            cube.coord('latitude').guess_bounds()
+        if not cube.coord('longitude').has_bounds():
+            cube.coord('longitude').guess_bounds()
         cube = cube.regrid(target_grid, HORIZONTAL_SCHEMES[scheme])
 
     return cube


### PR DESCRIPTION
**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
<!-- -   [ ] Add unit tests -->
<!-- -   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient. -->
<!-- -   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html) -->
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
<!-- -   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes -->
<!-- -   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below -->

* * *

Closes {#422}
