### PR TITLE
Fix CMIP5  FGOALS-g2 and NorESM1-ME coordinates

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/fgoals_g2.py
+++ b/esmvalcore/cmor/_fixes/cmip5/fgoals_g2.py
@@ -4,6 +4,7 @@ from cf_units import Unit
 from iris.exceptions import CoordinateNotFoundError
 
 from ..fix import Fix
+from ..shared import round_coordinates
 
 
 class AllVars(Fix):
@@ -14,6 +15,8 @@ class AllVars(Fix):
         Fix metadata.
 
         Fixes time units
+
+        Fixes longitude precision
 
         Parameters
         ----------
@@ -31,4 +34,7 @@ class AllVars(Fix):
                 pass
             else:
                 time.units = Unit(time.units.name, time.units.calendar)
+
+        round_coordinates(cubes, 4, coord_names=['longitude'])
+
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/noresm1_me.py
+++ b/esmvalcore/cmor/_fixes/cmip5/noresm1_me.py
@@ -3,6 +3,28 @@ from ..fix import Fix
 from ..shared import round_coordinates
 
 
+class Pr(Fix):
+    """Fix errors for pr."""
+
+    def fix_metadata(self, cubes):
+        """Fix metadata.
+
+        Fixes latitude coordinate inaccuracies
+
+        Data is fixed in-place, as well as returned
+
+        Parameters
+        ----------
+        cube: iris.cube.CubeList
+
+        Returns
+        -------
+        iris.cube.CubeList
+
+        """
+        return round_coordinates(cubes, 12, coord_names=['latitude'])
+
+
 class Tas(Fix):
     """Fixes for tas."""
 

--- a/tests/integration/cmor/_fixes/cmip5/test_fgoals_g2.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_fgoals_g2.py
@@ -13,11 +13,18 @@ class TestAll(unittest.TestCase):
     """Test fixes for all vars."""
     def setUp(self):
         """Prepare tests."""
-        self.cube = Cube([1.0, 2.0], var_name='co2', units='J')
+        self.cube = Cube([[1.0, 2.0]], var_name='co2', units='J')
         self.cube.add_dim_coord(
-            DimCoord([0.0, 1.0],
-                     standard_name='time',
-                     units=Unit('days since 0001-01', calendar='gregorian')),
+            DimCoord(
+                [0.0, 1.0],
+                standard_name='time',
+                units=Unit('days since 0001-01', calendar='gregorian')),
+            1)
+        self.cube.add_dim_coord(
+            DimCoord(
+                [180],
+                standard_name='longitude',
+                units=Unit('degrees')),
             0)
         self.fix = AllVars(None)
 


### PR DESCRIPTION
Provides small fixes for two CMIP5 datasets.

This relies on #476 . The relevant commit is included in this PR to let unit tests pass, but this PR should preferably not be merged before that one has been merged, and this PR is then updated.

----

Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
(https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes {Link to corresponding issue}
