### PR TITLE
Fix mistake in error message for diagnostic scripts that are not executable

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -445,7 +445,7 @@ class DiagnosticTask(BaseTask):
             if exc.errno == errno.ENOEXEC:
                 logger.error(
                     "Diagnostic script has its executable bit set, but is "
-                    "not executable. To fix this run:\nchmod +x %s", cmd[0])
+                    "not executable. To fix this run:\nchmod -x %s", cmd[0])
                 logger.error(
                     "You may also need to fix this in the git repository.")
             raise


### PR DESCRIPTION
Fix mistake in error message introduced in #385.
