### PR TITLE
Added documentation to avoid using leading 0s to specify years in recipe

### DIFF
--- a/doc/esmvalcore/recipe.rst
+++ b/doc/esmvalcore/recipe.rst
@@ -82,7 +82,10 @@ data specifications:
   ``RCP8.5``)
 - mip (for CMIP data, key ``mip``, value e.g. ``Amon``, ``Omon``, ``LImon``)
 - ensemble member (key ``ensemble``, value e.g. ``r1i1p1``, ``r1i1p1f1``)
-- time range (e.g. key-value ``start_year: 1982``, ``end_year: 1990``)
+- time range (e.g. key-value ``start_year: 1982``, ``end_year: 1990``. Please
+  note that `yaml`_ interprets numbers with a leading ``0`` as octal numbers,
+  so we recommend to avoid them. For example, use ``128`` to specify the year
+  128 instead of ``0128``.)
 - model grid (native grid ``grid: gn`` or regridded grid ``grid: gr``, for
   CMIP6 data only).
 
@@ -133,6 +136,8 @@ Please, bear in mind that this syntax can only be used in the ensemble tag.
 
 Note that this section is not required, as datasets can also be provided in the
 Diagnostics_ section.
+
+.. _`yaml`: https://yaml.org/refcard.html
 
 .. _Preprocessors:
 


### PR DESCRIPTION
Added documentation to avoid using leading 0s to specify years in recipe.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

* * *

Closes #25
