### PR TITLE
Fix missing refs after 351 merge

### DIFF
--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -10,6 +10,7 @@ following the default order in which they are applied:
 * :ref:`Variable derivation`
 * :ref:`CMOR check and dataset-specific fixes`
 * :ref:`Vertical interpolation`
+* :ref:`Weighting`
 * :ref:`Land/Sea/Ice masking`
 * :ref:`Horizontal regridding`
 * :ref:`Masking of missing values`
@@ -244,6 +245,50 @@ extract the levels and vertically regrid onto the vertical levels of
 	  points will be masked, otherwise they will be set to NaN.
 
 
+.. _weighting:
+
+Weighting
+=========
+
+.. _land/sea fraction weighting:
+
+Land/sea fraction weighting
+---------------------------
+
+This preprocessor allows weighting of data by land or sea fractions. In other
+words, this function multiplies the given input field by a fraction in the range 0-1 to
+account for the fact that not all grid points are completely land- or sea-covered.
+
+The application of this preprocessor is very important for most carbon cycle variables (and
+other land surface outputs), which are e.g. reported in units of
+:math:`kgC~m^{-2}`. Here, the surface unit actually refers to 'square meter of land/sea' and
+NOT 'square meter of gridbox'. In order to integrate these globally or
+regionally one has to weight by both the surface quantity and the
+land/sea fraction.
+
+For example, to weight an input field with the land fraction, the following
+preprocessor can be used:
+
+.. code-block:: yaml
+
+    preprocessors:
+      preproc_weighting:
+        weighting_landsea_fraction:
+          area_type: land
+          exclude: ['CanESM2', 'reference_dataset']
+
+Allowed arguments for the keyword ``area_type`` are ``land`` (fraction is 1
+for grid cells with only land surface, 0 for grid cells with only sea surface
+and values in between 0 and 1 for coastal regions) and ``sea`` (1 for
+sea, 0 for land, in between for coastal regions). The optional argument
+``exclude`` allows to exclude specific datasets from this preprocessor, which
+is for example useful for climate models which do not offer land/sea fraction
+files. This arguments also accepts the special dataset specifiers
+``reference_dataset`` and ``alternative_dataset``.
+
+See also :func:`esmvalcore.preprocessor.weighting_landsea_fraction`.
+
+
 .. _masking:
 
 Masking
@@ -294,7 +339,7 @@ the case for some models and almost all observational datasets), the
 preprocessor attempts to mask the data using Natural Earth mask files (that are
 vectorized rasters). As mentioned above, the spatial resolution of the the
 Natural Earth masks are much higher than any typical global model (10m for
-land and 50m for ocean masks).
+land and glaciated areas and 50m for ocean masks).
 
 See also :func:`esmvalcore.preprocessor.mask_landsea`.
 
@@ -316,6 +361,23 @@ and requires only one argument: ``mask_out``: either ``landsea`` or ``ice``.
 
 As in the case of ``mask_landsea``, the preprocessor automatically retrieves
 the ``fx_files: [sftgif]`` mask.
+
+See also :func:`esmvalcore.preprocessor.mask_landseaice`.
+
+Glaciated masking
+-----------------
+
+For masking out glaciated areas a Natural Earth shapefile is used. To mask
+glaciated areas out, ``mask_glaciated`` can be used:
+
+.. code-block:: yaml
+
+  preprocessors:
+    preproc_mask:
+      mask_glaciated:
+        mask_out: glaciated
+
+and it requires only one argument: ``mask_out``: only ``glaciated``.
 
 See also :func:`esmvalcore.preprocessor.mask_landseaice`.
 
@@ -895,16 +957,21 @@ Extract a shape or a representative point for this shape from
 the data.
 
 Parameters:
-	* ``shapefile``: path to the shapefile containing the geometry of the region to be
-	  extracted. This path can be relative to ``auxiliary_data_dir`` defined in
-	  the :ref:`user configuration file`.
-	* ``method``: the method to select the region, selecting either all points
+  * ``shapefile``: path to the shapefile containing the geometry of the 
+    region to be extracted. If the file contains multiple shapes behaviour 
+    depends on the decomposed parameter. This path can be relative to 
+    ``auxiliary_data_dir`` defined in the :ref:`user configuration file`.
+  * ``method``: the method to select the region, selecting either all points
 	  contained by the shape or a single representative point. Choose either
 	  'contains' or 'representative'. If not a single grid point is contained
 	  in the shape, a representative point will be selected.
