### PR TITLE
Updated docstrings for area and volume statistics to work with fx variables definitions (PR 439 child 3)

### DIFF
--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -221,6 +221,9 @@ def area_statistics(cube, operator, fx_files=None):
     | `max`      | Maximum value                                    |
     +------------+--------------------------------------------------+
 
+    If fx_files is provided, the variable's preprocessor chain will be applied
+    to each of the requested fx variables, up to and not including this step.
+
     Parameters
     ----------
         cube: iris.cube.Cube
@@ -228,8 +231,11 @@ def area_statistics(cube, operator, fx_files=None):
         operator: str
             The operation, options: mean, median, min, max, std_dev, sum,
             variance
-        fx_files: dict
-            dictionary of field:filename for the fx_files
+        fx_files: list
+            list of field:str short_name for the fx variables requested or
+            list of field:dict for the fx variables requested, including
+            but not limited to: keys: short_name, mip, experiment etc (at least
+            short_name required if dict)
 
     Returns
     -------

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -176,7 +176,9 @@ def volume_statistics(
 
     The volume average is weighted acoording to the cell volume. Cell volume
     is calculated from iris's cartography tool multiplied by the cell
-    thickness.
+    thickness. If fx_files is provided, the variable's preprocessor chain will
+    be applied to each of the requested fx variables, up to and not including
+    this step.
 
     Parameters
     ----------
@@ -184,8 +186,11 @@ def volume_statistics(
             Input cube.
         operator: str
             The operation to apply to the cube, options are: 'mean'.
-        fx_files: dict
-            dictionary of field:filename for the fx_files
+        fx_files: list
+            list of field:str short_name for the fx variables requested or
+            list of field:dict for the fx variables requested, including
+            but not limited to: keys: short_name, mip, experiment etc (at least
+            short_name required if dict)
 
     Returns
     -------


### PR DESCRIPTION
Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

**READ BEFORE PROCEEDING**

Issue #436 lays down the need for preprocessing fx variables as integrated with `area_atatistics` and `volume_statistics`; PR #439 implements that; reviewers expressed their consternation that that PR is huuuge so it got broken down; the layout for the PR 439 children is outlined in https://github.com/ESMValGroup/ESMValCore/issues/436#issuecomment-589717672
This is the 3rd child that depends upon integration of the 2nd child; it contains the updated docstrings for area and volume statistics in light of the new recipe syntax with fx vars as dicts.
