### PR TITLE
Added preprocessor to extract amplitude of cycles

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1239,7 +1239,7 @@ The ``_cycles.py`` module contains the following preprocessor functions:
 ``amplitude``
 -------------
 
-This functions extracts the peak-to-peak amplitude (maximum value minus minimum
+This function extracts the peak-to-peak amplitude (maximum value minus minimum
 value) of a field aggregated over specified coordinates. Its only argument is
 ``coords``, which can either be a single coordinate (given as :obj:`str`) or
 multiple coordinates (given as :obj:`list` of :obj:`str`). Usually, these

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -18,6 +18,7 @@ following the default order in which they are applied:
 * :ref:`Time operations`
 * :ref:`Area operations`
 * :ref:`Volume operations`
+* :ref:`Cycles`
 * :ref:`Detrend`
 * :ref:`Unit conversion`
 * :ref:`Other`
@@ -1223,6 +1224,34 @@ Note that this function uses the expensive ``interpolate`` method from
 ``Iris.analysis.trajectory``, but it may be necessary for irregular grids.
 
 See also :func:`esmvalcore.preprocessor.extract_trajectory`.
+
+
+.. _cycles:
+
+Cycles
+======
+
+The ``_cycles.py`` module contains the following preprocessor functions:
+
+* ``amplitude``: Extract the peak-to-peak amplitude of a cycle aggregated over
+  specified coordinates.
+
+``amplitude``
+-------------
+
+This functions extracts the peak-to-peak amplitude (maximum value minus minimum
+value) of a field aggregated over specified coordinates. Its only argument is
+``coords``, which can either be a single coordinate (given as :obj:`str`) or
+multiple coordinates (given as :obj:`list` of :obj:`str`). Usually, these
+coordinates refer to temporal `categorised coordinates
+<https://scitools.org.uk/iris/docs/latest/iris/iris/coord_categorisation.html>`_
+like `year`, `month`, `day of year`, etc. For example, to extract the amplitude
+of the annual cycle for every single year in the data, use ``coords: year``; to
+extract the amplitude of the diurnal cycle for every single day in the data,
+use ``coords: [year, day_of_year]``.
+
+See also :func:`esmvalcore.preprocessor.amplitude`.
+
 
 .. _detrend:
 

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -9,7 +9,8 @@ from iris.cube import Cube
 from .._provenance import TrackedFile
 from .._task import BaseTask
 from ._area import (area_statistics, extract_named_regions, extract_region,
-                    extract_shape, zonal_statistics, meridional_statistics)
+                    extract_shape, meridional_statistics, zonal_statistics)
+from ._cycles import amplitude
 from ._derive import derive
 from ._detrend import detrend
 from ._download import download
@@ -22,11 +23,11 @@ from ._multimodel import multi_model_statistics
 from ._other import clip
 from ._reformat import (cmor_check_data, cmor_check_metadata, fix_data,
                         fix_file, fix_metadata)
-from ._regrid import extract_levels, regrid, extract_point
+from ._regrid import extract_levels, extract_point, regrid
 from ._time import (annual_statistics, anomalies, climate_statistics,
                     daily_statistics, decadal_statistics, extract_month,
                     extract_season, extract_time, monthly_statistics,
-                    regrid_time, seasonal_statistics, timeseries_filter,)
+                    regrid_time, seasonal_statistics, timeseries_filter)
 from ._units import convert_units
 from ._volume import (depth_integration, extract_trajectory, extract_transect,
                       extract_volume, volume_statistics)