-	* ``crop``: by default extract_region_ will be used to crop the data to a
+  * ``crop``: by default extract_region_ will be used to crop the data to a
 	  minimal rectangular region containing the shape. Set to ``false`` to only
 	  mask data outside the shape. Data on irregular grids will not be cropped.
+  * ``decomposed``: by default ``false``, in this case the union of all the 
+    regions in the shape file is masked out. If ``true``, the regions in the 
+    shapefiles are masked out seperately, generating an auxiliary dimension 
+    for the cube for this.
 
 Examples:
     * Extract the shape of the river Elbe from a shapefile:

--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -10,7 +10,6 @@ following the default order in which they are applied:
 * :ref:`Variable derivation`
 * :ref:`CMOR check and dataset-specific fixes`
 * :ref:`Vertical interpolation`
-* :ref:`Weighting`
 * :ref:`Land/Sea/Ice masking`
 * :ref:`Horizontal regridding`
 * :ref:`Masking of missing values`
@@ -245,50 +244,6 @@ extract the levels and vertically regrid onto the vertical levels of
 	  points will be masked, otherwise they will be set to NaN.
 
 
-.. _weighting:
-
-Weighting
-=========
-
-.. _land/sea fraction weighting:
-
-Land/sea fraction weighting
----------------------------
-
-This preprocessor allows weighting of data by land or sea fractions. In other
-words, this function multiplies the given input field by a fraction in the range 0-1 to
-account for the fact that not all grid points are completely land- or sea-covered.
-
-The application of this preprocessor is very important for most carbon cycle variables (and
-other land surface outputs), which are e.g. reported in units of
-:math:`kgC~m^{-2}`. Here, the surface unit actually refers to 'square meter of land/sea' and
-NOT 'square meter of gridbox'. In order to integrate these globally or
-regionally one has to weight by both the surface quantity and the
-land/sea fraction.
-
-For example, to weight an input field with the land fraction, the following
-preprocessor can be used:
-
-.. code-block:: yaml
-
-    preprocessors:
-      preproc_weighting:
-        weighting_landsea_fraction:
-          area_type: land
-          exclude: ['CanESM2', 'reference_dataset']
-
-Allowed arguments for the keyword ``area_type`` are ``land`` (fraction is 1
-for grid cells with only land surface, 0 for grid cells with only sea surface
-and values in between 0 and 1 for coastal regions) and ``sea`` (1 for
-sea, 0 for land, in between for coastal regions). The optional argument
-``exclude`` allows to exclude specific datasets from this preprocessor, which
-is for example useful for climate models which do not offer land/sea fraction
-files. This arguments also accepts the special dataset specifiers
-``reference_dataset`` and ``alternative_dataset``.
-
-See also :func:`esmvalcore.preprocessor.weighting_landsea_fraction`.
-
-
 .. _masking:
 
 Masking
@@ -339,7 +294,7 @@ the case for some models and almost all observational datasets), the
 preprocessor attempts to mask the data using Natural Earth mask files (that are
 vectorized rasters). As mentioned above, the spatial resolution of the the
 Natural Earth masks are much higher than any typical global model (10m for
-land and glaciated areas and 50m for ocean masks).
+land and 50m for ocean masks).
 
 See also :func:`esmvalcore.preprocessor.mask_landsea`.
 
@@ -361,23 +316,6 @@ and requires only one argument: ``mask_out``: either ``landsea`` or ``ice``.
 
 As in the case of ``mask_landsea``, the preprocessor automatically retrieves
 the ``fx_files: [sftgif]`` mask.
-
-See also :func:`esmvalcore.preprocessor.mask_landseaice`.
-
-Glaciated masking
------------------
-
-For masking out glaciated areas a Natural Earth shapefile is used. To mask
-glaciated areas out, ``mask_glaciated`` can be used:
-
-.. code-block:: yaml
-
-  preprocessors:
-    preproc_mask:
-      mask_glaciated:
-        mask_out: glaciated
-
-and it requires only one argument: ``mask_out``: only ``glaciated``.
 
 See also :func:`esmvalcore.preprocessor.mask_landseaice`.
 
@@ -957,21 +895,16 @@ Extract a shape or a representative point for this shape from
 the data.
 
 Parameters:
-  * ``shapefile``: path to the shapefile containing the geometry of the 
-    region to be extracted. If the file contains multiple shapes behaviour 
-    depends on the decomposed parameter. This path can be relative to 
-    ``auxiliary_data_dir`` defined in the :ref:`user configuration file`.
-  * ``method``: the method to select the region, selecting either all points
+	* ``shapefile``: path to the shapefile containing the geometry of the region to be
+	  extracted. This path can be relative to ``auxiliary_data_dir`` defined in
+	  the :ref:`user configuration file`.
+	* ``method``: the method to select the region, selecting either all points
 	  contained by the shape or a single representative point. Choose either
 	  'contains' or 'representative'. If not a single grid point is contained
 	  in the shape, a representative point will be selected.
