### PR TITLE
Unpin on Python<3.8 for conda package

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -29,7 +29,7 @@ build:
 requirements:
   build:
     - git
-    - python>=3.6,<3.8
+    - python>=3.6
     # Normally installed via pip:
     - pytest-runner
     - setuptools_scm


### PR DESCRIPTION
@bouweandela any reason you kept the pin in `meta.yml`? Anyways, I tested the unpinning and all works fine :beer: