### PR TITLE
Test get start end year replace with tmp_dir/test.nc so no fluke dates can be found in temporary file name

### DIFF
--- a/tests/unit/data_finder/test_get_start_end_year.py
+++ b/tests/unit/data_finder/test_get_start_end_year.py
@@ -33,10 +33,9 @@ def test_get_start_end_year(case):
     assert case_end == end
 
 
-def test_read_time_from_cube():
+def test_read_time_from_cube(tmp_path):
     """Try to get time from cube if no date in filename"""
-    temp_file = tempfile.NamedTemporaryFile(suffix='.nc')
-    temp_file.name = re.sub(r'\d', 'v', temp_file.name)
+    temp_file = str(tmp_path / 'test.nc')
     cube = iris.cube.Cube([0, 0], var_name='var')
     time = iris.coords.DimCoord([0, 366],
                                 'time',

--- a/tests/unit/data_finder/test_get_start_end_year.py
+++ b/tests/unit/data_finder/test_get_start_end_year.py
@@ -30,9 +30,10 @@ def test_get_start_end_year(case):
     assert case_end == end
 
 
-def test_read_time_from_cube(tmp_path):
+def test_read_time_from_cube(monkeypatch, tmp_path):
     """Try to get time from cube if no date in filename"""
-    temp_file = str(tmp_path / 'test.nc')
+    monkeypatch.chdir(tmp_path)
+    temp_file = 'test.nc'
     cube = iris.cube.Cube([0, 0], var_name='var')
     time = iris.coords.DimCoord([0, 366],
                                 'time',

--- a/tests/unit/data_finder/test_get_start_end_year.py
+++ b/tests/unit/data_finder/test_get_start_end_year.py
@@ -1,6 +1,8 @@
 """Unit tests for :func:`esmvalcore._data_finder.regrid._stock_cube`"""
 
+import re
 import tempfile
+
 import iris
 import pytest
 
@@ -34,6 +36,7 @@ def test_get_start_end_year(case):
 def test_read_time_from_cube():
     """Try to get time from cube if no date in filename"""
     temp_file = tempfile.NamedTemporaryFile(suffix='.nc')
+    temp_file.name = re.sub(r'\d', 'v', temp_file.name)
     cube = iris.cube.Cube([0, 0], var_name='var')
     time = iris.coords.DimCoord([0, 366],
                                 'time',

--- a/tests/unit/data_finder/test_get_start_end_year.py
+++ b/tests/unit/data_finder/test_get_start_end_year.py
@@ -1,8 +1,5 @@
 """Unit tests for :func:`esmvalcore._data_finder.regrid._stock_cube`"""
 
-import re
-import tempfile
-
 import iris
 import pytest
 

--- a/tests/unit/data_finder/test_get_start_end_year.py
+++ b/tests/unit/data_finder/test_get_start_end_year.py
@@ -38,8 +38,8 @@ def test_read_time_from_cube(tmp_path):
                                 'time',
                                 units='days since 1990-01-01')
     cube.add_dim_coord(time, 0)
-    iris.save(cube, temp_file.name)
-    start, end = get_start_end_year(temp_file.name)
+    iris.save(cube, temp_file)
+    start, end = get_start_end_year(temp_file)
     assert start == 1990
     assert end == 1991
 


### PR DESCRIPTION
Motivated by transient test fails due to random combinations that look like dates as @bouweandela explains in https://github.com/ESMValGroup/ESMValCore/pull/530#issuecomment-593466236