### PR TITLE
Include alias in MultiModel attributes

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -606,7 +606,8 @@ def _update_statistic_settings(products, order, preproc_dir):
     some_product = next(iter(products))
     for statistic in some_product.settings[step]['statistics']:
         attributes = _get_statistic_attributes(products)
-        attributes['dataset'] = attributes['alias'] = 'MultiModel{}'.format(statistic.title())
+        attributes['dataset'] = attributes['alias'] = 'MultiModel{}'.format(
+            statistic.title())
         attributes['filename'] = get_statistic_output_file(
             attributes, preproc_dir)
         common_settings = _get_remaining_common_settings(step, order, products)

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -606,7 +606,7 @@ def _update_statistic_settings(products, order, preproc_dir):
     some_product = next(iter(products))
     for statistic in some_product.settings[step]['statistics']:
         attributes = _get_statistic_attributes(products)
-        attributes['dataset'] = 'MultiModel{}'.format(statistic.title())
+        attributes['dataset'] = attributes['alias'] = 'MultiModel{}'.format(statistic.title())
         attributes['filename'] = get_statistic_output_file(
             attributes, preproc_dir)
         common_settings = _get_remaining_common_settings(step, order, products)


### PR DESCRIPTION
Automatic attribute where 'alias' and 'dataset' name are the same.
Could be overwritten with a specific custom alias.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.


* * *

Closes {#486}