-  * ``crop``: by default extract_region_ will be used to crop the data to a
+	* ``crop``: by default extract_region_ will be used to crop the data to a
 	  minimal rectangular region containing the shape. Set to ``false`` to only
 	  mask data outside the shape. Data on irregular grids will not be cropped.
-  * ``decomposed``: by default ``false``, in this case the union of all the 
-    regions in the shape file is masked out. If ``true``, the regions in the 
-    shapefiles are masked out seperately, generating an auxiliary dimension 
-    for the cube for this.
 
 Examples:
     * Extract the shape of the river Elbe from a shapefile:

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -412,7 +412,7 @@ def climate_statistics(cube, operator='mean', period='full'):
     cube.remove_coord(clim_coord)
     clim_cube.remove_coord('time')
     iris.util.promote_aux_coord_to_dim_coord(clim_cube, clim_coord.name())
-    return cube
+    return clim_cube
 
 
 def anomalies(cube, period):

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -206,6 +206,9 @@ def daily_statistics(cube, operator='mean'):
 
     operator = get_iris_analysis_operation(operator)
     cube = cube.aggregated_by(['day_of_year', 'year'], operator)
+
+    cube.remove_coord('day_of_year')
+    cube.remove_coord('year')
     return cube
 
 
@@ -405,9 +408,10 @@ def climate_statistics(cube, operator='mean', period='full'):
 
     clim_coord = _get_period_coord(cube, period)
     operator = get_iris_analysis_operation(operator)
-    cube = cube.aggregated_by(clim_coord, operator)
-    cube.remove_coord('time')
-    iris.util.promote_aux_coord_to_dim_coord(cube, clim_coord.name())
+    clim_cube = cube.aggregated_by(clim_coord, operator)
+    cube.remove_coord(clim_coord)
+    clim_cube.remove_coord('time')
+    iris.util.promote_aux_coord_to_dim_coord(clim_cube, clim_coord.name())
     return cube
 
 

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -36,6 +36,13 @@ def _create_sample_cube():
     return cube
 
 
+def add_auxiliary_coordinate(cubelist):
+    """Add AuxCoords to cubes in cubelist."""
+    for cube in cubelist:
+        iris.coord_categorisation.add_day_of_month(cube, cube.coord('time'))
+        iris.coord_categorisation.add_day_of_year(cube, cube.coord('time'))
+
+
 class TestExtractMonth(tests.Test):
     """Tests for extract_month."""
 
@@ -578,6 +585,7 @@ class TestRegridTimeMonthly(tests.Test):
             ),
             0,
         )
+        add_auxiliary_coordinate([self.cube_1, self.cube_2])
 
     def test_regrid_time_mon(self):
         """Test changes to cubes."""
@@ -624,6 +632,7 @@ class TestRegridTimeDaily(tests.Test):
             ),
             0,
         )
+        add_auxiliary_coordinate([self.cube_1, self.cube_2])
 
     def test_regrid_time_day(self):
         """Test changes to cubes."""
@@ -670,6 +679,7 @@ class TestRegridTime6Hourly(tests.Test):
             ),
             0,
         )
+        add_auxiliary_coordinate([self.cube_1, self.cube_2])
 
     def test_regrid_time_6hour(self):
         """Test changes to cubes."""
@@ -716,6 +726,7 @@ class TestRegridTime3Hourly(tests.Test):
             ),
             0,
         )
+        add_auxiliary_coordinate([self.cube_1, self.cube_2])
 
     def test_regrid_time_3hour(self):
         """Test changes to cubes."""
@@ -762,6 +773,7 @@ class TestRegridTime1Hourly(tests.Test):
             ),
             0,
         )
+        add_auxiliary_coordinate([self.cube_1, self.cube_2])
 
     def test_regrid_time_hour(self):
         """Test changes to cubes."""


### PR DESCRIPTION
merging #351 missed a whole lot of refs  that I re-added here
A good example not to trust 100% gitHub when it tells you able to merge and do a `git merge master` in the branch before; that was an old PR that was initially pointing to `development` and the able to merge message has not been redirected towards `master` @mattiarighi can you pls approve so we can fix the `master` (currently the tests are failing there)