### PR TITLE
Add regrid to sispeed derivation when siu and siv are not in the same grid

### DIFF
--- a/esmvalcore/preprocessor/_derive/sispeed.py
+++ b/esmvalcore/preprocessor/_derive/sispeed.py
@@ -44,7 +44,7 @@ class DerivedVariable(DerivedVariableBase):
         try:
             return DerivedVariable._get_speed(siu, siv)
         except ValueError:
-            logger.info('Regridding siv into siu grid to compute sispeed')
+            logger.debug('Regridding siv into siu grid to compute sispeed')
             siv = regrid(siv, siu, 'linear')
             return DerivedVariable._get_speed(siu, siv)
 

--- a/esmvalcore/preprocessor/_derive/sispeed.py
+++ b/esmvalcore/preprocessor/_derive/sispeed.py
@@ -5,6 +5,8 @@ import numpy as np
 from iris import Constraint
 from iris.coords import DimCoord
 
+from .._regrid import regrid
+
 from ._baseclass import DerivedVariableBase
 
 logger = logging.getLogger(__name__)
@@ -39,42 +41,12 @@ class DerivedVariable(DerivedVariableBase):
         """
         siu = cubes.extract_strict(Constraint(name='sea_ice_x_velocity'))
         siv = cubes.extract_strict(Constraint(name='sea_ice_y_velocity'))
-
         try:
             return DerivedVariable._get_speed(siu, siv)
         except ValueError:
-            # Models usually store siu and siv in slightly different points
-            if not DerivedVariable._coordinate_close(siu, siv, 'latitude'):
-                raise
-            if not DerivedVariable._coordinate_close(siu, siv, 'longitude'):
-                raise
-            logger.warning(
-                'Coordinates for sea ice velocity components differ. '
-                'Changing y component latitude and longitude to match the '
-                'coordinates of x component')
-            siv.remove_coord('latitude')
-            siv.remove_coord('longitude')
-
-            if isinstance(siu.coord('latitude'), DimCoord):
-                siv.add_dim_coord(siu.coord('latitude'),
-                                  siu.coord_dims('latitude'))
-                siv.add_dim_coord(siu.coord('longitude'),
-                                  siu.coord_dims('longitude'))
-            else:
-                siv.add_aux_coord(siu.coord('latitude'),
-                                  siu.coord_dims('latitude'))
-                siv.add_aux_coord(siu.coord('longitude'),
-                                  siu.coord_dims('longitude'))
+            logger.info('Regridding siv into siu grid to compute sispeed')
+            siv = regrid(siv, siu, 'linear')
             return DerivedVariable._get_speed(siu, siv)
-
-    @staticmethod
-    def _coordinate_close(siu, siv, coord):
-        return np.allclose(
-            siu.coord(coord).points,
-            siv.coord(coord).points,
-            rtol=0.,
-            atol=5.,
-        )
 
     @staticmethod
     def _get_speed(siu, siv):

--- a/esmvalcore/preprocessor/_derive/sispeed.py
+++ b/esmvalcore/preprocessor/_derive/sispeed.py
@@ -1,9 +1,7 @@
 """Derivation of variable `sispeed`."""
 
 import logging
-import numpy as np
 from iris import Constraint
-from iris.coords import DimCoord
 
 from .._regrid import regrid
 


### PR DESCRIPTION
Adding regrid to sispeed derivation

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below