@@ -93,6 +94,7 @@ __all__ = [
     # Time operations
     # 'annual_cycle': annual_cycle,
     # 'diurnal_cycle': diurnal_cycle,
+    'amplitude',
     'zonal_statistics',
     'meridional_statistics',
     'daily_statistics',

--- a/esmvalcore/preprocessor/_cycles.py
+++ b/esmvalcore/preprocessor/_cycles.py
@@ -1,0 +1,68 @@
+"""Operations related to cycles (annual cycle, diurnal cycle, etc.)."""
+import logging
+
+import iris
+import iris.coord_categorisation
+
+logger = logging.getLogger(__name__)
+
+
+def amplitude(cube, coords):
+    """Calculate amplitude of cycles by aggregating over coordinates.
+
+    Note
+    ----
+    The amplitude is calculated as `peak-to-peak` amplitude (difference
+    between maximum and minimum value of the signal). Other amplitude types
+    are currently not supported.
+
+    Parameters
+    ----------
+    cube : iris.cube.Cube
+        Input data.
+    coords : str or list of str
+        Coordinates over which is aggregated. For example, use ``'year'`` to
+        extract the annual cycle amplitude for each year in the data or
+        ``['day_of_year', 'year']`` to extract the diurnal cycle amplitude for
+        each individual day in the data. If the coordinates are not found in
+        ``cube``, try to add it via :mod:`iris.coord_categorisation` (this only
+        works for temporal coordinates).
+
+    Returns
+    -------
+    iris.cube.Cube
+        Amplitudes.
+
+    Raises
+    ------
+    iris.exceptions.CoordinateNotFoundError
+        A coordinate is not found in ``cube`` and cannot be added via
+        :mod:`iris.coord_categorisation`.
+
+    """
+    if isinstance(coords, str):
+        coords = [coords]
+
+    # Add coordinate if necessary
+    for coord_name in coords:
+        if cube.coords(coord_name):
+            continue
+        logger.debug("Trying to add coordinate '%s' to cube via iris."
+                     "coord_categorisation", coord_name)
+        if hasattr(iris.coord_categorisation, f'add_{coord_name}'):
+            getattr(iris.coord_categorisation, f'add_{coord_name}')(cube,
+                                                                    'time')
+            logger.debug("Added temporal coordinate '%s'", coord_name)
+        else:
+            raise iris.exceptions.CoordinateNotFoundError(
+                f"Coordinate '{coord_name}' is not a coordinate of cube "
+                f"{cube.summary(shorten=True)} and cannot be added via "
+                f"iris.coord_categorisation")
+
+    # Calculate amplitude
+    max_cube = cube.aggregated_by(coords, iris.analysis.MAX)
+    min_cube = cube.aggregated_by(coords, iris.analysis.MIN)
+    amplitude_cube = max_cube - min_cube
+    amplitude_cube.metadata = cube.metadata
+
+    return amplitude_cube

--- a/esmvalcore/preprocessor/_cycles.py
+++ b/esmvalcore/preprocessor/_cycles.py
@@ -25,8 +25,11 @@ def amplitude(cube, coords):
         extract the annual cycle amplitude for each year in the data or
         ``['day_of_year', 'year']`` to extract the diurnal cycle amplitude for
         each individual day in the data. If the coordinates are not found in
-        ``cube``, try to add it via :mod:`iris.coord_categorisation` (this only
-        works for temporal coordinates).
+        ``cube``, try to add it via :mod:`iris.coord_categorisation` (at the
+        moment, this only works for the temporal coordinates ``day_of_month``,
+        ``day_of_year``, ``hour``, ``month``, ``month_fullname``,
+        ``month_number``, ``season``, ``season_number``, ``season_year``,
+        ``weekday``, ``weekday_fullname``, ``weekday_number`` or ``year``.
 
     Returns
     -------

--- a/tests/unit/preprocessor/_cycles/test_cycles.py
+++ b/tests/unit/preprocessor/_cycles/test_cycles.py
@@ -1,0 +1,114 @@
+"""Unit tests for :mod:`esmvalcore.preprocessor._cycles`."""
+import iris
+import iris.coord_categorisation
+import numpy as np
+import pytest
+from cf_units import Unit
+
+from esmvalcore.preprocessor._cycles import amplitude
+
+
+@pytest.fixture
+def annual_cycle_cube():
+    """Cube including annual cycle."""
+    time_units = Unit('days since 1850-01-01 00:00:00', calendar='noleap')
+    n_times = 3 * 365
+    n_lat = 4
+    time_coord = iris.coords.DimCoord(
+        np.arange(n_times, dtype=np.float64), var_name='time',
+        standard_name='time', long_name='time', units=time_units)
+    time_coord.guess_bounds()
+    lat_coord = iris.coords.DimCoord(
+        np.arange(n_lat, dtype=np.float64) * 10, var_name='lat',
+        standard_name='latitude', long_name='latitude', units='degrees')
+    lat_coord.guess_bounds()
+    new_data = (np.sin(np.arange(n_times) * 2.0 * np.pi / 365.0) *
+                (np.arange(n_times) + 1.0) * 0.005 + 0.005 *
+                np.arange(n_times)).reshape(n_times, 1) * np.arange(n_lat)
+    annual_cycle_cube = iris.cube.Cube(
+        new_data, var_name='tas', standard_name='air_temperature',
+        units='K', dim_coords_and_dims=[(time_coord, 0), (lat_coord, 1)])
+    return annual_cycle_cube
+
+
+def test_amplitude_fail_wrong_coord(annual_cycle_cube):
+    """Test amplitude calculation when wrong coordinate is given."""
+    with pytest.raises(iris.exceptions.CoordinateNotFoundError):
+        amplitude(annual_cycle_cube, ['year', 'invalid_coord'])
+
+
+ANNUAL_CYCLE_AMPLITUDE = [
+    [0.0, 1.79357289, 3.58714578, 5.38071868],
+    [0.0, 4.64430872, 9.28861744, 13.93292616],
+    [0.0, 8.26307683, 16.52615367, 24.7892305],
+]
+
+
+def test_amplitude_annual_cycle_add_year(annual_cycle_cube):
+    """Test amplitude of annual cycle when year is not given in cube."""
+    assert not annual_cycle_cube.coords('year')
+    amplitude_cube = amplitude(annual_cycle_cube, 'year')
+    assert amplitude_cube.shape == (3, 4)
+    assert amplitude_cube.coords('year')
+    np.testing.assert_allclose(amplitude_cube.data, ANNUAL_CYCLE_AMPLITUDE)
+    assert amplitude_cube.metadata == annual_cycle_cube.metadata
+
+
+def test_amplitude_annual_cycle_do_not_add_year(annual_cycle_cube):
+    """Test amplitude of annual cycle when year is given in cube."""
+    assert not annual_cycle_cube.coords('year')
+    iris.coord_categorisation.add_year(annual_cycle_cube, 'time')
+    amplitude_cube = amplitude(annual_cycle_cube, 'year')
+    assert amplitude_cube.shape == (3, 4)
+    assert amplitude_cube.coords('year')
+    np.testing.assert_allclose(amplitude_cube.data, ANNUAL_CYCLE_AMPLITUDE)
+    assert amplitude_cube.metadata == annual_cycle_cube.metadata
+
+
+@pytest.fixture
+def diurnal_cycle_cube():
+    """Cube including diurnal cycle."""
+    time_units = Unit('hours since 1850-01-01 00:00:00', calendar='noleap')
+    n_days = 2 * 365
+    n_times = n_days * 4
+    time_coord = iris.coords.DimCoord(
+        np.arange(n_times, dtype=np.float64) * 6.0, var_name='time',
+        standard_name='time', long_name='time', units=time_units)
+    time_coord.guess_bounds()
+    new_data = np.concatenate((
+        [-2.0, -3.0, 0.0, 1.0] * int(n_days / 2),
+        [-5.0, -1.0, 5.0, 0.0] * int(n_days / 2),
+    ), axis=None)
+    diurnal_cycle_cube = iris.cube.Cube(
+        new_data, var_name='tas', standard_name='air_temperature',
+        units='K', dim_coords_and_dims=[(time_coord, 0)])
+    return diurnal_cycle_cube
+
+
+DIURNAL_CYCLE_AMPLITUDE = [4.0] * 365 + [10.0] * 365
+
+
+def test_amplitude_diurnal_cycle_add_coords(diurnal_cycle_cube):
+    """Test amplitude of diurnal cycle when coords are not given in cube."""
+    assert not diurnal_cycle_cube.coords('day_of_year')
+    assert not diurnal_cycle_cube.coords('year')
+    amplitude_cube = amplitude(diurnal_cycle_cube, ['day_of_year', 'year'])
+    assert amplitude_cube.shape == (730,)
+    assert amplitude_cube.coords('day_of_year')
+    assert amplitude_cube.coords('year')
+    np.testing.assert_allclose(amplitude_cube.data, DIURNAL_CYCLE_AMPLITUDE)
+    assert amplitude_cube.metadata == diurnal_cycle_cube.metadata
+
+
+def test_amplitude_diurnal_cycle_do_not_add_coords(diurnal_cycle_cube):
+    """Test amplitude of diurnal cycle when coords are given in cube."""
+    assert not diurnal_cycle_cube.coords('day_of_year')
+    assert not diurnal_cycle_cube.coords('year')
+    iris.coord_categorisation.add_day_of_year(diurnal_cycle_cube, 'time')
+    iris.coord_categorisation.add_year(diurnal_cycle_cube, 'time')
+    amplitude_cube = amplitude(diurnal_cycle_cube, ['day_of_year', 'year'])
+    assert amplitude_cube.shape == (730,)
+    assert amplitude_cube.coords('day_of_year')
+    assert amplitude_cube.coords('year')
+    np.testing.assert_allclose(amplitude_cube.data, DIURNAL_CYCLE_AMPLITUDE)
+    assert amplitude_cube.metadata == diurnal_cycle_cube.metadata


### PR DESCRIPTION
This PR adds a preprocessor to calculate peak-to-peak amplitude of data aggregated over specified coordinates.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #596.
