### PR TITLE
Added derivation script for co2s

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
@@ -5,29 +5,6 @@ from dask import array as da
 from ..fix import Fix
 
 
-class Co2(Fix):
-    """Fixes for co2 variable."""
-
-    def fix_data(self, cube):
-        """Fix data.
-
-        Fixes discrepancy between declared units and real units
-
-        Parameters
-        ----------
-        cube: iris.cube.Cube
-
-        Returns
-        -------
-        iris.cube.Cube
-
-        """
-        metadata = cube.metadata
-        cube *= 28.966 / 44.0
-        cube.metadata = metadata
-        return cube
-
-
 class Gpp(Fix):
     """Fixes for gpp variable."""
 

--- a/esmvalcore/cmor/tables/custom/CMOR_co2s.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_co2s.dat
@@ -1,0 +1,20 @@
+SOURCE: CMIP5
+!============
+variable_entry:    co2s
+!============
+modeling_realm:    atmos
+!----------------------------------
+! Variable attributes:
+!----------------------------------
+standard_name:     mole_fraction_of_carbon_dioxide_in_air
+units:             mol mol-1
+cell_methods:      time: mean
+cell_measures:     area: areacella
+long_name:         Mole Fraction of CO2 at surface level
+!----------------------------------
+! Additional variable information:
+!----------------------------------
+dimensions:        longitude latitude time
+type:              real
+!----------------------------------
+!

--- a/esmvalcore/preprocessor/_derive/co2s.py
+++ b/esmvalcore/preprocessor/_derive/co2s.py
@@ -1,0 +1,39 @@
+"""Derivation of variable ``co2s``."""
+import dask.array as da
+import iris
+
+from ._baseclass import DerivedVariableBase
+
+
+class DerivedVariable(DerivedVariableBase):
+    """Derivation of variable ``co2s``."""
+
+    @staticmethod
+    def required(project):
+        """Declare the variables needed for derivation."""
+        required = [{'short_name': 'co2'}]
+        return required
+
+    @staticmethod
+    def calculate(cubes):
+        """Compute mole fraction of CO2 at surface."""
+        cube = cubes.extract_strict(
+            iris.Constraint(name='mole_fraction_of_carbon_dioxide_in_air'))
+        mask = da.ma.getmaskarray(cube.core_data())
+        if not mask.any():
+            cube = cube[:, 0, :, :]
+        else:
+            numerical_mask = da.where(mask, -1.0, 1.0)
+            indices_first_positive = da.argmax(numerical_mask, axis=1)
+            indices = da.meshgrid(
+                da.arange(cube.shape[0]),
+                da.arange(cube.shape[2]),
+                da.arange(cube.shape[3]),
+                indexing='ij',
+            )
+            indices.insert(1, indices_first_positive)
+            surface_data = cube.data[tuple(indices)]
+            cube = cube[:, 0, :, :]
+            cube.data = surface_data
+        cube.convert_units('mol mol-1')
+        return cube

--- a/tests/integration/cmor/_fixes/cmip5/test_cesm1_bgc.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_cesm1_bgc.py
@@ -2,41 +2,22 @@
 import unittest
 
 import numpy as np
-from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Co2, Gpp, Nbp
+from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Gpp, Nbp
 from esmvalcore.cmor.fix import Fix
-
-
-class TestCo2(unittest.TestCase):
-    """Tests for co2."""
-    def setUp(self):
-        """Prepare tests."""
-        self.cube = Cube([1.0], var_name='co2', units='J')
-        self.fix = Co2(None)
-
-    def test_get(self):
-        """Test fix get"""
-        self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'co2'), [Co2(None)])
-
-    def test_fix_data(self):
-        """Test fix to set units correctly."""
-        cube = self.fix.fix_data(self.cube)
-        self.assertEqual(cube.data[0], 28.966 / 44.0)
-        self.assertEqual(cube.units, Unit('J'))
 
 
 class TestGpp(unittest.TestCase):
     """Tests for gpp."""
+
     def setUp(self):
         """Prepare tests."""
         self.cube = Cube([1.0, 1.0e33, 2.0])
         self.fix = Gpp(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'gpp'), [Gpp(None)])
 
@@ -52,12 +33,13 @@ class TestGpp(unittest.TestCase):
 
 class TestNbp(TestGpp):
     """Tests for nbp."""
+
     def setUp(self):
         """Prepare tests."""
         self.cube = Cube([1.0, 1.0e33, 2.0])
         self.fix = Nbp(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'nbp'), [Nbp(None)])

--- a/tests/integration/cmor/_fixes/test_fix.py
+++ b/tests/integration/cmor/_fixes/test_fix.py
@@ -34,9 +34,9 @@ class TestFix(unittest.TestCase):
                              [Ch4(None)])
 
     def test_get_fixes_with_generic(self):
-        from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Co2
+        from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Gpp
         self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'co2'), [Co2(None)])
+            Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'gpp'), [Gpp(None)])
 
     def test_get_fix_no_project(self):
         with pytest.raises(KeyError):

