### PR TITLE
Added fixes for CESM2 models

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2.py
@@ -1,21 +1,83 @@
 """Fixes for CESM2 model."""
+from shutil import copyfile
+
+from netCDF4 import Dataset
+
 from ..fix import Fix
 from ..shared import (add_scalar_depth_coord, add_scalar_height_coord,
                       add_scalar_typeland_coord, add_scalar_typesea_coord)
 
 
+class Cl(Fix):
+    """Fixes for ``cl``."""
+
+    def fix_file(self, filepath, output_dir):
+        """Fix hybrid pressure coordinate.
+
+        Adds missing ``formula_terms`` attribute to file and fix ordering
+        of auxiliary coordinates ``a`` and ``b``.
+
+        Note
+        ----
+        Fixing this with :mod:`iris` in ``fix_metadata`` or ``fix_data`` is
+        **not** possible, since the bounds of the vertical coordinates ``a``
+        and ``b`` are not present in the loaded :class:`iris.cube.CubeList`,
+        even when :func:`iris.load_raw` is used.
+
+        Parameters
+        ----------
+        filepath : str
+            Path to the original file.
+        output_dir : str
+            Path of the directory where the fixed file is saved to.
+
+        Returns
+        -------
+        str
+            Path to the fixed file.
+
+        """
+        new_path = self.get_fixed_filepath(output_dir, filepath)
+        copyfile(filepath, new_path)
+        dataset = Dataset(new_path, mode='a')
+
+        # Fix hybrid sigma pressure coordinate
+        dataset.variables['lev'].formula_terms = 'p0: p0 a: a b: b ps: ps'
+        dataset.variables['lev'].standard_name = (
+            'atmosphere_hybrid_sigma_pressure_coordinate')
+        dataset.variables['lev'].units = '1'
+
+        # Fix auxiliary coordinates
+        dataset.variables['a'][:] = dataset.variables['a'][::-1]
+        dataset.variables['b'][:] = dataset.variables['b'][::-1]
+
+        # Save
+        dataset.close()
+        return new_path
+
+
+class Cli(Cl):
+    """Fixes for ``cli``."""
+
+
+class Clw(Cl):
+    """Fixes for ``clw``."""
+
+
 class Fgco2(Fix):
     """Fixes for fgco2."""
+
     def fix_metadata(self, cubes):
         """Add depth (0m) coordinate.
 
         Parameters
         ----------
-        cube : iris.cube.CubeList
+        cubes : iris.cube.CubeList
+            Input cubes.
 
         Returns
         -------
-        iris.cube.Cube
+        iris.cube.CubeList
 
         """
         cube = self.get_cube_from_list(cubes)
@@ -25,16 +87,18 @@ class Fgco2(Fix):
 
 class Tas(Fix):
     """Fixes for tas."""
+
     def fix_metadata(self, cubes):
         """Add height (2m) coordinate.
 
         Parameters
         ----------
-        cube : iris.cube.CubeList
+        cubes : iris.cube.CubeList
+            Input cubes.
 
         Returns
         -------
-        iris.cube.Cube
+        iris.cube.CubeList
 
         """
         cube = self.get_cube_from_list(cubes)
@@ -44,16 +108,18 @@ class Tas(Fix):
 
 class Sftlf(Fix):
     """Fixes for sftlf."""
+
     def fix_metadata(self, cubes):
         """Add typeland coordinate.
 
         Parameters
         ----------
-        cube : iris.cube.CubeList
+        cubes : iris.cube.CubeList
+            Input cubes.
 
         Returns
         -------
-        iris.cube.Cube
+        iris.cube.CubeList
 
         """
         cube = self.get_cube_from_list(cubes)
@@ -63,16 +129,18 @@ class Sftlf(Fix):
 
 class Sftof(Fix):
     """Fixes for sftof."""
+
     def fix_metadata(self, cubes):
         """Add typesea coordinate.
 
         Parameters
         ----------
-        cube : iris.cube.CubeList
+        cubes : iris.cube.CubeList
+            Input cubes.
 
         Returns
         -------
-        iris.cube.Cube
+        iris.cube.CubeList
 
         """
         cube = self.get_cube_from_list(cubes)

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_fv2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_fv2.py
@@ -1,0 +1,19 @@
+"""Fixes for CESM2-FV2 model."""
+from .cesm2 import Cl as BaseCl
+from .cesm2 import Tas as BaseTas
+
+
+class Cl(BaseCl):
+    """Fixes for ``cl``."""
+
+
+class Clw(Cl):
+    """Fixes for ``clw``."""
+
+
+class Cli(Cl):
+    """Fixes for ``cli``."""
+
+
+class Tas(BaseTas):
+    """Fixes for ``tas``."""

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm.py
@@ -1,5 +1,53 @@
 """Fixes for CESM2-WACCM model."""
