### PR TITLE
Fix bug that made diagnostics with diagnostics as ancestors fail

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -268,7 +268,7 @@ class DiagnosticTask(BaseTask):
         super().__init__(ancestors=ancestors, name=name)
         self.script = script
         self.settings = settings
-        self.output_dir = Path(output_dir)
+        self.output_dir = output_dir
         self.cmd = self._initialize_cmd()
         self.log = Path(settings['run_dir']) / 'log.txt'
         self.resource_log = Path(settings['run_dir']) / 'resource_usage.txt'


### PR DESCRIPTION
Fix bug that made diagnostics with diagnostics as ancestors fail

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

* * *

Closes #554