### PR TITLE
Add option to round only specified coordinates

### DIFF
--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -81,10 +81,38 @@ def cube_to_aux_coord(cube):
     )
 
 
-def round_coordinates(cubes, decimals=5):
-    """Round all dimensional coordinates of all cubes."""
+def round_coordinates(cubes, decimals=5, coord_names=None):
+    """Round all dimensional coordinates of all cubes in place
+
+    Cubes can be a list of Iris cubes, or an Iris `CubeList`.
+
+    Cubes are modified *in place*. The return value is simply for
+    convenience.
+
+    Parameters
+    ----------
+    - cubes: iris.cube.CubeList (or a list of iris.cube.Cube).
+
+    - decimals: number of decimals to round to.
+
+    - coord_names: list of strings, or None.
+        If None (or a falsey value), all dimensional coordinates will
+        be rounded.
+        Otherwise, only coordinates given by the names in
+        `coord_names` are rounded.
+
+    Returns
+    -------
+    The modified input `cubes`
+
+    """
+
     for cube in cubes:
-        for coord in cube.coords(dim_coords=True):
+        if not coord_names:
+            coords = cube.coords(dim_coords=True)
+        else:
+            coords = [cube.coord(name) for name in coord_names]
+        for coord in coords:
             coord.points = da.round(da.asarray(coord.core_points()), decimals)
             if coord.bounds is not None:
                 coord.bounds = da.round(da.asarray(coord.core_bounds()),

--- a/tests/integration/cmor/_fixes/test_shared.py
+++ b/tests/integration/cmor/_fixes/test_shared.py
@@ -167,3 +167,21 @@ def test_cube_to_aux_coord():
     assert coord.long_name == cube.long_name
     assert coord.units == cube.units
     assert np.all(coord.points == cube.data)
+
+
+def test_round_coordinates_single_coord():
+    """Test rounding of specified coordinate"""
+    coords, bounds = [10.0001], [[9.0001, 11.0001]]
+    latcoord = iris.coords.DimCoord(coords.copy(), bounds=bounds.copy(),
+                                    standard_name='latitude')
+    loncoord = iris.coords.DimCoord(coords.copy(), bounds=bounds.copy(),
+                                    standard_name='longitude')
+    cube = iris.cube.Cube([[1.0]], standard_name='air_temperature',
+                          dim_coords_and_dims=[(latcoord, 0), (loncoord, 1)])
+    cubes = iris.cube.CubeList([cube])
+
+    out = round_coordinates(cubes, decimals=3, coord_names=['latitude'])
+    assert out is cubes
+    assert cubes[0].coord('longitude') is out[0].coord('longitude')
+    np.testing.assert_allclose(out[0].coord('latitude').points, [10])
+    np.testing.assert_allclose(out[0].coord('latitude').bounds, [[9, 11]])


### PR DESCRIPTION
Coordinates that require different rounding values, can be given as a
list of strings. The default of `None` will round all dimension
coordinates, following the old behaviour.

Note that this functionality is used in a fix for a dataset (different pull request); instead of writing a completely new function, it was easier to adjust this one.

----

Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] ~If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)~
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] ~Please use `yamllint` to check that your YAML files do not contain mistakes~
-   [ ] ~If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below~

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes {Link to corresponding issue}
