### PR TITLE
Try to add is-enes3 community and is-enes3 grant to zenodo and update authors

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -92,5 +92,18 @@
     "license": {
         "id": "Apache-2.0"
     },
-    "title": "ESMValCore"
+    "title": "ESMValCore",
+    "communities": [
+        {
+            "identifier": "is-enes3"
+        },
+        {
+            "identifier": "ecfunded"
+        }
+    ],
+    "grants": [
+        {
+            "id": "10.13039/501100000780::824084"
+        }
+    ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,20 +7,12 @@
         },
         {
             "affiliation": "DLR, Germany",
-            "name": "Bock, Lisa",
-            "orcid": "0000-0001-7058-5938"
-        },
-        {
-            "affiliation": "DLR, Germany",
             "name": "Broetz, Bjoern"
         },
         {
-            "affiliation": "NLeSC, Netherlands",
-            "name": "Diblen, Faruk"
-        },
-        {
-            "affiliation": "MetOffice, UK",
-            "name": "Dreyer, Laura"
+            "affiliation": "PML, UK",
+            "name": "de Mora, Lee",
+            "orcid": "0000-0002-5080-3149"
         },
         {
             "affiliation": "NLeSC, Netherlands",
@@ -28,18 +20,9 @@
             "orcid": "0000-0001-9795-7981"
         },
         {
-            "affiliation": "MetOffice, UK",
-            "name": "Earnshaw, Paul"
-        },
-        {
             "affiliation": "DLR, Germany",
             "name": "Eyring, Veronika",
             "orcid": "0000-0002-6887-4885"
-        },
-        {
-            "affiliation": "DLR, Germany",
-            "name": "Hassler, Birgit",
-            "orcid": "0000-0003-2724-709X"
         },
         {
             "affiliation": "AWI, Germany",
@@ -50,19 +33,6 @@
             "affiliation": "DLR, Germany",
             "name": "Lauer, Axel",
             "orcid": "0000-0002-9270-1044"
-        },
-        {
-            "affiliation": "MetOffice, UK",
-            "name": "Little, Bill"
-        },
-        {
-            "affiliation": "BSC, Spain",
-            "name": "Loosveldt-Tomas, Saskia"
-        },
-        {
-            "affiliation": "PML, UK",
-            "name": "de Mora, Lee",
-            "orcid": "0000-0002-5080-3149"
         },
         {
             "affiliation": "URead, UK",
@@ -86,6 +56,36 @@
         {
             "affiliation": "SMHI, Sweden",
             "name": "Zimmermann, Klaus"
+        },
+        {
+            "affiliation": "DLR, Germany",
+            "name": "Bock, Lisa",
+            "orcid": "0000-0001-7058-5938"
+        },
+        {
+            "affiliation": "NLeSC, Netherlands",
+            "name": "Diblen, Faruk"
+        },
+        {
+            "affiliation": "MetOffice, UK",
+            "name": "Dreyer, Laura"
+        },
+        {
+            "affiliation": "MetOffice, UK",
+            "name": "Earnshaw, Paul"
+        },
+        {
+            "affiliation": "DLR, Germany",
+            "name": "Hassler, Birgit",
+            "orcid": "0000-0003-2724-709X"
+        },
+        {
+            "affiliation": "MetOffice, UK",
+            "name": "Little, Bill"
+        },
+        {
+            "affiliation": "BSC, Spain",
+            "name": "Loosveldt-Tomas, Saskia"
         }
     ],
     "description": "ESMValCore: A community tool for pre-processing data from Earth system models in CMIP and running analysis scripts.",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,40 +9,24 @@ authors:
     orcid: "https://orcid.org/0000-0001-9005-8940"
   -
     affiliation: "DLR, Germany"
-    family-names: Bock
-    given-names: Lisa
-    orcid: "https://orcid.org/0000-0001-7058-5938"
-  -
-    affiliation: "DLR, Germany"
     family-names: Broetz
     given-names: Bjoern
   -
-    affiliation: "NLeSC, Netherlands"
-    family-names: Diblen
-    given-names: Faruk
-  -
-    affiliation: "MetOffice, UK"
-    family-names: Dreyer
-    given-names: Laura
+    affiliation: "PML, UK"
+    name-particle: de
+    family-names: Mora
+    given-names: Lee
+    orcid: "https://orcid.org/0000-0002-5080-3149"
   -
     affiliation: "NLeSC, Netherlands"
     family-names: Drost
     given-names: Niels
     orcid: "https://orcid.org/0000-0001-9795-7981"
   -
-    affiliation: "MetOffice, UK"
-    family-names: Earnshaw
-    given-names: Paul
-  -
     affiliation: "DLR, Germany"
     family-names: Eyring
     given-names: Veronika
     orcid: "https://orcid.org/0000-0002-6887-4885"
-  -
-    affiliation: "DLR, Germany"
-    family-names: Hassler
-    given-names: Birgit
-    orcid: "https://orcid.org/0000-0003-2724-709X"
   -
     affiliation: "AWI, Germany"
     family-names: Koldunov
@@ -53,20 +37,6 @@ authors:
     family-names: Lauer
     given-names: Axel
     orcid: "https://orcid.org/0000-0002-9270-1044"
-  -
-    affiliation: "MetOffice, UK"
-    family-names: Little
-    given-names: Bill
-  -
-    affiliation: "BSC, Spain"
-    family-names: Loosveldt-Tomas
-    given-names: Saskia
-  -
-    affiliation: "PML, UK"
-    name-particle: de
-    family-names: Mora
-    given-names: Lee
-    orcid: "https://orcid.org/0000-0002-5080-3149"
   -
     affiliation: "URead, UK"
     family-names: Predoi
@@ -90,6 +60,36 @@ authors:
     affiliation: "SMHI, Sweden"
     family-names: Zimmermann
     given-names: Klaus
+  -
+    affiliation: "DLR, Germany"
+    family-names: Bock
+    given-names: Lisa
+    orcid: "https://orcid.org/0000-0001-7058-5938"
+  -
+    affiliation: "NLeSC, Netherlands"
+    family-names: Diblen
+    given-names: Faruk
+  -
+    affiliation: "MetOffice, UK"
+    family-names: Dreyer
+    given-names: Laura
+  -
+    affiliation: "MetOffice, UK"
+    family-names: Earnshaw
+    given-names: Paul
+  -
+    affiliation: "DLR, Germany"
+    family-names: Hassler
+    given-names: Birgit
+    orcid: "https://orcid.org/0000-0003-2724-709X"
+  -
+    affiliation: "MetOffice, UK"
+    family-names: Little
+    given-names: Bill
+  -
+    affiliation: "BSC, Spain"
+    family-names: Loosveldt-Tomas
+    given-names: Saskia
 
 cff-version: "1.0.3"
 date-released: 2019-10-31


### PR DESCRIPTION
Let's see if it works.

I found the instructions here: https://developers.zenodo.org/#representation

This pull request also puts the core development team at the top of the list.