### PR TITLE
Fix sithick derivation when units of siconc are %

### DIFF
--- a/esmvalcore/preprocessor/_derive/sithick.py
+++ b/esmvalcore/preprocessor/_derive/sithick.py
@@ -36,8 +36,9 @@ class DerivedVariable(DerivedVariableBase):
             Cube containing sea ice speed.
 
         """
-        siconc = cubes.extract_strict(Constraint(name='sea_ice_thickness'))
-        sivol = cubes.extract_strict(Constraint(name='sea_ice_area_fraction'))
+        sivol = cubes.extract_strict(Constraint(name='sea_ice_thickness'))
+        siconc = cubes.extract_strict(Constraint(name='sea_ice_area_fraction'))
+        siconc.convert_units('1.0')
 
-        sithick = siconc * sivol
+        sithick = sivol / siconc
         return sithick

--- a/tests/integration/preprocessor/_derive/test_sithick.py
+++ b/tests/integration/preprocessor/_derive/test_sithick.py
@@ -9,8 +9,22 @@ from esmvalcore.preprocessor._derive.sithick import DerivedVariable
 def test_sispeed_calculation():
     """Test calculation of `sithick`."""
 
-    siconc = Cube(np.full((2, 2), 0.5), 'sea_ice_area_fraction')
-    sivol = Cube(np.full((2, 2), 2.), 'sea_ice_thickness')
+    siconc = Cube(np.full((2, 2), 0.5), 'sea_ice_area_fraction', units='1.0')
+    sivol = Cube(np.full((2, 2), 0.5), 'sea_ice_thickness')
+
+    derived_var = DerivedVariable()
+    sispeed = derived_var.calculate(CubeList((siconc, sivol)))
+
+    assert np.all(
+        sispeed.data == np.ones_like(sispeed.data)
+    )
+
+
+def test_sispeed_calculation_percent():
+    """Test calculation of `sithick` with sit in %."""
+
+    siconc = Cube(np.full((2, 2), 50.), 'sea_ice_area_fraction', units='%')
+    sivol = Cube(np.full((2, 2), 0.5), 'sea_ice_thickness')
 
     derived_var = DerivedVariable()
     sispeed = derived_var.calculate(CubeList((siconc, sivol)))


### PR DESCRIPTION
Fixed a couple of issues in sithick derivation

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below