+from netCDF4 import Dataset
+
+from .cesm2 import Cl as BaseCl
 from .cesm2 import Tas as BaseTas
+
+
+class Cl(BaseCl):
+    """Fixes for cl."""
+
+    def fix_file(self, filepath, output_dir):
+        """Fix hybrid pressure coordinate.
+
+        Adds missing ``formula_terms`` attribute to file and fix ordering
+        of auxiliary coordinates ``a``, ``b``, ``a_bnds`` and ``b_bnds``.
+
+        Note
+        ----
+        Fixing this with :mod:`iris` in ``fix_metadata`` or ``fix_data`` is
+        **not** possible, since the bounds of the vertical coordinates ``a``
+        and ``b`` are not present in the loaded :class:`iris.cube.CubeList`,
+        even when :func:`iris.load_raw` is used.
+
+        Parameters
+        ----------
+        filepath : str
+            Path to the original file.
+        output_dir : str
+            Path of the directory where the fixed file is saved to.
+
+        Returns
+        -------
+        str
+            Path to the fixed file.
+
+        """
+        new_path = super().fix_file(filepath, output_dir)
+        dataset = Dataset(new_path, mode='a')
+        dataset.variables['a_bnds'][:] = dataset.variables['a_bnds'][::-1]
+        dataset.variables['b_bnds'][:] = dataset.variables['b_bnds'][::-1]
+        dataset.close()
+        return new_path
+
+
+class Cli(Cl):
+    """Fixes for ``cli``."""
+
+
+class Clw(Cl):
+    """Fixes for ``clw``."""
 
 
 class Tas(BaseTas):

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2.py
@@ -1,25 +1,213 @@
 """Tests for the fixes of CESM2."""
+import os
+import unittest
+
 import iris
+import numpy as np
 import pytest
 from cf_units import Unit
+from netCDF4 import Dataset
 
-from esmvalcore.cmor._fixes.cmip6.cesm2 import Tas
+from esmvalcore.cmor._fixes.cmip6.cesm2 import Cl, Cli, Clw, Tas
 from esmvalcore.cmor.fix import Fix
 
 
 @pytest.fixture
