### PR TITLE
Run more relevant tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,20 @@
 ---
 version: 2
+
+aliases:
+  check_changes: &check_changes
+    name: Check changes
+    command: |
+      if (test "$CIRCLE_BRANCH" = master ||
+          git --no-pager diff --name-only origin/master... |
+          grep -q -E -f .circleci/install_triggers)
+      then
+        echo Running installation tests
+      else
+        echo Skipping installation tests
+        circleci step halt
+      fi
+
 jobs:
   test:
     # Run tests
@@ -40,6 +55,7 @@ jobs:
       - image: continuumio/miniconda3
     steps:
       - checkout
+      - run: *check_changes
       - restore_cache:
           key: python3-install-{{ .Branch }}
       - run:
@@ -117,6 +133,7 @@ jobs:
       - image: continuumio/miniconda3
     steps:
       - checkout
+      - run: *check_changes
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -145,6 +162,7 @@ jobs:
       - image: continuumio/miniconda3
     steps:
       - checkout
+      - run: *check_changes
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -190,9 +208,9 @@ workflows:
   commit:
     jobs:
       - test
-      - install:
-          requires:
-            - test
+      - install
+      - develop
+      - conda_build
       - documentation
   nightly:
     triggers:

--- a/.circleci/install_triggers
+++ b/.circleci/install_triggers
@@ -1,4 +1,5 @@
 ^\.circleci/
-^setup\.py$
 ^environment\.yml$
-^meta\.yaml$
+^[A-Za-z_]*meta\.yaml$
+^setup\.py$
+^setup\.cfg$

--- a/.circleci/install_triggers
+++ b/.circleci/install_triggers
@@ -1,0 +1,4 @@
+^\.circleci/
+^setup\.py$
+^environment\.yml$
+^meta\.yaml$

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ addopts =
     --doctest-modules
     --ignore=esmvalcore/cmor/tables/
     --cov=esmvalcore
-    --cov-report=term
     --cov-report=xml:test-reports/coverage.xml
     --cov-report=html:test-reports/coverage_html
     --html=test-reports/report.html


### PR DESCRIPTION
This pull request tries to make the tests we run on CircleCI more relevant.
- With these changes, CircleCI will only run tests that require installation/conda build for the master branch or when there are changes to the relevant files (meta.yaml, environment.yml, setup.py or the CircleCI configuration itself).
- Do not print the test coverage after every test run, this will make the output less cluttered.