### PR TITLE
minor bugfix in CMOR fix for CMIP5 model HadGEM2-ES

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/hadgem2_es.py
+++ b/esmvalcore/cmor/_fixes/cmip5/hadgem2_es.py
@@ -27,7 +27,7 @@ class AllVars(Fix):
                 lat = cube.coord('latitude')
                 lat.points = np.clip(lat.points, -90., 90.)
                 if not lat.has_bounds():
-                  lat.guess_bounds()
+                    lat.guess_bounds()
                 lat.bounds = np.clip(lat.bounds, -90., 90.)
 
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/hadgem2_es.py
+++ b/esmvalcore/cmor/_fixes/cmip5/hadgem2_es.py
@@ -26,6 +26,8 @@ class AllVars(Fix):
             if lats:
                 lat = cube.coord('latitude')
                 lat.points = np.clip(lat.points, -90., 90.)
+                if not lat.has_bounds():
+                  lat.guess_bounds()
                 lat.bounds = np.clip(lat.bounds, -90., 90.)
 
         return cubes


### PR DESCRIPTION
Checks whether latitude bounds are present before trying to limit their range to -90...+90. In some cases, latitude bounds are missing causing this fix to crash without such an additional check.