### PR TITLE
Fix to allow Ofx or Omon volcello data in recipe.py

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -415,6 +415,9 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
         fx_var['mip'] = var['mip']
         fx_files = _get_input_files(fx_var, config_user)
 
+    if not fx_files:
+        logger.warning("Unable to locate Fx files in Ofx or %s", var['mip'])
+
     # allow for empty lists corrected for by NE masks
     if fx_files:
         fx_files = fx_files[0]

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -403,15 +403,7 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
                                      var)
         elif fx_varname == 'volcello':
             fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'Ofx'},
-                                         var)
-
-        # elif fx_varname == 'volcello':
-        #     if var['dataset'] in ['UKESM1-0-LL', 'GFDL-CM4', 'HadGEM3-GC31-LL', ]:
-        #         fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': var['mip']},
-        #                                  var)
-        #     else:
-        #         fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'Ofx'},
-        #                                  var)
+                                     var)
     else:
         raise RecipeError(
             f"Project {var['project']} not supported with fx variables")

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -401,6 +401,10 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
         elif fx_varname == 'sftgif':
             fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'fx'},
                                      var)
+        elif fx_varname == 'volcello':
+            fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'Ofx'},
+                                         var)
+
         # elif fx_varname == 'volcello':
         #     if var['dataset'] in ['UKESM1-0-LL', 'GFDL-CM4', 'HadGEM3-GC31-LL', ]:
         #         fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': var['mip']},

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -418,6 +418,7 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
     # allow for empty lists corrected for by NE masks
     if fx_files:
         fx_files = fx_files[0]
+
     return fx_files
 
 

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -401,6 +401,15 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
         elif fx_varname == 'sftgif':
             fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'fx'},
                                      var)
+        elif fx_varname == 'volcello':
+            if var['dataset'] in ['UKESM1-0-LL', 'GFDL-CM4', 'HadGEM3-GC31-LL', ]:
+                fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': var['mip']},
+                                         var)
+            else: 
+                fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'Ofx'},
+                                         var)
+       
+            print(fx_var, var['dataset'], var['mip'])
     else:
         raise RecipeError(
             f"Project {var['project']} not supported with fx variables")
@@ -409,7 +418,6 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
     # allow for empty lists corrected for by NE masks
     if fx_files:
         fx_files = fx_files[0]
-
     return fx_files
 
 

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -401,18 +401,24 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
         elif fx_varname == 'sftgif':
             fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'fx'},
                                      var)
-        elif fx_varname == 'volcello':
-            if var['dataset'] in ['UKESM1-0-LL', 'GFDL-CM4', 'HadGEM3-GC31-LL', ]:
-                fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': var['mip']},
-                                         var)
-            else:
-                fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'Ofx'},
-                                         var)
+        # elif fx_varname == 'volcello':
+        #     if var['dataset'] in ['UKESM1-0-LL', 'GFDL-CM4', 'HadGEM3-GC31-LL', ]:
+        #         fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': var['mip']},
+        #                                  var)
+        #     else:
+        #         fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'Ofx'},
+        #                                  var)
     else:
         raise RecipeError(
             f"Project {var['project']} not supported with fx variables")
 
     fx_files = _get_input_files(fx_var, config_user)
+
+    # If can't find Ofx files, then try with original variable mip
+    if not fx_files and fx_var['mip'] == 'Ofx':
+        fx_var['mip'] = var['mip']
+        fx_files = _get_input_files(fx_var, config_user)
+
     # allow for empty lists corrected for by NE masks
     if fx_files:
         fx_files = fx_files[0]

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -405,11 +405,9 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
             if var['dataset'] in ['UKESM1-0-LL', 'GFDL-CM4', 'HadGEM3-GC31-LL', ]:
                 fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': var['mip']},
                                          var)
-            else: 
+            else:
                 fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'Ofx'},
                                          var)
-       
-            print(fx_var, var['dataset'], var['mip'])
     else:
         raise RecipeError(
             f"Project {var['project']} not supported with fx variables")


### PR DESCRIPTION
**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes {https://github.com/ESMValGroup/ESMValCore/issues/405}
