### PR TITLE
Restrict mock to <4

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -49,6 +49,7 @@ requirements:
     - netCDF4
     - numba
     - numpy
+    - mock>=3.0.5,<4.0
     - prov
     - psutil
     - pydot

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ REQUIREMENTS = {
     # Execute 'python setup.py test' to run tests
     'test': [
         'easytest',
-        'mock',
+        'mock>=3.0.5,<4.0',
         'nose',
         'pytest>=3.9',
         'pytest-cov',


### PR DESCRIPTION
#453 `mock=4` beta seems dodgy at the moment and the CI is picking it up from God knows where (nowhere on the conda forge or pypi official repos)