+def cl_file(tmp_path):
+    """Create netcdf file with similar issues as ``cl``."""
+    nc_path = os.path.join(tmp_path, 'cesm2_cl.nc')
+    dataset = Dataset(nc_path, mode='w')
+    dataset.createDimension('time', size=1)
+    dataset.createDimension('lev', size=2)
+    dataset.createDimension('lat', size=3)
+    dataset.createDimension('lon', size=4)
+    dataset.createDimension('bnds', size=2)
+
+    # Dimensional variables
+    dataset.createVariable('time', np.float64, dimensions=('time',))
+    dataset.createVariable('lev', np.float64, dimensions=('lev',))
+    dataset.createVariable('lev_bnds', np.float64, dimensions=('lev', 'bnds'))
+    dataset.createVariable('lat', np.float64, dimensions=('lat',))
+    dataset.createVariable('lon', np.float64, dimensions=('lon',))
+    dataset.variables['time'][:] = [0.0]
+    dataset.variables['time'].standard_name = 'time'
+    dataset.variables['time'].units = 'days since 6543-2-1'
+    dataset.variables['lev'][:] = [1.0, 2.0]
+    dataset.variables['lev'].bounds = 'lev_bnds'
+    dataset.variables['lev'].units = '1'
+    dataset.variables['lev_bnds'][:] = [[0.5, 1.5], [1.5, 3.0]]
+    dataset.variables['lev_bnds'].standard_name = (
+        'atmosphere_hybrid_sigma_pressure_coordinate')
+    dataset.variables['lev_bnds'].units = '1'
+    dataset.variables['lev_bnds'].formula_terms = (
+        'p0: p0 a: a_bnds b: b_bnds ps: ps')
+    dataset.variables['lat'][:] = [-30.0, 0.0, 30.0]
+    dataset.variables['lat'].standard_name = 'latitude'
+    dataset.variables['lat'].units = 'degrees_north'
+    dataset.variables['lon'][:] = [30.0, 60.0, 90.0, 120.0]
+    dataset.variables['lon'].standard_name = 'longitude'
+    dataset.variables['lon'].units = 'degrees_east'
+
+    # Coordinates for derivation of pressure coordinate
+    dataset.createVariable('a', np.float64, dimensions=('lev',))
+    dataset.createVariable('a_bnds', np.float64, dimensions=('lev', 'bnds'))
+    dataset.createVariable('b', np.float64, dimensions=('lev',))
+    dataset.createVariable('b_bnds', np.float64, dimensions=('lev', 'bnds'))
+    dataset.createVariable('p0', np.float64, dimensions=())
+    dataset.createVariable('ps', np.float64,
+                           dimensions=('time', 'lat', 'lon'))
+    dataset.variables['a'][:] = [2.0, 1.0]  # Wrong order intended
+    dataset.variables['a'].bounds = 'a_bnds'
+    dataset.variables['a_bnds'][:] = [[0.0, 1.5], [1.5, 3.0]]
+    dataset.variables['b'][:] = [1.0, 0.0]  # Wrong order intended
+    dataset.variables['b'].bounds = 'b_bnds'
+    dataset.variables['b_bnds'][:] = [[-1.0, 0.5], [0.5, 2.0]]
+    dataset.variables['p0'][:] = 1.0
+    dataset.variables['p0'].units = 'Pa'
+    dataset.variables['ps'][:] = np.arange(1 * 3 * 4).reshape(1, 3, 4)
+    dataset.variables['ps'].standard_name = 'surface_air_pressure'
+    dataset.variables['ps'].units = 'Pa'
+
+    # Cl variable
+    dataset.createVariable('cl', np.float32,
+                           dimensions=('time', 'lev', 'lat', 'lon'))
+    dataset.variables['cl'][:] = np.full((1, 2, 3, 4), 0.0, dtype=np.float32)
+    dataset.variables['cl'].standard_name = (
+        'cloud_area_fraction_in_atmosphere_layer')
+    dataset.variables['cl'].units = '%'
+
+    dataset.close()
+    return nc_path
+
+
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2', 'Amon', 'cl')
+    assert fix == [Cl(None)]
+
+
+AIR_PRESSURE_POINTS = np.array([[[[1.0, 1.0, 1.0, 1.0],
+                                  [1.0, 1.0, 1.0, 1.0],
+                                  [1.0, 1.0, 1.0, 1.0]],
+                                 [[2.0, 3.0, 4.0, 5.0],
+                                  [6.0, 7.0, 8.0, 9.0],
+                                  [10.0, 11.0, 12.0, 13.0]]]])
+AIR_PRESSURE_BOUNDS = np.array([[[[[0.0, 1.5],
+                                   [-1.0, 2.0],
+                                   [-2.0, 2.5],
+                                   [-3.0, 3.0]],
+                                  [[-4.0, 3.5],
+                                   [-5.0, 4.0],
+                                   [-6.0, 4.5],
+                                   [-7.0, 5.0]],
+                                  [[-8.0, 5.5],
+                                   [-9.0, 6.0],
+                                   [-10.0, 6.5],
+                                   [-11.0, 7.0]]],
+                                 [[[1.5, 3.0],
+                                   [2.0, 5.0],
+                                   [2.5, 7.0],
+                                   [3.0, 9.0]],
+                                  [[3.5, 11.0],
+                                   [4.0, 13.0],
+                                   [4.5, 15.0],
+                                   [5.0, 17.0]],
+                                  [[5.5, 19.0],
+                                   [6.0, 21.0],
+                                   [6.5, 23.0],
+                                   [7.0, 25.0]]]]])
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2.Fix.get_fixed_filepath',
+    autospec=True)
+def test_cl_fix_file(mock_get_filepath, cl_file, tmp_path):
+    """Test ``fix_file`` for ``cl``."""
+    cubes = iris.load(cl_file)
+
+    # Raw cubes
+    assert len(cubes) == 5
+    var_names = [cube.var_name for cube in cubes]
+    assert 'cl' in var_names
+    assert 'a' in var_names
+    assert 'b' in var_names
+    assert 'p0' in var_names
+    assert 'ps' in var_names
+
+    # Raw cl cube
+    cl_cube = cubes.extract_strict('cloud_area_fraction_in_atmosphere_layer')
+    assert not cl_cube.coords('air_pressure')
+
+    # Apply fix
+    mock_get_filepath.return_value = os.path.join(tmp_path,
+                                                  'fixed_cesm2_cl.nc')
+    fix = Cl(None)
+    fixed_file = fix.fix_file(cl_file, tmp_path)
+    mock_get_filepath.assert_called_once_with(tmp_path, cl_file)
+    fixed_cubes = iris.load(fixed_file)
+    assert len(fixed_cubes) == 2
+    var_names = [cube.var_name for cube in fixed_cubes]
+    assert 'cl' in var_names
+    assert 'ps' in var_names
+    fixed_cl_cube = fixed_cubes.extract_strict(
+        'cloud_area_fraction_in_atmosphere_layer')
+    fixed_air_pressure_coord = fixed_cl_cube.coord('air_pressure')
+    assert fixed_air_pressure_coord.points is not None
+    assert fixed_air_pressure_coord.bounds is not None
+    np.testing.assert_allclose(fixed_air_pressure_coord.points,
+                               AIR_PRESSURE_POINTS)
+    np.testing.assert_allclose(fixed_air_pressure_coord.bounds,
+                               AIR_PRESSURE_BOUNDS)
+
+
+def test_get_cli_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2', 'Amon', 'cli')
+    assert fix == [Cli(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2.Cl.fix_metadata',
+    autospec=True)
+def test_cli_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``cli``."""
+    fix = Cli(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')
+
+
+def test_get_clw_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2', 'Amon', 'clw')
+    assert fix == [Clw(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2.Cl.fix_metadata',
+    autospec=True)
+def test_clw_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``clw``."""
+    fix = Clw(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')
+
+
+@pytest.fixture
 def tas_cubes():
+    """Cubes to test fixes for ``tas``."""
     ta_cube = iris.cube.Cube([1.0], var_name='ta')
     tas_cube = iris.cube.Cube([3.0], var_name='tas')
     return iris.cube.CubeList([ta_cube, tas_cube])
 
 
 def test_get_tas_fix():
+    """Test getting of fix."""
     fix = Fix.get_fixes('CMIP6', 'CESM2', 'Amon', 'tas')
     assert fix == [Tas(None)]
 
 
 def test_tas_fix_metadata(tas_cubes):
+    """Test ``fix_metadata`` for ``tas``."""
     for cube in tas_cubes:
         with pytest.raises(iris.exceptions.CoordinateNotFoundError):
             cube.coord('height')

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2_fv2.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2_fv2.py
@@ -1,0 +1,69 @@
+"""Tests for the fixes of CESM2-FV2."""
+import unittest
+
+from esmvalcore.cmor._fixes.cmip6.cesm2_fv2 import Cl, Cli, Clw, Tas
+from esmvalcore.cmor.fix import Fix
+
+
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-FV2', 'Amon', 'cl')
+    assert fix == [Cl(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2_fv2.BaseCl.fix_metadata',
+    autospec=True)
+def test_cl_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``cl``."""
+    fix = Cl(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')
+
+
+def test_get_cli_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-FV2', 'Amon', 'cl')
+    assert fix == [Cl(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2_fv2.Cl.fix_metadata',
+    autospec=True)
+def test_cli_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``cli``."""
+    fix = Cli(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')
+
+
+def test_get_clw_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-FV2', 'Amon', 'clw')
+    assert fix == [Clw(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2_fv2.Cl.fix_metadata',
+    autospec=True)
+def test_clw_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``clw``."""
+    fix = Clw(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')
+
+
+def test_get_tas_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-FV2', 'Amon', 'tas')
+    assert fix == [Tas(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2_fv2.BaseTas.fix_metadata',
+    autospec=True)
+def test_tas_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``tas``."""
+    fix = Tas(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm.py
@@ -1,25 +1,132 @@
 """Tests for the fixes of CESM2-WACCM."""
+import os
+import unittest
+
 import iris
+import numpy as np
 import pytest
 from cf_units import Unit
+from netCDF4 import Dataset
 
-from esmvalcore.cmor._fixes.cmip6.cesm2_waccm import Tas
+from esmvalcore.cmor._fixes.cmip6.cesm2_waccm import Cl, Cli, Clw, Tas
 from esmvalcore.cmor.fix import Fix
 
 
 @pytest.fixture
+def cl_file(tmp_path):
+    """Create netcdf file with similar issues as ``cl``."""
+    nc_path = os.path.join(tmp_path, 'cesm2_waccm_cl.nc')
+    dataset = Dataset(nc_path, mode='w')
+    dataset.createDimension('lev', size=2)
+    dataset.createDimension('bnds', size=2)
+
+    # Dimensional variables
+    dataset.createVariable('lev', np.float64, dimensions=('lev',))
+    dataset.createVariable('lev_bnds', np.float64, dimensions=('lev', 'bnds'))
+    dataset.variables['lev'][:] = [1.0, 2.0]
+    dataset.variables['lev'].bounds = 'lev_bnds'
+    dataset.variables['lev'].units = '1'
+    dataset.variables['lev_bnds'][:] = [[0.5, 1.5], [1.5, 3.0]]
+    dataset.variables['lev_bnds'].standard_name = (
+        'atmosphere_hybrid_sigma_pressure_coordinate')
+    dataset.variables['lev_bnds'].units = '1'
+    dataset.variables['lev_bnds'].formula_terms = (
+        'p0: p0 a: a_bnds b: b_bnds ps: ps')
+
+    # Coordinates for derivation of pressure coordinate
+    dataset.createVariable('a', np.float64, dimensions=('lev',))
+    dataset.createVariable('a_bnds', np.float64, dimensions=('lev', 'bnds'))
+    dataset.createVariable('b', np.float64, dimensions=('lev',))
+    dataset.createVariable('b_bnds', np.float64, dimensions=('lev', 'bnds'))
+    dataset.variables['a'][:] = [2.0, 1.0]
+    dataset.variables['a'].bounds = 'a_bnds'
+    dataset.variables['a_bnds'][:] = [[1.5, 3.0], [0.0, 1.5]]
+    dataset.variables['b'][:] = [1.0, 0.0]
+    dataset.variables['b'].bounds = 'b_bnds'
+    dataset.variables['b_bnds'][:] = [[0.5, 2.0], [-1.0, 0.5]]
+
+    dataset.close()
+    return nc_path
+
+
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-WACCM', 'Amon', 'cl')
+    assert fix == [Cl(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2.Fix.get_fixed_filepath',
+    autospec=True)
+def test_cl_fix_file(mock_get_filepath, cl_file, tmp_path):
+    """Test ``fix_file`` for ``cl``."""
+    mock_get_filepath.return_value = os.path.join(tmp_path,
+                                                  'fixed_cesm2_waccm_cl.nc')
+    fix = Cl(None)
+    fixed_file = fix.fix_file(cl_file, tmp_path)
+    mock_get_filepath.assert_called_once_with(tmp_path, cl_file)
+    fixed_dataset = Dataset(fixed_file, mode='r')
+    assert fixed_dataset.variables['lev'].standard_name == (
+        'atmosphere_hybrid_sigma_pressure_coordinate')
+    assert fixed_dataset.variables['lev'].formula_terms == (
+        'p0: p0 a: a b: b ps: ps')
+    assert fixed_dataset.variables['lev'].units == '1'
+    np.testing.assert_allclose(fixed_dataset.variables['a'][:], [1.0, 2.0])
+    np.testing.assert_allclose(fixed_dataset.variables['b'][:], [0.0, 1.0])
+    np.testing.assert_allclose(fixed_dataset.variables['a_bnds'][:],
+                               [[0.0, 1.5], [1.5, 3.0]])
+    np.testing.assert_allclose(fixed_dataset.variables['b_bnds'][:],
+                               [[-1.0, 0.5], [0.5, 2.0]])
+
+
+def test_get_cli_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-WACCM', 'Amon', 'cli')
+    assert fix == [Cli(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2_waccm.Cl.fix_metadata',
+    autospec=True)
+def test_cli_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``cli``."""
+    fix = Cli(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')
+
+
+def test_get_clw_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-WACCM', 'Amon', 'clw')
+    assert fix == [Clw(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip6.cesm2_waccm.Cl.fix_metadata',
+    autospec=True)
+def test_clw_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``clw``."""
+    fix = Clw(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')
+
+
+@pytest.fixture
 def tas_cubes():
+    """Cubes to test fixes for ``tas``."""
     ta_cube = iris.cube.Cube([1.0], var_name='ta')
     tas_cube = iris.cube.Cube([3.0], var_name='tas')
     return iris.cube.CubeList([ta_cube, tas_cube])
 
 
 def test_get_tas_fix():
+    """Test getting of fix."""
     fix = Fix.get_fixes('CMIP6', 'CESM2-WACCM', 'Amon', 'tas')
     assert fix == [Tas(None)]
 
 
 def test_tas_fix_metadata(tas_cubes):
+    """Test ``fix_metadata`` for ``tas``."""
     for cube in tas_cubes:
         with pytest.raises(iris.exceptions.CoordinateNotFoundError):
             cube.coord('height')


### PR DESCRIPTION
This PR adds several fixes for `cl`, `cli` and `clw` for the CESM2 models.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Related to #538, #539. (Note: Automatic closing of these issues is not desired; they should be closed when the issue is reported to the modelers).
