### PR TITLE
Do not try to guess or warn about missing bounds when there shouldn't be any

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -379,11 +379,11 @@ class CMORCheck():
                     self.report_error(self._attr_msg, var_name, 'units',
                                       cmor.units, coord.units)
         self._check_coord_values(cmor, coord, var_name)
-        self._check_coord_bounds(coord, var_name)
+        self._check_coord_bounds(cmor, coord, var_name)
         self._check_coord_monotonicity_and_direction(cmor, coord, var_name)
 
-    def _check_coord_bounds(self, coord, var_name):
-        if not coord.has_bounds():
+    def _check_coord_bounds(self, cmor, coord, var_name):
+        if cmor.must_have_bounds == 'yes' and not coord.has_bounds():
             if self.automatic_fixes:
                 try:
                     coord.guess_bounds()

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -73,6 +73,7 @@ class CoordinateInfoMock:
             self.units = "units"
 
         self.stored_direction = "increasing"
+        self.must_have_bounds = "yes"
         self.requested = []
 
         valid_limits = {'lat': ('-90', '90'), 'lon': ('0', '360')}
@@ -349,11 +350,18 @@ class TestCMORCheck(unittest.TestCase):
         self._check_warnings_on_metadata(automatic_fixes=False)
         self.assertFalse(self.cube.coord('longitude').has_bounds())
 
-    def test_not_bounds_with_fixes(self):
+    def test_guess_bounds_with_fixes(self):
         """Warning if bounds added with automatic fixes."""
         self.cube.coord('longitude').bounds = None
         self._check_warnings_on_metadata(automatic_fixes=True)
         self.assertTrue(self.cube.coord('longitude').has_bounds())
+
+    def test_not_guess_bounds_with_fixes(self):
+        """Warning if bounds added with automatic fixes."""
+        self.cube.coord('longitude').bounds = None
+        self.var_info.coordinates['lon'].must_have_bounds = "no"
+        self._check_cube(automatic_fixes=True)
+        self.assertFalse(self.cube.coord('longitude').has_bounds())
 
     def test_not_correct_lons(self):
         """Fail if longitudes are not correct in metadata step."""


### PR DESCRIPTION
Since #166 was merged, the tool is generating lots of warnings because it's trying to automatically add bounds to coordinates that do not need them. This pull request changes the behaviour so we only try to guess bounds when they are required by the CMOR table.

**Tasks**

-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

* * *