--- a/tests/unit/preprocessor/_derive/test_co2s.py
+++ b/tests/unit/preprocessor/_derive/test_co2s.py
@@ -1,0 +1,95 @@
+"""Test derivation of ``co2s``."""
+import dask.array as da
+import iris
+import numpy as np
+import pytest
+
+import esmvalcore.preprocessor._derive.co2s as co2s
+
+
+def get_coord_spec():
+    """Coordinate specs for cubes."""
+    time_coord = iris.coords.DimCoord([0], var_name='time',
+                                      standard_name='time',
+                                      units='days since 0000-01-01 00:00:00')
+    plev_coord = iris.coords.DimCoord([123456.0, 50000.0, 1000.0],
+                                      var_name='plev',
+                                      standard_name='air_pressure', units='Pa')
+    lat_coord = iris.coords.DimCoord([0.0, 1.0], var_name='latitude',
+                                     standard_name='latitude', units='degrees')
+    lon_coord = iris.coords.DimCoord([0.0, 1.0], var_name='longitude',
+                                     standard_name='longitude',
+                                     units='degrees')
+    coord_spec = [
+        (time_coord, 0),
+        (plev_coord, 1),
+        (lat_coord, 2),
+        (lon_coord, 3),
+    ]
+    return coord_spec
+
+
+@pytest.fixture
+def masked_cubes():
+    """Masked CO2 cube."""
+    coord_spec = get_coord_spec()
+    co2_data = da.ma.masked_less([[[[170.0, -1.0],
+                                    [-1.0, -1.0]],
+                                   [[150.0, 100.0],
+                                    [80.0, -1.0]],
+                                   [[100.0, 50.0],
+                                    [30.0, 10.0]]]], 0.0)
+    cube = iris.cube.Cube(
+        co2_data,
+        var_name='co2',
+        standard_name='mole_fraction_of_carbon_dioxide_in_air',
+        units='1',
+        dim_coords_and_dims=coord_spec,
+    )
+    return iris.cube.CubeList([cube])
+
+
+@pytest.fixture
+def unmasked_cubes():
+    """Unmasked CO2 cube."""
+    coord_spec = get_coord_spec()
+    co2_data = da.array([[[[200.0, 100.0],
+                           [80.0, 9.0]],
+                          [[150.0, 80.0],
+                           [70.0, 5.0]],
+                          [[100.0, 50.0],
+                           [30.0, 1.0]]]])
+    cube = iris.cube.Cube(
+        co2_data,
+        var_name='co2',
+        standard_name='mole_fraction_of_carbon_dioxide_in_air',
+        units='1e-1',
+        dim_coords_and_dims=coord_spec,
+    )
+    return iris.cube.CubeList([cube])
+
+
+def test_co2_calculate_masked_cubes(masked_cubes):
+    """Test function ``calculate`` with masked cube."""
+    derived_var = co2s.DerivedVariable()
+    out_cube = derived_var.calculate(masked_cubes)
+    assert not np.ma.is_masked(out_cube.data)
+    np.testing.assert_allclose(out_cube.data,
+                               [[[170.0, 100.0],
+                                 [80.0, 10.0]]])
+    assert out_cube.units == 'mol mol-1'
+    np.testing.assert_allclose(out_cube.coord('air_pressure').points,
+                               123456.0)
+
+
+def test_co2_calculate_unmasked_cubes(unmasked_cubes):
+    """Test function ``calculate`` with unmasked cube."""
+    derived_var = co2s.DerivedVariable()
+    out_cube = derived_var.calculate(unmasked_cubes)
+    assert not np.ma.is_masked(out_cube.data)
+    np.testing.assert_allclose(out_cube.data,
+                               [[[20.0, 10.0],
+                                 [8.0, 0.9]]])
+    assert out_cube.units == 'mol mol-1'
+    np.testing.assert_allclose(out_cube.coord('air_pressure').points,
+                               123456.0)


### PR DESCRIPTION
This PR adds the derivation script for `co2s` (CO2 mole fraction at surface level). It can be tested with this sample recipe:

```yaml
# recipe_test.yml
---
documentation:

  description: |
    Test.

  authors:
    - schlund_manuel

  maintainer:
    - schlund_manuel

  projects:
    - crescendo


DATASET_ANCHOR: &datasets
  - {dataset: BNU-ESM}
  - {dataset: CanESM2}
  - {dataset: CESM1-BGC}
  - {dataset: GFDL-ESM2G}
  - {dataset: GFDL-ESM2M}
  - {dataset: MIROC-ESM}
  - {dataset: NorESM1-ME}


diagnostics:

  test:
    variables:
      co2s:
        project: CMIP5
        exp: esmHistorical
        ensemble: r1i1p1
        mip: Amon
        additional_datasets: *datasets
        start_year: 1950
        end_year: 1955
        derive: true
    scripts:
      null
```

Please note that using `core_data()` instead of `data` [here](https://github.com/ESMValGroup/ESMValCore/blob/dede748b065741e76590982ca0e1c5e5b94a7a40/esmvalcore/preprocessor/_derive/co2s.py#L35) results in an `NotImplementedError: Don't yet support nd fancy indexing` of `dask`.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #586.
