### PR TITLE
Better error message when cube does not contain requested time

### DIFF
--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -107,8 +107,12 @@ class TestTimeSlice(tests.Test):
 
     def test_extract_time_no_slice(self):
         """Test fail of extract_time."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as ctx:
             extract_time(self.cube, 2200, 1, 1, 2200, 12, 31)
+        msg = (
+            "Time slice 2200-01-01 00:00:00 to 2200-12-31 00:00:00 is outside"
+            " cube time bounds 1950-01-16 00:00:00 to 1951-12-07 00:00:00.")
+        assert ctx.exception.args == (msg, )
 
     def test_extract_time_one_time(self):
         """Test extract_time with one time step."""


### PR DESCRIPTION
The error message when trying to use `extract_time` on a cube which does not contain data for that time was not correct. This pull request fixes that.

**Tasks**

-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
