### PR TITLE
Add max, min and std operators to multimodel

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -635,13 +635,13 @@ to observational data, these biases have a significantly lower statistical
 impact when using a multi-model ensemble. ESMValTool has the capability of
 computing a number of multi-model statistical measures: using the preprocessor
 module ``multi_model_statistics`` will enable the user to ask for either a
-multi-model ``mean``, ``median``, ```max``, ``min`` and / or ``std`` with a set
+multi-model ``mean``, ``median``, ``max``, ``min`` and / or ``std`` with a set
 of argument parameters passed to ``multi_model_statistics``.
 
-Multimodel statistics in ESMValTool are computed along the time axis, and as
-such, can be computed across a common overlap in time (by specifying ``span:
-overlap`` argument) or across the full length in time of each model (by
-specifying ``span: full`` argument).
+Note that current multimodel statistics in ESMValTool are local (not global),
+and are computed along the time axis. As such, can be computed across a common
+overlap in time (by specifying ``span: overlap`` argument) or across the full
+length in time of each model (by specifying ``span: full`` argument).
 
 Restrictive computation is also available by excluding  any set of models that
 the user will not want to include in the statistics (by setting ``exclude:

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -635,8 +635,8 @@ to observational data, these biases have a significantly lower statistical
 impact when using a multi-model ensemble. ESMValTool has the capability of
 computing a number of multi-model statistical measures: using the preprocessor
 module ``multi_model_statistics`` will enable the user to ask for either a
-multi-model ``mean`` and/or ``median`` with a set of argument parameters passed
-to ``multi_model_statistics``.
+multi-model ``mean``, ``median``, ```max``, ``min`` and / or ``std`` with a set
+of argument parameters passed to ``multi_model_statistics``.
 
 Multimodel statistics in ESMValTool are computed along the time axis, and as
 such, can be computed across a common overlap in time (by specifying ``span:

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -62,6 +62,12 @@ def _compute_statistic(data, statistic_name):
         statistic_function = np.ma.median
     elif statistic_name == 'mean':
         statistic_function = np.ma.mean
+    elif statistic_name == 'std':
+        statistic_function = np.ma.std
+    elif statistic_name == 'max':
+        statistic_function = np.ma.max
+    elif statistic_name == 'min':
+        statistic_function = np.ma.min
     else:
         raise NotImplementedError
 
@@ -326,7 +332,8 @@ def multi_model_statistics(products, span, output_products, statistics):
     output_products: dict
         dictionary of output products.
     statistics: str
-        statistical measure to be computed (mean or median).
+        statistical measure to be computed. Available options: mean, median,
+        max, min, std
     Returns
     -------
     list

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -90,6 +90,29 @@ class Test(tests.Test):
         self.assert_array_equal(stat_mean, expected_mean)
         self.assert_array_equal(stat_median, expected_median)
 
+    def test_compute_std(self):
+        """Test statistic."""
+        data = [self.cube1.data[0], self.cube2.data[0] * 2]
+        stat = _compute_statistic(data, "std")
+        expected = np.ma.ones((3, 2, 2)) * 0.5
+        expected[0, 0, 0] = 0
+        self.assert_array_equal(stat, expected)
+
+    def test_compute_max(self):
+        """Test statistic."""
+        data = [self.cube1.data[0] * 0.5, self.cube2.data[0] * 2]
+        stat = _compute_statistic(data, "max")
+        expected = np.ma.ones((3, 2, 2)) * 2
+        expected[0, 0, 0] = 0.5
+        self.assert_array_equal(stat, expected)
+
+    def test_compute_min(self):
+        """Test statistic."""
+        data = [self.cube1.data[0] * 0.5, self.cube2.data[0] * 2]
+        stat = _compute_statistic(data, "min")
+        expected = np.ma.ones((3, 2, 2)) * 0.5
+        self.assert_array_equal(stat, expected)
+
     def test_put_in_cube(self):
         """Test put in cube."""
         cube_data = np.ma.ones((2, 3, 2, 2))


### PR DESCRIPTION
Added several operators to the multimodel, as requested by @mwjury 

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *
Closes #563