### PR TITLE
Add preprocessor extract_point function

### DIFF
--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -975,6 +975,7 @@ The area manipulation module contains the following preprocessor functions:
 * extract_named_regions_: Extract a specific region from in the region
   cooordinate.
 * extract_shape_: Extract a region defined by a shapefile.
+* extract_point_: Extract a single point (with interpolation)
 * zonal_statistics_: Compute zonal statistics.
 * meridional_statistics_: Compute meridional statistics.
 * area_statistics_: Compute area statistics.
@@ -1043,6 +1044,30 @@ Examples:
               method: contains
 
 See also :func:`esmvalcore.preprocessor.extract_shape`.
+
+
+``extract_point``
+-----------------
+
+Extract a single point from the data. This is done using either
+nearest or linear interpolation.
+
+Returns a cube with the extracted point(s), and with adjusted latitude
+and longitude coordinates (see below).
+
+Multiple points can also be extracted, by supplying an array of
+latitude and/or longitude coordinates. The resulting point cube will
+match the respective latitude and longitude coordinate to those of the
+input coordinates. If the input coordinate is a scalar, the dimension
+will be missing in the output cube (that is, it will be a scalar).
+
+Parameters:
+  * ``cube``: the input dataset cube.
+  * ``latitude``, ``longitude``: coordinates (as floating point
+    values) of the point to be extracted. Either (or both) can also
+    be an array of floating point values.
+  * ``scheme``: interpolation scheme: either ``'linear'`` or
+    ``'nearest'``. There is no default.
 
 
 ``zonal_statistics``

--- a/doc/esmvalcore/preprocessor.rst
+++ b/doc/esmvalcore/preprocessor.rst
@@ -26,7 +26,7 @@ Overview
 ========
 
 ..
-   ESMValTool is a modular ``Python 3.6+`` software package possesing capabilities
+   ESMValTool is a modular ``Python 3.6+`` software package possessing capabilities
    of executing a large number of diagnostic routines that can be written in a
    number of programming languages (Python, NCL, R, Julia). The modular nature
    benefits the users and developers in different key areas: a new feature
@@ -120,12 +120,13 @@ CMORization and dataset-specific fixes
 Data checking
 -------------
 
-Data preprocessed by ESMValTool is automatically checked against its cmor
-definition. To reduce the impact of this check while maintaing it as realiable
-as possible, it is split in two parts: one will check the metadata and will
-be done just after loading and concatenating the data and the other one will
-check the data itself and will be applied after all extracting operations are
-applied to reduce the amount of data to process.
+Data preprocessed by ESMValTool is automatically checked against its
+cmor definition. To reduce the impact of this check while maintaining
+it as reliable as possible, it is split in two parts: one will check
+the metadata and will be done just after loading and concatenating the
+data and the other one will check the data itself and will be applied
+after all extracting operations are applied to reduce the amount of
+data to process.
 
 Checks include, but are not limited to:
 
@@ -315,7 +316,7 @@ Introduction to masking
 
 Certain metrics and diagnostics need to be computed and performed on specific
 domains on the globe. The ESMValTool preprocessor supports filtering
-the input data on continents, oceans/seas and ice. This is achived by masking
+the input data on continents, oceans/seas and ice. This is achieved by masking
 the model data and keeping only the values associated with grid points that
 correspond to, e.g., land, ocean or ice surfaces, as specified by the
 user. Where possible, the masking is realized using the standard mask files
@@ -402,7 +403,7 @@ Mask files
 
 At the core of the land/sea/ice masking in the preprocessor are the mask files
 (whether it be fx type or Natural Earth type of files); these files (bar
-Natural Earth) can be retrived and used in the diagnostic phase as well. By
+Natural Earth) can be retrieved and used in the diagnostic phase as well. By
 specifying the ``fx_files:`` key in the variable in diagnostic in the recipe,
 and populating it with a list of desired files e.g.:
 
