### PR TITLE
Added fix for hur of MIROC5

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/miroc5.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc5.py
@@ -130,6 +130,10 @@ class Tas(Fix):
         return round_coordinates(cubes)
 
 
+class Hur(Tas):
+    """Fixes for hur."""
+
+
 class Tos(Fix):
     """Fixes for tos."""
 

--- a/tests/integration/cmor/_fixes/cmip5/test_miroc5.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_miroc5.py
@@ -5,8 +5,24 @@ import iris
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip5.miroc5 import Sftof, Tas
+from esmvalcore.cmor._fixes.cmip5.miroc5 import Hur, Sftof, Tas
 from esmvalcore.cmor.fix import Fix
+
+
+def test_get_hur_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP5', 'MIROC5', 'Amon', 'hur')
+    assert fix == [Hur(None)]
+
+
+@unittest.mock.patch(
+    'esmvalcore.cmor._fixes.cmip5.miroc5.Tas.fix_metadata',
+    autospec=True)
+def test_hur_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``hur``."""
+    fix = Hur(None)
+    fix.fix_metadata('cubes')
+    mock_base_fix_metadata.assert_called_once_with(fix, 'cubes')
 
 
 class TestSftof(unittest.TestCase):


### PR DESCRIPTION
This PR adds a fix for `hur` of MIROC5.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Note: No dataset issue open since this refers to a CMIP5 model.