### PR TITLE
Allowed arbitrary CMIP6 fx variables in special preprocessors and added a catch on project not found in config-developer (invalid project)

### DIFF
--- a/esmvalcore/_config.py
+++ b/esmvalcore/_config.py
@@ -168,7 +168,11 @@ def configure_logging(cfg_file=None, output=None, console_log_level=None):
 def get_project_config(project):
     """Get developer-configuration for project."""
     logger.debug("Retrieving %s configuration", project)
-    return CFG[project]
+    if project in CFG:
+        return CFG[project]
+    else:
+        raise ValueError("Project '{}' not in config-developer".format(
+            project))
 
 
 def get_institutes(variable):

--- a/esmvalcore/_config.py
+++ b/esmvalcore/_config.py
@@ -171,7 +171,7 @@ def get_project_config(project):
     if project in CFG:
         return CFG[project]
     else:
-        raise ValueError("Project '{}' not in config-developer".format(
+        raise ValueError("Project '{}' not in config-developer.yml".format(
             project))
 
 

--- a/esmvalcore/_config.py
+++ b/esmvalcore/_config.py
@@ -171,8 +171,7 @@ def get_project_config(project):
     if project in CFG:
         return CFG[project]
     else:
-        raise ValueError("Project '{}' not in config-developer.yml".format(
-            project))
+        raise ValueError(f"Project '{project}' not in config-developer.yml")
 
 
 def get_institutes(variable):

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -385,11 +385,11 @@ def _add_fxvar_keys(fx_var_dict, variable):
     return fx_variable
 
 
-def _get_cmip6_fx_files(variable, fx_varname, config_user):
-    """Get fx files for CMIP6 (searching all possible mips)."""
+def _get_correct_fx_file(variable, fx_varname, config_user):
+    """Get fx files (searching all possible mips)."""
     # TODO: allow user to specify certain mip if desired
     var = dict(variable)
-    cmor_table = CMOR_TABLES['CMIP6']
+    cmor_table = CMOR_TABLES[variable['project']]
 
     # Get all fx-related mips ('fx' always first, original mip last)
     fx_mips = ['fx']
@@ -423,21 +423,6 @@ def _get_cmip6_fx_files(variable, fx_varname, config_user):
         raise RecipeError(
             f"Requested fx variable '{fx_varname}' for CMIP6 not available in "
             f"any 'fx'-related CMOR table ({fx_mips})")
-
-    return fx_files
-
-
-def _get_correct_fx_file(variable, fx_varname, config_user):
-    """Get paths to fx files."""
-    var = dict(variable)
-    if var['project'] in ['CMIP5', 'OBS', 'OBS6', 'obs4mips']:
-        fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': 'fx'}, var)
-        fx_files = _get_input_files(fx_var, config_user)
-    elif var['project'] == 'CMIP6':
-        fx_files = _get_cmip6_fx_files(var, fx_varname, config_user)
-    else:
-        raise RecipeError(
-            f"Project {var['project']} not supported with fx variables")
 
     # allow for empty lists corrected for by NE masks
     if fx_files:

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -745,7 +745,7 @@ def _get_single_preprocessor_task(variables,
     order = _extract_preprocessor_order(profile)
     ancestor_products = [p for task in ancestor_tasks for p in task.products]
 
-    if variables[0]['frequency'] == 'fx':
+    if variables[0].get('frequency') == 'fx':
         check.check_for_temporal_preprocs(profile)
         ancestor_products = None
 

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -412,7 +412,7 @@ def _get_cmip6_fx_files(variable, fx_varname, config_user):
             # If files found, return them
             if fx_files:
                 logger.debug("Found CMIP6 fx variables '%s':\n%s",
-                             fx_varname, fx_files)
+                             fx_varname, pformat(fx_files))
                 break
     else:
         # No files found

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -410,9 +410,6 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
             raise RecipeError(
                 f"Requested fx variable '{fx_varname}' for CMIP6 not "
                 f"available in any 'fx'-related CMOR table ({fx_mips})")
-        if fx_variable is None:
-            fx_var = _add_fxvar_keys({'short_name': fx_varname, 'mip': '=fx'},
-                                     var)
     else:
         raise RecipeError(
             f"Project {var['project']} not supported with fx variables")

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -389,7 +389,8 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
     """Get fx files (searching all possible mips)."""
     # TODO: allow user to specify certain mip if desired
     var = dict(variable)
-    cmor_table = CMOR_TABLES[variable['project']]
+    var_project = variable['project']
+    cmor_table = CMOR_TABLES[var_project]
 
     # Get all fx-related mips ('fx' always first, original mip last)
     fx_mips = ['fx']
@@ -421,8 +422,8 @@ def _get_correct_fx_file(variable, fx_varname, config_user):
     # If fx variable was not found in any table, raise exception
     if not searched_mips:
         raise RecipeError(
-            f"Requested fx variable '{fx_varname}' for CMIP6 not available in "
-            f"any 'fx'-related CMOR table ({fx_mips})")
+            f"Requested fx variable '{fx_varname}' not available in "
+            f"any 'fx'-related CMOR table ({fx_mips}) for '{var_project}'")
 
     # allow for empty lists corrected for by NE masks
     if fx_files:

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1749,7 +1749,7 @@ def test_fx_vars_mip_change_cmip6(tmp_path, patched_datafinder, config_user):
     assert len(fx_files) == 6
     assert '_fx_' in fx_files['areacella']
     assert '_Ofx_' in fx_files['areacello']
-    assert 'Efx_' in fx_files['clayfrac']
+    assert '_Efx_' in fx_files['clayfrac']
     assert '_fx_' in fx_files['sftlf']
     assert '_fx_' in fx_files['sftgif']
     assert '_Ofx_' in fx_files['sftof']

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1658,7 +1658,7 @@ def test_landmask_no_fx(tmp_path, patched_failing_datafinder, config_user):
           landmask:
             mask_landsea:
               mask_out: sea
-              always_use_ne_mask: true
+              always_use_ne_mask: false
 
         diagnostics:
           diagnostic_name:
@@ -1673,6 +1673,8 @@ def test_landmask_no_fx(tmp_path, patched_failing_datafinder, config_user):
                 ensemble: r1i1p1
                 additional_datasets:
                   - {dataset: CanESM2}
+                  - {dataset: CanESM5, project: CMIP6, grid: gn,
+                     ensemble: r1i1p1f1}
                   - {dataset: TEST, project: obs4mips, level: 1, version: 1,
                      tier: 1}
             scripts: null
@@ -1684,14 +1686,14 @@ def test_landmask_no_fx(tmp_path, patched_failing_datafinder, config_user):
     task = recipe.tasks.pop()
     assert task.name == 'diagnostic_name' + TASKSEP + 'gpp'
 
-    # Check weighting
-    assert len(task.products) == 2
+    # Check masking
+    assert len(task.products) == 3
     for product in task.products:
         assert 'mask_landsea' in product.settings
         settings = product.settings['mask_landsea']
         assert len(settings) == 3
         assert settings['mask_out'] == 'sea'
-        assert settings['always_use_ne_mask'] is True
+        assert settings['always_use_ne_mask'] is False
         fx_files = settings['fx_files']
         assert isinstance(fx_files, list)
         assert fx_files == []
@@ -1771,6 +1773,98 @@ def test_fx_vars_mip_change_cmip6(tmp_path, patched_datafinder, config_user):
             assert False
 
 
+def test_fx_vars_volcello_in_ofx_cmip6(tmp_path, patched_datafinder,
+                                       config_user):
+    content = dedent("""
+        preprocessors:
+          preproc:
+           volume_statistics:
+             operator: mean
+             fx_files: ['volcello']
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tos:
+                preprocessor: preproc
+                project: CMIP6
+                mip: Omon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+            scripts: null
+        """)
+    recipe = get_recipe(tmp_path, content, config_user)
+
+    # Check generated tasks
+    assert len(recipe.tasks) == 1
+    task = recipe.tasks.pop()
+    assert task.name == 'diagnostic_name' + TASKSEP + 'tos'
+    assert len(task.products) == 1
+    product = task.products.pop()
+
+    # Check volume_statistics
+    assert 'volume_statistics' in product.settings
+    settings = product.settings['volume_statistics']
+    assert len(settings) == 2
+    assert settings['operator'] == 'mean'
+    fx_files = settings['fx_files']
+    assert isinstance(fx_files, dict)
+    assert len(fx_files) == 1
+    assert '_Ofx_' in fx_files['volcello']
+    assert '_Omon_' not in fx_files['volcello']
+
+
+def test_fx_vars_volcello_in_omon_cmip6(tmp_path, patched_failing_datafinder,
+                                        config_user):
+    content = dedent("""
+        preprocessors:
+          preproc:
+           volume_statistics:
+             operator: mean
+             fx_files: ['volcello']
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tos:
+                preprocessor: preproc
+                project: CMIP6
+                mip: Omon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+            scripts: null
+        """)
+    recipe = get_recipe(tmp_path, content, config_user)
+
+    # Check generated tasks
+    assert len(recipe.tasks) == 1
+    task = recipe.tasks.pop()
+    assert task.name == 'diagnostic_name' + TASKSEP + 'tos'
+    assert len(task.products) == 1
+    product = task.products.pop()
+
+    # Check volume_statistics
+    assert 'volume_statistics' in product.settings
+    settings = product.settings['volume_statistics']
+    assert len(settings) == 2
+    assert settings['operator'] == 'mean'
+    fx_files = settings['fx_files']
+    assert isinstance(fx_files, dict)
+    assert len(fx_files) == 1
+    assert '_Ofx_' not in fx_files['volcello']
+    assert '_Omon_' in fx_files['volcello']
+
+
 def test_invalid_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
     content = dedent("""
         preprocessors:
@@ -1800,6 +1894,36 @@ def test_invalid_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
         """)
     msg = ("Requested fx variable 'wrong_fx_variable' for CMIP6 not "
            "available in any 'fx'-related CMOR table")
+    with pytest.raises(RecipeError) as rec_err_exp:
+        get_recipe(tmp_path, content, config_user)
+        assert msg in rec_err_exp
+
+
+def test_fx_var_invalid_project(tmp_path, patched_datafinder, config_user):
+    content = dedent("""
+        preprocessors:
+          preproc:
+           area_statistics:
+             operator: mean
+             fx_files: ['areacella']
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: preproc
+                project: EMAC
+                mip: Amon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+            scripts: null
+        """)
+    msg = 'Project EMAC not supported with fx variables'
     with pytest.raises(RecipeError) as rec_err_exp:
         get_recipe(tmp_path, content, config_user)
         assert msg in rec_err_exp

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1420,7 +1420,6 @@ def test_extract_shape_raises(tmp_path, patched_datafinder, config_user,
 
 
 def test_weighting_landsea_fraction(tmp_path, patched_datafinder, config_user):
-
     content = dedent("""
         preprocessors:
           landfrac_weighting:
@@ -1471,7 +1470,6 @@ def test_weighting_landsea_fraction(tmp_path, patched_datafinder, config_user):
 
 def test_weighting_landsea_fraction_no_fx(tmp_path, patched_failing_datafinder,
                                           config_user):
-
     content = dedent("""
         preprocessors:
           landfrac_weighting:
@@ -1524,7 +1522,6 @@ def test_weighting_landsea_fraction_no_fx(tmp_path, patched_failing_datafinder,
 
 def test_weighting_landsea_fraction_exclude(tmp_path, patched_datafinder,
                                             config_user):
-
     content = dedent("""
         preprocessors:
           landfrac_weighting:
@@ -1577,7 +1574,6 @@ def test_weighting_landsea_fraction_exclude(tmp_path, patched_datafinder,
 
 def test_weighting_landsea_fraction_exclude_fail(tmp_path, patched_datafinder,
                                                  config_user):
-
     content = dedent("""
         preprocessors:
           landfrac_weighting:
@@ -1611,7 +1607,6 @@ def test_weighting_landsea_fraction_exclude_fail(tmp_path, patched_datafinder,
 
 
 def test_landmask(tmp_path, patched_datafinder, config_user):
-
     content = dedent("""
         preprocessors:
           landmask:
@@ -1658,7 +1653,6 @@ def test_landmask(tmp_path, patched_datafinder, config_user):
 
 
 def test_landmask_no_fx(tmp_path, patched_failing_datafinder, config_user):
-
     content = dedent("""
         preprocessors:
           landmask:
@@ -1701,3 +1695,108 @@ def test_landmask_no_fx(tmp_path, patched_failing_datafinder, config_user):
         fx_files = settings['fx_files']
         assert isinstance(fx_files, list)
         assert fx_files == []
+
+
+def test_fx_vars_mip_change_cmip6(tmp_path, patched_datafinder, config_user):
+    content = dedent("""
+        preprocessors:
+          preproc:
+           area_statistics:
+             operator: mean
+             fx_files: [
+               'areacella',
+               'areacello',
+               'clayfrac',
+               'sftlf',
+               'sftof',
+             ]
+           mask_landsea:
+             mask_out: sea
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: preproc
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+            scripts: null
+        """)
+    recipe = get_recipe(tmp_path, content, config_user)
+
+    # Check generated tasks
+    assert len(recipe.tasks) == 1
+    task = recipe.tasks.pop()
+    assert task.name == 'diagnostic_name' + TASKSEP + 'tas'
+    assert len(task.products) == 1
+    product = task.products.pop()
+
+    # Check area_statistics
+    assert 'area_statistics' in product.settings
+    settings = product.settings['area_statistics']
+    assert len(settings) == 2
+    assert settings['operator'] == 'mean'
+    fx_files = settings['fx_files']
+    assert isinstance(fx_files, dict)
+    assert len(fx_files) == 5
+    assert '_fx_' in fx_files['areacella']
+    assert '_Ofx_' in fx_files['areacello']
+    assert 'Efx_' in fx_files['clayfrac']
+    assert '_fx_' in fx_files['sftlf']
+    assert '_Ofx_' in fx_files['sftof']
+
+    # Check mask_landsea
+    assert 'mask_landsea' in product.settings
+    settings = product.settings['mask_landsea']
+    assert len(settings) == 2
+    assert settings['mask_out'] == 'sea'
+    fx_files = settings['fx_files']
+    assert isinstance(fx_files, list)
+    assert len(fx_files) == 2
+    for fx_file in fx_files:
+        if 'sftlf' in fx_file:
+            assert '_fx_' in fx_file
+        elif 'sftof' in fx_file:
+            assert '_Ofx_' in fx_file
+        else:
+            assert False
+
+def test_invalid_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
+    content = dedent("""
+        preprocessors:
+          preproc:
+           area_statistics:
+             operator: mean
+             fx_files: [
+               'areacella',
+               'wrong_fx_variable',
+             ]
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: preproc
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+            scripts: null
+        """)
+    msg = ("Requested fx variable 'wrong_fx_variable' for CMIP6 not "
+           "available in any 'fx'-related CMOR table")
+    with pytest.raises(RecipeError) as rec_err_exp:
+        recipe = get_recipe(tmp_path, content, config_user)
+        assert msg in rec_err_exp

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1770,6 +1770,7 @@ def test_fx_vars_mip_change_cmip6(tmp_path, patched_datafinder, config_user):
         else:
             assert False
 
+
 def test_invalid_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
     content = dedent("""
         preprocessors:
@@ -1800,5 +1801,5 @@ def test_invalid_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
     msg = ("Requested fx variable 'wrong_fx_variable' for CMIP6 not "
            "available in any 'fx'-related CMOR table")
     with pytest.raises(RecipeError) as rec_err_exp:
-        recipe = get_recipe(tmp_path, content, config_user)
+        get_recipe(tmp_path, content, config_user)
         assert msg in rec_err_exp

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1956,6 +1956,34 @@ def test_fx_vars_volcello_in_fx_cmip5(tmp_path, patched_datafinder,
     assert '_Omon_' not in fx_files['volcello']
 
 
+def test_wrong_project(tmp_path, patched_datafinder, config_user):
+    content = dedent("""
+        preprocessors:
+          preproc:
+           volume_statistics:
+             operator: mean
+             fx_files: ['volcello']
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tos:
+                preprocessor: preproc
+                project: CMIP7
+                mip: Omon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1
+                additional_datasets:
+                  - {dataset: CanESM2}
+            scripts: null
+        """)
+    with pytest.raises(ValueError) as wrong_proj:
+        get_recipe(tmp_path, content, config_user)
+        assert wrong_proj == "Project CMIP7 not in config-developer"
+
+
 def test_invalid_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
     content = dedent("""
         preprocessors:

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1708,6 +1708,7 @@ def test_fx_vars_mip_change_cmip6(tmp_path, patched_datafinder, config_user):
                'areacello',
                'clayfrac',
                'sftlf',
+               'sftgif',
                'sftof',
              ]
            mask_landsea:
@@ -1745,11 +1746,12 @@ def test_fx_vars_mip_change_cmip6(tmp_path, patched_datafinder, config_user):
     assert settings['operator'] == 'mean'
     fx_files = settings['fx_files']
     assert isinstance(fx_files, dict)
-    assert len(fx_files) == 5
+    assert len(fx_files) == 6
     assert '_fx_' in fx_files['areacella']
     assert '_Ofx_' in fx_files['areacello']
     assert 'Efx_' in fx_files['clayfrac']
     assert '_fx_' in fx_files['sftlf']
+    assert '_fx_' in fx_files['sftgif']
     assert '_Ofx_' in fx_files['sftof']
 
     # Check mask_landsea


### PR DESCRIPTION
**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #431.
