### PR TITLE
Moved and completed time preprocessors list (PR 439 child 1)

### DIFF
--- a/esmvalcore/_recipe_checks.py
+++ b/esmvalcore/_recipe_checks.py
@@ -8,7 +8,7 @@ import yamale
 
 from ._data_finder import get_start_end_year
 from ._task import get_flattened_tasks, which
-from .preprocessor import PreprocessingTask
+from .preprocessor import PreprocessingTask, TIME_PREPROCESSORS
 
 logger = logging.getLogger(__name__)
 
@@ -131,8 +131,7 @@ def data_availability(input_files, var, dirnames, filenames):
     if missing_years:
         raise RecipeError(
             "No input data available for years {} in files {}".format(
-                ", ".join(str(year) for year in missing_years),
-                input_files))
+                ", ".join(str(year) for year in missing_years), input_files))
 
 
 def tasks_valid(tasks):
@@ -149,16 +148,10 @@ def tasks_valid(tasks):
 
 def check_for_temporal_preprocs(profile):
     """Check for temporal operations on fx variables."""
-    temporal_preprocs = [
-        'extract_season',
-        'extract_month',
-        'annual_mean',
-        'seasonal_mean',
-        'time_average',
-        'regrid_time',
-    ]
     temp_preprocs = [
-        preproc for preproc in profile if preproc in temporal_preprocs]
+        preproc for preproc in profile
+        if profile[preproc] and preproc in TIME_PREPROCESSORS
+    ]
     if temp_preprocs:
         raise RecipeError(
             "Time coordinate preprocessor step(s) {} not permitted on fx "

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -109,6 +109,20 @@ __all__ = [
     'cleanup',
 ]
 
+TIME_PREPROCESSORS = [
+    'extract_time',
+    'extract_season',
+    'extract_month',
+    'daily_statistics',
+    'monthly_statistics',
+    'seasonal_statistics',
+    'annual_statistics',
+    'decadal_statistics',
+    'climate_statistics',
+    'anomalies',
+    'regrid_time',
+]
+
 DEFAULT_ORDER = tuple(__all__)
 
 # The order of initial and final steps cannot be configured


### PR DESCRIPTION
Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

This alleviates some of the burden from PR #439 that will be now be broken into smaller bits - this is the first child
