### PR TITLE
Added weightless_mean, weightless_sum operators to volume_statistics preprocessor

### DIFF
--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -1058,7 +1058,10 @@ This function calculates the volume-weighted average across three dimensions,
 but maintains the time dimension.
 
 This function takes the argument: ``operator``, which defines the operation to
-apply over the volume.
+apply over the volume. The operator options are ``mean``: the volume-weighted
+mean, ``weightless_mean``: the mean over three dimenstions independent of cell
+volume, and ``weightless_sum``: the sum along all three dimensions independent
+of cell volume.
 
 No depth coordinate is required as this is determined by Iris. This function
 works best when the ``fx_files`` provide the cell volume.

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -200,6 +200,17 @@ def volume_statistics(
     # TODO: Test sigma coordinates.
     # TODO: Add other operations.
 
+    # #####
+    # Operators, weightless sum, weightless mean. 
+    if operator == 'weightless_mean':
+        return cube.collapsed([cube.coord(axis='z'),
+                               'longitude', 'latitude'],
+                              iris.analysis.MEAN)
+    if operator == 'weightless_sum':
+        return cube.collapsed([cube.coord(axis='z'),
+                               'longitude', 'latitude'],
+                              iris.analysis.SUM)
+
     # ####
     # Load z coordinate field and figure out which dim is which.
     t_dim = cube.coord_dims('time')[0]

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -201,7 +201,7 @@ def volume_statistics(
     # TODO: Add other operations.
 
     # #####
-    # Operators, weightless sum, weightless mean. 
+    # Operators, weightless sum, weightless mean.
     if operator == 'weightless_mean':
         return cube.collapsed([cube.coord(axis='z'),
                                'longitude', 'latitude'],

--- a/tests/unit/preprocessor/_volume/test_volume.py
+++ b/tests/unit/preprocessor/_volume/test_volume.py
@@ -100,7 +100,7 @@ class Test(tests.Test):
         expected = np.array([1., 1., 1., 1.])
         self.assert_array_equal(result.data, expected)
 
-    def test_volume_statistics_sum(self):
+    def test_volume_statistics_weightless_sum(self):
         """
         Test to take the volume independant sum of a (4,3,2,2) cube.
 
@@ -108,10 +108,10 @@ class Test(tests.Test):
         different methods for small and large cubes.
         """
         result = volume_statistics(self.grid_4d_2, 'weightless_sum')
-        expected = np.array([12., 12., 12., 12.])
+        expected = np.ma.array([11., 12., 12., 12.])
         self.assert_array_equal(result.data, expected)
 
-    def test_volume_statistics_mean(self):
+    def test_volume_statistics_weightless_mean(self):
         """
         Test to take the volume independant sum of a (4,3,2,2) cube.
 
@@ -119,7 +119,7 @@ class Test(tests.Test):
         different methods for small and large cubes.
         """
         result = volume_statistics(self.grid_4d_2, 'weightless_mean')
-        expected = np.array([1., 1., 1., 1.])
+        expected = np.ma.array([1., 1., 1., 1.])
         self.assert_array_equal(result.data, expected)
 
     def test_depth_integration_1d(self):

--- a/tests/unit/preprocessor/_volume/test_volume.py
+++ b/tests/unit/preprocessor/_volume/test_volume.py
@@ -100,6 +100,28 @@ class Test(tests.Test):
         expected = np.array([1., 1., 1., 1.])
         self.assert_array_equal(result.data, expected)
 
+    def test_volume_statistics_sum(self):
+        """
+        Test to take the volume independant sum of a (4,3,2,2) cube.
+
+        This extra time is needed, as the volume average calculation uses
+        different methods for small and large cubes.
+        """
+        result = volume_statistics(self.grid_4d_2, 'weightless_sum')
+        expected = np.array([12., 12., 12., 12.])
+        self.assert_array_equal(result.data, expected)
+
+    def test_volume_statistics_mean(self):
+        """
+        Test to take the volume independant sum of a (4,3,2,2) cube.
+
+        This extra time is needed, as the volume average calculation uses
+        different methods for small and large cubes.
+        """
+        result = volume_statistics(self.grid_4d_2, 'weightless_mean')
+        expected = np.array([1., 1., 1., 1.])
+        self.assert_array_equal(result.data, expected)
+
     def test_depth_integration_1d(self):
         """Test to take the depth integration of a 3 layer cube."""
         result = depth_integration(self.grid_3d[:, 0, 0])


### PR DESCRIPTION
Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [ ] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes {442} in part. This issue was raised to address the problems in `sum` in `area_statistics`, but these same issues appear i nthe `volume_statistics` preprocessor.