@@ -436,7 +437,7 @@ Missing values masks
 Missing (masked) values can be a nuisance especially when dealing with
 multimodel ensembles and having to compute multimodel statistics; different
 numbers of missing data from dataset to dataset may introduce biases and
-artifically assign more weight to the datasets that have less missing
+artificially assign more weight to the datasets that have less missing
 data. This is handled in ESMValTool via the missing values masks: two types of
 such masks are available, one for the multimodel case and another for the
 single model case.
@@ -448,7 +449,7 @@ individual models into a multimodel missing values mask; the individual model
 masks are built according to common criteria: the user chooses a time window in
 which missing data points are counted, and if the number of missing data points
 relative to the number of total data points in a window is less than a chosen
-fractional theshold, the window is discarded i.e. all the points in the window
+fractional threshold, the window is discarded i.e. all the points in the window
 are masked (set to missing).
 
 .. code-block:: yaml
@@ -494,7 +495,7 @@ interval thresholding and masking can also be performed. These functions are
 ``mask_above_threshold``, ``mask_below_threshold``, ``mask_inside_range``, and
 ``mask_outside_range``.
 
-Thes functions always take a cube as first argument and either ``threshold``
+These functions always take a cube as first argument and either ``threshold``
 for threshold masking or the pair ``minimum`, ``maximum`` for interval masking.
 
 See also :func:`esmvalcore.preprocessor.mask_above_threshold` and related
@@ -527,8 +528,10 @@ we show a few examples.
 Regridding on a reference dataset grid
 --------------------------------------
 
-The example below shows how to regrid on the reference dataset ``ERA-Interim``
-(observational data, but just as well CMIP, obs4mips, or ana4mips datasets can be used); in this case the `scheme` is `linear`.
+The example below shows how to regrid on the reference dataset
+``ERA-Interim`` (observational data, but just as well CMIP, obs4mips,
+or ana4mips datasets can be used); in this case the `scheme` is
+`linear`.
 
 .. code-block:: yaml
 
@@ -544,7 +547,7 @@ Regridding on an ``MxN`` grid specification
 The example below shows how to regrid on a reference grid with a cell
 specification of ``2.5x2.5`` degrees. This is similar to regridding on
 reference datasets, but in the previous case the reference dataset grid cell
-specifications are not necessarily known a priori. Reegridding on an ``MxN``
+specifications are not necessarily known a priori. Regridding on an ``MxN``
 cell specification is oftentimes used when operating on localized data.
 
 .. code-block:: yaml
@@ -581,7 +584,7 @@ Regridding (interpolation, extrapolation) schemes
 
 The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
-implementaions in Iris:
+implementations in Iris:
 
 * ``linear``: `Linear(extrapolation_mode='mask') <https://scitools.org.uk/iris/docs/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
 * ``linear_extrapolate``: `Linear(extrapolation_mode='extrapolate') <https://scitools.org.uk/iris/docs/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
@@ -628,7 +631,7 @@ Multi-model statistics
 Computing multi-model statistics is an integral part of model analysis and
 evaluation: individual models display a variety of biases depending on model
 set-up, initial conditions, forcings and implementation; comparing model data
-to observational data, these biases have a significanly lower statistical
+to observational data, these biases have a significantly lower statistical
 impact when using a multi-model ensemble. ESMValTool has the capability of
 computing a number of multi-model statistical measures: using the preprocessor
 module ``multi_model_statistics`` will enable the user to ask for either a
@@ -921,7 +924,7 @@ See also :func:`esmvalcore.preprocessor.anomalies`.
 This function aligns the time points of each component dataset so that the Iris
 cubes from different datasets can be subtracted. The operation makes the
 datasets time points common; it also resets the time
-bounds and auxiliary coordinates to reflect the artifically shifted time
+bounds and auxiliary coordinates to reflect the artificially shifted time
 points. Current implementation for monthly and daily data; the ``frequency`` is
 set automatically from the variable CMOR table unless a custom ``frequency`` is
 set manually by the user in recipe.
@@ -973,7 +976,7 @@ The area manipulation module contains the following preprocessor functions:
 * extract_region_: Extract a region from a cube based on ``lat/lon``
   corners.
 * extract_named_regions_: Extract a specific region from in the region
-  cooordinate.
+  coordinate.
 * extract_shape_: Extract a region defined by a shapefile.
 * extract_point_: Extract a single point (with interpolation)
 * zonal_statistics_: Compute zonal statistics.
@@ -984,7 +987,7 @@ The area manipulation module contains the following preprocessor functions:
 ``extract_region``
 ------------------
 
-This function masks data outside a rectagular region requested. The boundairies
+This function masks data outside a rectangular region requested. The boundaries
 of the region are provided as latitude and longitude coordinates in the
 arguments:
 
@@ -1005,7 +1008,7 @@ See also :func:`esmvalcore.preprocessor.extract_region`.
 This function extracts a specific named region from the data. This function
 takes the following argument: ``regions`` which is either a string or a list
 of strings of named regions. Note that the dataset must have a ``region``
-cooordinate which includes a list of strings as values. This function then
+coordinate which includes a list of strings as values. This function then
 matches the named regions against the requested string.
 
 See also :func:`esmvalcore.preprocessor.extract_named_regions`.
@@ -1018,9 +1021,9 @@ Extract a shape or a representative point for this shape from
 the data.
 
 Parameters:
-  * ``shapefile``: path to the shapefile containing the geometry of the 
-    region to be extracted. If the file contains multiple shapes behaviour 
-    depends on the decomposed parameter. This path can be relative to 
+  * ``shapefile``: path to the shapefile containing the geometry of the
+    region to be extracted. If the file contains multiple shapes behaviour
+    depends on the decomposed parameter. This path can be relative to
     ``auxiliary_data_dir`` defined in the :ref:`user configuration file`.
   * ``method``: the method to select the region, selecting either all points
 	  contained by the shape or a single representative point. Choose either
@@ -1029,9 +1032,9 @@ Parameters:
   * ``crop``: by default extract_region_ will be used to crop the data to a
 	  minimal rectangular region containing the shape. Set to ``false`` to only
 	  mask data outside the shape. Data on irregular grids will not be cropped.
-  * ``decomposed``: by default ``false``, in this case the union of all the 
-    regions in the shape file is masked out. If ``true``, the regions in the 
-    shapefiles are masked out seperately, generating an auxiliary dimension 
+  * ``decomposed``: by default ``false``, in this case the union of all the
+    regions in the shape file is masked out. If ``true``, the regions in the
+    shapefiles are masked out separately, generating an auxiliary dimension
     for the cube for this.
 
 Examples:
@@ -1073,7 +1076,8 @@ Parameters:
 ``zonal_statistics``
 --------------------
 
-The function calculates the zonal statistics by applying an operator along the longitude coordinate. This function takes one argument:
+The function calculates the zonal statistics by applying an operator
+along the longitude coordinate. This function takes one argument:
 
 * ``operator``: Which operation to apply: mean, std_dev, median, min, max or sum
 
@@ -1083,7 +1087,9 @@ See also :func:`esmvalcore.preprocessor.zonal_means`.
 ``meridional_statistics``
 -------------------------
 
-The function calculates the meridional statistics by applying an operator along the latitude coordinate. This function takes one argument:
+The function calculates the meridional statistics by applying an
+operator along the latitude coordinate. This function takes one
+argument:
 
 * ``operator``: Which operation to apply: mean, std_dev, median, min, max or sum
 
@@ -1098,7 +1104,7 @@ areas of the region. This function takes the argument, ``operator``: the name
 of the operation to apply.
 
 This function can be used to apply several different operations in the
-horizonal plane: mean, standard deviation, median variance, minimum and maximum.
+horizontal plane: mean, standard deviation, median variance, minimum and maximum.
 
 Note that this function is applied over the entire dataset. If only a specific
 region, depth layer or time period is required, then those regions need to be
@@ -1129,7 +1135,7 @@ takes two arguments, a minimum and a maximum (``z_min`` and ``z_max``,
 respectively) in the `z`-direction.
 
 Note that this requires the requested `z`-coordinate range to be the same sign
-as the Iris cube. ie, if the cube has `z`-coordinate as negative, then
+as the Iris cube. That is, if the cube has `z`-coordinate as negative, then
 ``z_min`` and ``z_max`` need to be negative numbers.
 
 See also :func:`esmvalcore.preprocessor.extract_volume`.
@@ -1181,7 +1187,7 @@ See also :func:`esmvalcore.preprocessor.extract_transect`.
 ----------------------
 
 This function extract data along a specified trajectory.
-The three areguments are: ``latitudes``, ``longitudes`` and number of point
+The three arguments are: ``latitudes``, ``longitudes`` and number of point
 needed for extrapolation ``number_points``.
 
 If two points are provided, the ``number_points`` argument is used to set a
@@ -1192,7 +1198,7 @@ a cube which has extrapolated the data of the cube to those points, and
 ``number_points`` is not needed.
 
 Note that this function uses the expensive ``interpolate`` method from
-``Iris.analysis.trajectory``, but it may be neccesary for irregular grids.
+``Iris.analysis.trajectory``, but it may be necessary for irregular grids.
 
 See also :func:`esmvalcore.preprocessor.extract_trajectory`.
 
@@ -1209,12 +1215,12 @@ This function has two parameters:
 * ``method``: It can be ``linear`` or ``constant``. Default: ``linear``
 
 If method is ``linear``, detrend will calculate the linear trend along the
-selected axis and substract it to the data. For example, this can be used to
+selected axis and subtract it to the data. For example, this can be used to
 remove the linear trend caused by climate change on some variables is selected
 dimension is time.
 
 If method is ``constant``, detrend will compute the mean along that dimension
-and substract it from the data
+and subtract it from the data
 
 See also :func:`esmvalcore.preprocessor.detrend`.
 
@@ -1246,7 +1252,7 @@ See also :func:`esmvalcore.preprocessor.convert_units`.
 Information on maximum memory required
 ======================================
 In the most general case, we can set upper limits on the maximum memory the
-anlysis will require:
+analysis will require:
 
 
 ``Ms = (R + N) x F_eff - F_eff`` - when no multimodel analysis is performed;

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -22,7 +22,7 @@ from ._multimodel import multi_model_statistics
 from ._other import clip
 from ._reformat import (cmor_check_data, cmor_check_metadata, fix_data,
                         fix_file, fix_metadata)
-from ._regrid import extract_levels, regrid
+from ._regrid import extract_levels, regrid, extract_point
 from ._time import (annual_statistics, anomalies, climate_statistics,
                     daily_statistics, decadal_statistics, extract_month,
                     extract_season, extract_time, monthly_statistics,
@@ -65,6 +65,8 @@ __all__ = [
     'mask_landseaice',
     # Regridding
     'regrid',
+    # Point interpolation
+    'extract_point',
     # Masking missing values
     'mask_fillvalues',
     'mask_above_threshold',

--- a/tests/integration/preprocessor/_regrid/test_extract_point.py
+++ b/tests/integration/preprocessor/_regrid/test_extract_point.py
@@ -1,0 +1,202 @@
+"""
+Integration tests for the :func:`esmvalcore.preprocessor.regrid.regrid`
+function.
+
+"""
+
+import unittest
+
+import iris
+import numpy as np
+
+import tests
+from esmvalcore.preprocessor import extract_point
+from tests.unit.preprocessor._regrid import _make_cube
+
+
+class Test(tests.Test):
+    def setUp(self):
+        """Prepare tests."""
+        shape = (3, 4, 4)
+        data = np.arange(np.prod(shape)).reshape(shape)
+        self.cube = _make_cube(data, dtype=np.float)
+        self.cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
+
+    def test_extract_point__single_linear(self):
+        """Test linear interpolation when extracting a single point"""
+
+        point = extract_point(self.cube, 2.1, 2.1, scheme='linear')
+        self.assertEqual(point.shape, (3,))
+        np.testing.assert_allclose(point.data, [5.5, 21.5, 37.5])
+
+        # Exactly centred between grid points.
+        point = extract_point(self.cube, 2.5, 2.5, scheme='linear')
+        self.assertEqual(point.shape, (3,))
+        np.testing.assert_allclose(point.data, [7.5, 23.5, 39.5])
+
+        # On a (edge) grid point.
+        point = extract_point(self.cube, 4, 4, scheme='linear')
+        self.assertEqual(point.shape, (3,))
+        np.testing.assert_allclose(point.data, [15, 31, 47])
+
+        # Test two points outside the valid area.
+        # These should be masked, since we set up the interpolation
+        # schemes that way.
+        point = extract_point(self.cube, -1, -1, scheme='linear')
+        self.assertEqual(point.shape, (3,))
+        masked = np.ma.array([np.nan] * 3, mask=True)
+        self.assert_array_equal(point.data, masked)
+
+        point = extract_point(self.cube, 30, 30, scheme='linear')
+        self.assertEqual(point.shape, (3,))
+        self.assert_array_equal(point.data, masked)
+
+    def test_extract_point__single_nearest(self):
+        """Test nearest match when extracting a single point"""
+
+        point = extract_point(self.cube, 2.1, 2.1, scheme='nearest')
+        self.assertEqual(point.shape, (3,))
+        np.testing.assert_allclose(point.data, [5, 21, 37])
+
+        point = extract_point(self.cube, 4, 4, scheme='nearest')
+        self.assertEqual(point.shape, (3,))
+        np.testing.assert_allclose(point.data, [15, 31, 47])
+
+        # Test two points outside the valid area
+        point = extract_point(self.cube, -1, -1, scheme='nearest')
+        self.assertEqual(point.shape, (3,))
+        masked = np.ma.array(np.empty(3, dtype=np.float), mask=True)
+        self.assert_array_equal(point.data, masked)
+
+        point = extract_point(self.cube, 30, 30, scheme='nearest')
+        self.assertEqual(point.shape, (3,))
+        self.assert_array_equal(point.data, masked)
+
+    def test_extract_point__multiple_linear(self):
+        """Test linear interpolation for an array of one coordinate"""
+
+        # Test points on the grid edges, on a grid point, halfway and
+        # one in between.
+        coords = self.cube.coords(dim_coords=True)
+        print([coord.standard_name for coord in coords])
+
+        point = extract_point(self.cube, [1, 1.1, 1.5, 2, 4], 2,
+                              scheme='linear')
+        self.assertEqual(point.shape, (3, 5))
+        # Longitude is not a dimension coordinate anymore.
+        self.assertEqual(['air_pressure', 'latitude'], [
+            coord.standard_name for coord in point.coords(dim_coords=True)])
+        np.testing.assert_allclose(point.data, [[1, 1.4, 3, 5, 13],
+                                                [17, 17.4, 19., 21., 29],
+                                                [33, 33.4, 35, 37, 45]])
+
+        point = extract_point(self.cube, 4, [1, 1.1, 1.5, 2, 4],
+                              scheme='linear')
+        self.assertEqual(point.shape, (3, 5))
+        self.assertEqual(['air_pressure', 'longitude'], [
+            coord.standard_name for coord in point.coords(dim_coords=True)])
+        np.testing.assert_allclose(point.data, [[12, 12.1, 12.5, 13, 15],
+                                                [28, 28.1, 28.5, 29, 31],
+                                                [44, 44.1, 44.5, 45, 47]])
+
+        # Test latitude and longitude points outside the grid.
+        # These should all be masked.
+        coords = self.cube.coords(dim_coords=True)
+        point = extract_point(self.cube, [0, 10], 3,
+                              scheme='linear')
+        self.assertEqual(point.shape, (3, 2))
+        masked = np.ma.array(np.empty((3, 2), dtype=np.float), mask=True)
+        self.assert_array_equal(point.data, masked)
+        coords = self.cube.coords(dim_coords=True)
+        point = extract_point(self.cube, 2, [0, 10],
+                              scheme='linear')
+        coords = point.coords(dim_coords=True)
+        self.assertEqual(point.shape, (3, 2))
+        self.assert_array_equal(point.data, masked)
+
+    def test_extract_point__multiple_nearest(self):
+        """Test nearest match for an array of one coordinate"""
+
+        point = extract_point(self.cube, [1, 1.1, 1.5, 1.501, 2, 4], 2,
+                              scheme='nearest')
+        self.assertEqual(point.shape, (3, 6))
+        self.assertEqual(['air_pressure', 'latitude'], [
+            coord.standard_name for coord in point.coords(dim_coords=True)])
+        np.testing.assert_allclose(point.data, [[1, 1, 1, 5, 5, 13],
+                                                [17, 17, 17, 21, 21, 29],
+                                                [33, 33, 33, 37, 37, 45]])
+        point = extract_point(self.cube, 4, [1, 1.1, 1.5, 1.501, 2, 4],
+                              scheme='nearest')
+        self.assertEqual(point.shape, (3, 6))
+        self.assertEqual(['air_pressure', 'longitude'], [
+            coord.standard_name for coord in point.coords(dim_coords=True)])
+        np.testing.assert_allclose(point.data, [[12, 12, 12, 13, 13, 15],
+                                                [28, 28, 28, 29, 29, 31],
+                                                [44, 44, 44, 45, 45, 47]])
+        point = extract_point(self.cube, [0, 10], 3,
+                              scheme='nearest')
+        masked = np.ma.array(np.empty((3, 2), dtype=np.float), mask=True)
+        self.assertEqual(point.shape, (3, 2))
+        self.assert_array_equal(point.data, masked)
+        point = extract_point(self.cube, 2, [0, 10],
+                              scheme='nearest')
+        self.assertEqual(point.shape, (3, 2))
+        self.assert_array_equal(point.data, masked)
+
+    def test_extract_point__multiple_both_linear(self):
+        """Test for both latitude and longitude arrays, with
+        linear interpolation"""
+        point = extract_point(self.cube, [0, 1.1, 1.5, 1.51, 4, 5],
+                              [0, 1.1, 1.5, 1.51, 4, 5], scheme='linear')
+        self.assertEqual(point.data.shape, (3, 6, 6))
+
+        result = np.ma.array(np.empty((3, 6, 6), dtype=np.float), mask=True)
+        result[0, 1, 1:5] = [0.5, 0.9, 0.91, 3.4]
+        result[0, 2, 1:5] = [2.1, 2.5, 2.51, 5.0]
+        result[0, 3, 1:5] = [2.14, 2.54, 2.55, 5.04]
+        result[0, 4, 1:5] = [12.1, 12.5, 12.51, 15.0]
+
+        result[1, 1, 1:5] = [16.5, 16.9, 16.91, 19.4]
+        result[1, 2, 1:5] = [18.10, 18.5, 18.51, 21.0]
+        result[1, 3, 1:5] = [18.14, 18.54, 18.55, 21.04]
+        result[1, 4, 1:5] = [28.1, 28.5, 28.51, 31.0]
+
+        result[2, 1, 1:5] = [32.5, 32.9, 32.91, 35.4]
+        result[2, 2, 1:5] = [34.1, 34.5, 34.51, 37]
+        result[2, 3, 1:5] = [34.14, 34.54, 34.55, 37.04]
+        result[2, 4, 1:5] = [44.1, 44.5, 44.51, 47]
+        # Unmask the inner area of the result array.
+        # The outer edges of the extracted points are outside the cube
+        # grid, and should thus be masked.
+        result.mask[:, 1:5, 1:5] = False
+
+        np.testing.assert_allclose(point.data, result)
+
+    def test_extract_point__multiple_both_nearest(self):
+        """Test for both latitude and longitude arrays, with nearest match"""
+        point = extract_point(self.cube, [0, 1.1, 1.5, 1.51, 4, 5],
+                              [0, 1.1, 1.5, 1.51, 4, 5], scheme='nearest')
+        self.assertEqual(point.data.shape, (3, 6, 6))
+
+        result = np.ma.array(np.empty((3, 6, 6), dtype=np.float), mask=True)
+        result[0, 1, 1:5] = [0.0, 0.0, 1.0, 3.0]
+        result[0, 2, 1:5] = [0.0, 0.0, 1.0, 3.0]
+        result[0, 3, 1:5] = [4.0, 4.0, 5.0, 7.0]
+        result[0, 4, 1:5] = [12.0, 12.0, 13.0, 15.0]
+
+        result[1, 1, 1:5] = [16.0, 16.0, 17.0, 19.0]
+        result[1, 2, 1:5] = [16.0, 16.0, 17.0, 19.0]
+        result[1, 3, 1:5] = [20.0, 20.0, 21.0, 23.0]
+        result[1, 4, 1:5] = [28.0, 28.0, 29.0, 31.0]
+
+        result[2, 1, 1:5] = [32.0, 32.0, 33.0, 35.0]
+        result[2, 2, 1:5] = [32.0, 32.0, 33.0, 35.0]
+        result[2, 3, 1:5] = [36.0, 36.0, 37.0, 39.0]
+        result[2, 4, 1:5] = [44.0, 44.0, 45.0, 47.0]
+        result.mask[:, 1:5, 1:5] = False
+
+        np.testing.assert_allclose(point.data, result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/preprocessor/_regrid/test_extract_point.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_point.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for the
+:func:`esmvalcore.preprocessor.regrid.extract_point` function.
+
+"""
+
+import unittest
+from unittest import mock
+
+import iris
+
+import tests
+from esmvalcore.preprocessor import extract_point
+from esmvalcore.preprocessor._regrid import POINT_INTERPOLATION_SCHEMES
+
+
+class Test(tests.Test):
+    def setUp(self):
+        self.coord_system = mock.Mock(return_value=None)
+        self.coord = mock.sentinel.coord
+        self.coords = mock.Mock(return_value=[self.coord])
+        self.remove_coord = mock.Mock()
+        self.point_cube = mock.sentinel.point_cube
+        self.interpolate = mock.Mock(return_value=self.point_cube)
+        self.src_cube = mock.Mock(
+            spec=iris.cube.Cube,
+            coord_system=self.coord_system,
+            coords=self.coords,
+            remove_coord=self.remove_coord,
+            interpolate=self.interpolate)
+        self.schemes = ['linear', 'nearest']
+
+        self.mocks = [
+            self.coord_system, self.coords, self.interpolate, self.src_cube
+        ]
+
+    def test_invalid_scheme__unknown(self):
+        dummy = mock.sentinel.dummy
+        emsg = "Unknown interpolation scheme, got 'non-existent'"
+        with self.assertRaisesRegex(ValueError, emsg):
+            extract_point(dummy, dummy, dummy, 'non-existent')
+
+    def test_interpolation_schemes(self):
+        self.assertEqual(
+            set(POINT_INTERPOLATION_SCHEMES.keys()), set(self.schemes))
+
+    def test_extract_point_interpolation_schemes(self):
+        dummy = mock.sentinel.dummy
+        for scheme in self.schemes:
+            result = extract_point(self.src_cube, dummy, dummy, scheme)
+            self.assertEqual(result, self.point_cube)
+
+    def test_extract_point(self):
+        dummy = mock.sentinel.dummy
+        scheme = 'linear'
+        result = extract_point(self.src_cube, dummy, dummy, scheme)
+        self.assertEqual(result, self.point_cube)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This add a simple point extraction function the preprocessor, with interpolation. It uses `iris.cube.Cube.interpolate` under the hood.

Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes {Link to corresponding issue}
