### PR TITLE
Log max memory used by the recipe in the main log

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -120,8 +120,8 @@ def resource_usage_logger(pid, filename, interval=1, children=True):
                     logger.info(
                         'Maximum memory used (estimate): %.1f GB', max_mem)
                     logger.info(
-                        'Sampled every second. May be inaccurate if short but '
-                        'high spikes in memory consumption are present.')
+                        'Sampled every second. It may be inaccurate if short but '
+                        'high spikes in memory consumption occur.')
                     return
 
     thread = threading.Thread(target=_log_resource_usage)

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -117,7 +117,11 @@ def resource_usage_logger(pid, filename, interval=1, children=True):
                 file.write(msg)
                 time.sleep(interval)
                 if halt.is_set():
-                    logger.info('Maximum memory used: %.1f GB', max_mem)
+                    logger.info('Maximum memory used (estimate): %.1f GB', max_mem)
+                    logger.info(
+                        'Sampled every second. May be inaccurate if short but high
+                        'spikes in memory consumption are present.'
+                    )
                     return
 
     thread = threading.Thread(target=_log_resource_usage)

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -120,8 +120,8 @@ def resource_usage_logger(pid, filename, interval=1, children=True):
                     logger.info(
                         'Maximum memory used (estimate): %.1f GB', max_mem)
                     logger.info(
-                        'Sampled every second. It may be inaccurate if short but '
-                        'high spikes in memory consumption occur.')
+                        'Sampled every second. It may be inaccurate if short '
+                        'but high spikes in memory consumption occur.')
                     return
 
     thread = threading.Thread(target=_log_resource_usage)

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -117,11 +117,11 @@ def resource_usage_logger(pid, filename, interval=1, children=True):
                 file.write(msg)
                 time.sleep(interval)
                 if halt.is_set():
-                    logger.info('Maximum memory used (estimate): %.1f GB', max_mem)
                     logger.info(
-                        'Sampled every second. May be inaccurate if short but high'
-                        'spikes in memory consumption are present.'
-                    )
+                        'Maximum memory used (estimate): %.1f GB', max_mem)
+                    logger.info(
+                        'Sampled every second. May be inaccurate if short but '
+                        'high spikes in memory consumption are present.')
                     return
 
     thread = threading.Thread(target=_log_resource_usage)

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -119,7 +119,7 @@ def resource_usage_logger(pid, filename, interval=1, children=True):
                 if halt.is_set():
                     logger.info('Maximum memory used (estimate): %.1f GB', max_mem)
                     logger.info(
-                        'Sampled every second. May be inaccurate if short but high
+                        'Sampled every second. May be inaccurate if short but high'
                         'spikes in memory consumption are present.'
                     )
                     return


### PR DESCRIPTION
In the last few days I had to look several time in the resource logger for the maximum consumed memory. It is tedious.

I modified a bit the resource logger so it prints at the end that value in the main log, to make getting this value easier for all. 

I am not very happy with the implementation, so any suggestion on how to improve it is even more welcome than usual