### PR TITLE
[URGENT] Rename zonal_means to zonal_statistics

### DIFF
--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -987,7 +987,7 @@ See also :func:`esmvalcore.preprocessor.extract_shape`.
 
 
 ``zonal_statistics``
----------------
+--------------------
 
 The function calculates the zonal statistics by applying an operator along the longitude coordinate. This function takes one argument:
 
@@ -997,7 +997,7 @@ See also :func:`esmvalcore.preprocessor.zonal_means`.
 
 
 ``meridional_statistics``
----------------
+-------------------------
 
 The function calculates the meridional statistics by applying an operator along the latitude coordinate. This function takes one argument:
 

--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -916,8 +916,9 @@ The area manipulation module contains the following preprocessor functions:
 * extract_named_regions_: Extract a specific region from in the region
   cooordinate.
 * extract_shape_: Extract a region defined by a shapefile.
-* zonal_means_: Calculates the zonal or meridional means.
-* area_statistics_: Calculates the average value over a region.
+* zonal_statistics_: Calculates zonal statistics.
+* meridional_statistics_: Calculates meridional statistics.
+* area_statistics_: Calculates area statistics.
 
 
 ``extract_region``
@@ -985,18 +986,24 @@ Examples:
 See also :func:`esmvalcore.preprocessor.extract_shape`.
 
 
-``zonal_means``
+``zonal_statistics``
 ---------------
 
-The function calculates the zonal or meridional means. While this function is
-named ``zonal_mean``, it can be used to apply several different operations in
-an zonal or meridional direction. This function takes two arguments:
+The function calculates the zonal statistics by applying an operator along the longitude coordinate. This function takes one argument:
 
-* ``coordinate``: Which direction to apply the operation: latitude or longitude
-* ``mean_type``: Which operation to apply: mean, std_dev, variance, median,
-  min, max or sum
+* ``operator``: Which operation to apply: mean, std_dev, median, min, max or sum
 
 See also :func:`esmvalcore.preprocessor.zonal_means`.
+
+
+``meridional_statistics``
+---------------
+
+The function calculates the meridional statistics by applying an operator along the latitude coordinate. This function takes one argument:
+
+* ``operator``: Which operation to apply: mean, std_dev, median, min, max or sum
+
+See also :func:`esmvalcore.preprocessor.meridional_means`.
 
 
 ``area_statistics``

--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -916,9 +916,9 @@ The area manipulation module contains the following preprocessor functions:
 * extract_named_regions_: Extract a specific region from in the region
   cooordinate.
 * extract_shape_: Extract a region defined by a shapefile.
-* zonal_statistics_: Calculates zonal statistics.
-* meridional_statistics_: Calculates meridional statistics.
-* area_statistics_: Calculates area statistics.
+* zonal_statistics_: Compute zonal statistics.
+* meridional_statistics_: Compute meridional statistics.
+* area_statistics_: Compute area statistics.
 
 
 ``extract_region``

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -8,7 +8,7 @@ from iris.cube import Cube
 from .._provenance import TrackedFile
 from .._task import BaseTask
 from ._area import (area_statistics, extract_named_regions, extract_region,
-                    extract_shape, zonal_means)
+                    extract_shape, zonal_statistics, meridional_statistics)
 from ._derive import derive
 from ._detrend import detrend
 from ._download import download
@@ -87,7 +87,8 @@ __all__ = [
     # Time operations
     # 'annual_cycle': annual_cycle,
     # 'diurnal_cycle': diurnal_cycle,
-    'zonal_means',
+    'zonal_statistics',
+    'meridional_statistics',
     'daily_statistics',
     'monthly_statistics',
     'seasonal_statistics',

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -99,15 +99,25 @@ def zonal_statistics(cube, operator):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'.
 
     Returns
     -------
     iris.cube.Cube
-        Zonal statistics cube
+        Zonal statistics cube.
+
+    Raises
+    ------
+    ValueError
+        Error raised if computation on irregular grids is attempted.
+        Zonal statistics not yet implemented for irregular grids.
     """
-    operation = get_iris_analysis_operation(operator)
-    return cube.collapsed('longitude', operation)
+    if cube.coord('longitude').points.ndim < 2:
+        operation = get_iris_analysis_operation(operator)
+        return cube.collapsed('longitude', operation)
+    else:
+        msg = (f"Zonal statistics on irregular grids not yet implemnted")
+        raise ValueError(msg)
 
 
 def meridional_statistics(cube, operator):
@@ -121,15 +131,25 @@ def meridional_statistics(cube, operator):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'.
 
     Returns
     -------
     iris.cube.Cube
-        Meridional statistics cube
+        Meridional statistics cube.
+
+    Raises
+    ------
+    ValueError
+        Error raised if computation on irregular grids is attempted.
+        Zonal statistics not yet implemented for irregular grids.
     """
-    operation = get_iris_analysis_operation(operator)
-    return cube.collapsed('latitude', operation)
+    if cube.coord('latitude').points.ndim < 2:
+        operation = get_iris_analysis_operation(operator)
+        return cube.collapsed('latitude', operation)
+    else:
+        msg = (f"Meridional statistics on irregular grids not yet implemnted")
+        raise ValueError(msg)
 
 
 def tile_grid_areas(cube, fx_files):

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -88,35 +88,48 @@ def extract_region(cube, start_longitude, end_longitude, start_latitude,
     return cube
 
 
-def zonal_means(cube, coordinate, mean_type):
+def zonal_statistics(cube, operator):
     """
-    Get zonal means.
-
-    Function that returns zonal means along a coordinate `coordinate`;
-    the type of mean is controlled by mean_type variable (string):
-    - 'mean' -> MEAN
-    - 'median' -> MEDIAN
-    - 'std_dev' -> STD_DEV
-    - 'sum' -> SUM
-    - 'variance' -> VARIANCE
-    - 'min' -> MIN
-    - 'max' -> MAX
+    Compute zonal statistics.
 
     Parameters
     ----------
     cube: iris.cube.Cube
         input cube.
-    coordinate: str
-        name of coordinate to make mean.
-    mean_type: str
-        Type of analysis to use, from iris.analysis.
+
+    operator: str, optional
+        Select operator to apply.
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
 
     Returns
     -------
     iris.cube.Cube
+        Zonal statistics cube
     """
-    operation = get_iris_analysis_operation(mean_type)
-    return cube.collapsed(coordinate, operation)
+    operation = get_iris_analysis_operation(operator)
+    return cube.collapsed('longitude', operation)
+
+
+def meridional_statistics(cube, operator):
+    """
+    Compute meridional statistics.
+
+    Parameters
+    ----------
+    cube: iris.cube.Cube
+        input cube.
+
+    operator: str, optional
+        Select operator to apply.
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+
+    Returns
+    -------
+    iris.cube.Cube
+        Meridional statistics cube
+    """
+    operation = get_iris_analysis_operation(operator)
+    return cube.collapsed('latitude', operation)
 
 
 def tile_grid_areas(cube, fx_files):


### PR DESCRIPTION
In Table 1 of the paper, we mention `zonal_statistics` and `meridional_statistics`, but in the preprocessor this is called `zonal_means` and covers both the zonal (longitude stats) and the meridional (latitude stats) case.

This PR attempts to quickly solve the problem.

`recipe_flato13ipcc.yml` and `recipe_collins13ipcc.yml` should be adjusted accordingly.

Closes #24.
