### PR TITLE
Cast dtype float32 to output from zonal and meridional area preprocessors

### DIFF
--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -114,7 +114,9 @@ def zonal_statistics(cube, operator):
     """
     if cube.coord('longitude').points.ndim < 2:
         operation = get_iris_analysis_operation(operator)
-        return cube.collapsed('longitude', operation)
+        cube = cube.collapsed('longitude', operation)
+        cube.data = cube.core_data().astype(np.float32, casting='same_kind')
+        return cube
     else:
         msg = (f"Zonal statistics on irregular grids not yet implemnted")
         raise ValueError(msg)
@@ -146,7 +148,9 @@ def meridional_statistics(cube, operator):
     """
     if cube.coord('latitude').points.ndim < 2:
         operation = get_iris_analysis_operation(operator)
-        return cube.collapsed('latitude', operation)
+        cube = cube.collapsed('latitude', operation)
+        cube.data = cube.core_data().astype(np.float32, casting='same_kind')
+        return cube
     else:
         msg = (f"Meridional statistics on irregular grids not yet implemnted")
         raise ValueError(msg)


### PR DESCRIPTION
Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes https://github.com/ESMValGroup/ESMValCore/issues/577
