### PR TITLE
Adapted custom co2s table to match CMIP6 version

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_co2s.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_co2s.dat
@@ -7,10 +7,11 @@ modeling_realm:    atmos
 ! Variable attributes:
 !----------------------------------
 standard_name:     mole_fraction_of_carbon_dioxide_in_air
-units:             mol mol-1
-cell_methods:      time: mean
+units:             1e-06
+cell_methods:      area: time: mean
 cell_measures:     area: areacella
-long_name:         Mole Fraction of CO2 at surface level
+long_name:         Atmosphere CO2
+comment:           As co2, but only at the surface
 !----------------------------------
 ! Additional variable information:
 !----------------------------------

--- a/esmvalcore/preprocessor/_derive/co2s.py
+++ b/esmvalcore/preprocessor/_derive/co2s.py
@@ -11,7 +11,7 @@ class DerivedVariable(DerivedVariableBase):
     @staticmethod
     def required(project):
         """Declare the variables needed for derivation."""
-        required = [{'short_name': 'co2', 'mip': 'Amon'}]
+        required = [{'short_name': 'co2'}]
         return required
 
     @staticmethod

--- a/esmvalcore/preprocessor/_derive/co2s.py
+++ b/esmvalcore/preprocessor/_derive/co2s.py
@@ -11,7 +11,7 @@ class DerivedVariable(DerivedVariableBase):
     @staticmethod
     def required(project):
         """Declare the variables needed for derivation."""
-        required = [{'short_name': 'co2'}]
+        required = [{'short_name': 'co2', 'mip': 'Amon'}]
         return required
 
     @staticmethod
@@ -35,5 +35,5 @@ class DerivedVariable(DerivedVariableBase):
             surface_data = cube.data[tuple(indices)]
             cube = cube[:, 0, :, :]
             cube.data = surface_data
-        cube.convert_units('mol mol-1')
+        cube.convert_units('1e-6')
         return cube

--- a/tests/unit/preprocessor/_derive/test_co2s.py
+++ b/tests/unit/preprocessor/_derive/test_co2s.py
@@ -63,7 +63,7 @@ def unmasked_cubes():
         co2_data,
         var_name='co2',
         standard_name='mole_fraction_of_carbon_dioxide_in_air',
-        units='1e-7',
+        units='1e-8',
         dim_coords_and_dims=coord_spec,
     )
     return iris.cube.CubeList([cube])
@@ -88,8 +88,8 @@ def test_co2_calculate_unmasked_cubes(unmasked_cubes):
     out_cube = derived_var.calculate(unmasked_cubes)
     assert not np.ma.is_masked(out_cube.data)
     np.testing.assert_allclose(out_cube.data,
-                               [[[20.0, 10.0],
-                                 [8.0, 0.9]]])
+                               [[[2.0, 1.0],
+                                 [0.8, 0.09]]])
     assert out_cube.units == '1e-6'
     np.testing.assert_allclose(out_cube.coord('air_pressure').points,
                                123456.0)

--- a/tests/unit/preprocessor/_derive/test_co2s.py
+++ b/tests/unit/preprocessor/_derive/test_co2s.py
@@ -43,7 +43,7 @@ def masked_cubes():
         co2_data,
         var_name='co2',
         standard_name='mole_fraction_of_carbon_dioxide_in_air',
-        units='1',
+        units='1e-6',
         dim_coords_and_dims=coord_spec,
     )
     return iris.cube.CubeList([cube])
@@ -63,7 +63,7 @@ def unmasked_cubes():
         co2_data,
         var_name='co2',
         standard_name='mole_fraction_of_carbon_dioxide_in_air',
-        units='1e-1',
+        units='1e-7',
         dim_coords_and_dims=coord_spec,
     )
     return iris.cube.CubeList([cube])
@@ -77,7 +77,7 @@ def test_co2_calculate_masked_cubes(masked_cubes):
     np.testing.assert_allclose(out_cube.data,
                                [[[170.0, 100.0],
                                  [80.0, 10.0]]])
-    assert out_cube.units == 'mol mol-1'
+    assert out_cube.units == '1e-6'
     np.testing.assert_allclose(out_cube.coord('air_pressure').points,
                                123456.0)
 
@@ -90,6 +90,6 @@ def test_co2_calculate_unmasked_cubes(unmasked_cubes):
     np.testing.assert_allclose(out_cube.data,
                                [[[20.0, 10.0],
                                  [8.0, 0.9]]])
-    assert out_cube.units == 'mol mol-1'
+    assert out_cube.units == '1e-6'
     np.testing.assert_allclose(out_cube.coord('air_pressure').points,
                                123456.0)


### PR DESCRIPTION
This PR fixes the custom `co2s` table to match its CMIP6 version as discussed in #587.

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below