### PR TITLE
Extended fix for cl-like variables of CESM2 models

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2.py
@@ -11,11 +11,42 @@ from ..shared import (add_scalar_depth_coord, add_scalar_height_coord,
 class Cl(Fix):
     """Fixes for ``cl``."""
 
+    def _fix_formula_terms(self, filepath, output_dir):
+        """Fix ``formula_terms`` attribute."""
+        new_path = self.get_fixed_filepath(output_dir, filepath)
+        copyfile(filepath, new_path)
+        dataset = Dataset(new_path, mode='a')
+        dataset.variables['lev'].formula_terms = 'p0: p0 a: a b: b ps: ps'
+        dataset.variables['lev'].standard_name = (
+            'atmosphere_hybrid_sigma_pressure_coordinate')
+        dataset.close()
+        return new_path
+
+    def fix_data(self, cube):
+        """Fix data.
+
+        Fixed ordering of vertical coordinate.
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube to fix.
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        (z_axis,) = cube.coord_dims(cube.coord(axis='Z', dim_coords=True))
+        indices = [slice(None)] * cube.ndim
+        indices[z_axis] = slice(None, None, -1)
+        cube = cube[tuple(indices)]
+        return cube
+
     def fix_file(self, filepath, output_dir):
         """Fix hybrid pressure coordinate.
 
-        Adds missing ``formula_terms`` attribute to file and fix ordering
-        of auxiliary coordinates ``a`` and ``b``.
+        Adds missing ``formula_terms`` attribute to file.
 
         Note
         ----
@@ -37,21 +68,10 @@ class Cl(Fix):
             Path to the fixed file.
 
         """
-        new_path = self.get_fixed_filepath(output_dir, filepath)
-        copyfile(filepath, new_path)
+        new_path = self._fix_formula_terms(filepath, output_dir)
         dataset = Dataset(new_path, mode='a')
-
-        # Fix hybrid sigma pressure coordinate
-        dataset.variables['lev'].formula_terms = 'p0: p0 a: a b: b ps: ps'
-        dataset.variables['lev'].standard_name = (
-            'atmosphere_hybrid_sigma_pressure_coordinate')
-        dataset.variables['lev'].units = '1'
-
-        # Fix auxiliary coordinates
-        dataset.variables['a'][:] = dataset.variables['a'][::-1]
-        dataset.variables['b'][:] = dataset.variables['b'][::-1]
-
-        # Save
+        dataset.variables['a_bnds'][:] = dataset.variables['a_bnds'][::-1, :]
+        dataset.variables['b_bnds'][:] = dataset.variables['b_bnds'][::-1, :]
         dataset.close()
         return new_path
 

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm.py
@@ -11,8 +11,7 @@ class Cl(BaseCl):
     def fix_file(self, filepath, output_dir):
         """Fix hybrid pressure coordinate.
 
-        Adds missing ``formula_terms`` attribute to file and fix ordering
-        of auxiliary coordinates ``a``, ``b``, ``a_bnds`` and ``b_bnds``.
+        Adds missing ``formula_terms`` attribute to file.
 
         Note
         ----
@@ -34,10 +33,10 @@ class Cl(BaseCl):
             Path to the fixed file.
 
         """
-        new_path = super().fix_file(filepath, output_dir)
+        new_path = self._fix_formula_terms(filepath, output_dir)
         dataset = Dataset(new_path, mode='a')
-        dataset.variables['a_bnds'][:] = dataset.variables['a_bnds'][::-1]
-        dataset.variables['b_bnds'][:] = dataset.variables['b_bnds'][::-1]
+        dataset.variables['a_bnds'][:] = dataset.variables['a_bnds'][:, ::-1]
+        dataset.variables['b_bnds'][:] = dataset.variables['b_bnds'][:, ::-1]
         dataset.close()
         return new_path
 

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -9,7 +9,7 @@ import pandas as pd
 from cf_units import Unit
 from scipy.interpolate import interp1d
 
-from esmvalcore.preprocessor._derive._shared import var_name_constraint
+from esmvalcore.iris_helpers import var_name_constraint
 
 logger = logging.getLogger(__name__)
 

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -1,0 +1,7 @@
+"""Auxiliary functions for :mod:`iris`."""
+import iris
+
+
+def var_name_constraint(var_name):
+    """:mod:`iris.Constraint` using `var_name` of a :mod:`iris.cube.Cube`."""
+    return iris.Constraint(cube_func=lambda c: c.var_name == var_name)

--- a/esmvalcore/preprocessor/_derive/_shared.py
+++ b/esmvalcore/preprocessor/_derive/_shared.py
@@ -3,14 +3,8 @@
 import logging
 
 import iris
-from iris import Constraint
 
 logger = logging.getLogger(__name__)
-
-
-def var_name_constraint(var_name):
-    """:mod:`iris.Constraint` using `var_name` of a :mod:`iris.cube.Cube`."""
-    return Constraint(cube_func=lambda c: c.var_name == var_name)
 
 
 def cloud_area_fraction(cubes, tau_constraint, plev_constraint):

--- a/esmvalcore/preprocessor/_derive/alb.py
+++ b/esmvalcore/preprocessor/_derive/alb.py
@@ -5,8 +5,9 @@ authors:
 
 """
 
+from esmvalcore.iris_helpers import var_name_constraint
+
 from ._baseclass import DerivedVariableBase
-from ._shared import var_name_constraint
 
 
 class DerivedVariable(DerivedVariableBase):

--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -2,8 +2,9 @@
 
 import logging
 
+from esmvalcore.iris_helpers import var_name_constraint
+
 from ._baseclass import DerivedVariableBase
-from ._shared import var_name_constraint
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm.py
@@ -38,12 +38,12 @@ def cl_file(tmp_path):
     dataset.createVariable('a_bnds', np.float64, dimensions=('lev', 'bnds'))
     dataset.createVariable('b', np.float64, dimensions=('lev',))
     dataset.createVariable('b_bnds', np.float64, dimensions=('lev', 'bnds'))
-    dataset.variables['a'][:] = [2.0, 1.0]
+    dataset.variables['a'][:] = [1.0, 2.0]
     dataset.variables['a'].bounds = 'a_bnds'
-    dataset.variables['a_bnds'][:] = [[1.5, 3.0], [0.0, 1.5]]
-    dataset.variables['b'][:] = [1.0, 0.0]
+    dataset.variables['a_bnds'][:] = [[1.5, 0.0], [3.0, 1.5]]
+    dataset.variables['b'][:] = [0.0, 1.0]
     dataset.variables['b'].bounds = 'b_bnds'
-    dataset.variables['b_bnds'][:] = [[0.5, 2.0], [-1.0, 0.5]]
+    dataset.variables['b_bnds'][:] = [[0.5, -1.0], [2.0, 0.5]]
 
     dataset.close()
     return nc_path

--- a/tests/integration/cmor/_fixes/test_common.py
+++ b/tests/integration/cmor/_fixes/test_common.py
@@ -9,7 +9,7 @@ from netCDF4 import Dataset
 from esmvalcore.cmor._fixes.common import (ClFixHybridHeightCoord,
                                            ClFixHybridPressureCoord)
 from esmvalcore.cmor.table import get_var_info
-from esmvalcore.preprocessor._derive._shared import var_name_constraint
+from esmvalcore.iris_helpers import var_name_constraint
 
 
 def create_hybrid_pressure_file_without_ap(dataset, short_name):

--- a/tests/integration/cmor/_fixes/test_shared.py
+++ b/tests/integration/cmor/_fixes/test_shared.py
@@ -4,8 +4,7 @@ import numpy as np
 import pytest
 from cf_units import Unit
 
-from esmvalcore.cmor._fixes.shared import (altitude_to_pressure,
-                                           _get_altitude_to_pressure_func,
+from esmvalcore.cmor._fixes.shared import (_get_altitude_to_pressure_func,
                                            add_aux_coords_from_cubes,
                                            add_plev_from_altitude,
                                            add_scalar_depth_coord,
@@ -13,9 +12,10 @@ from esmvalcore.cmor._fixes.shared import (altitude_to_pressure,
                                            add_scalar_typeland_coord,
                                            add_scalar_typesea_coord,
                                            add_sigma_factory,
+                                           altitude_to_pressure,
                                            cube_to_aux_coord, fix_bounds,
                                            get_bounds_cube, round_coordinates)
-from esmvalcore.preprocessor._derive._shared import var_name_constraint
+from esmvalcore.iris_helpers import var_name_constraint
 
 
 @pytest.mark.parametrize('func', [altitude_to_pressure,

--- a/tests/unit/test_iris_helpers.py
+++ b/tests/unit/test_iris_helpers.py
@@ -1,0 +1,37 @@
+"""Tests for :mod:`esmvalcore.iris_helpers`."""
+import iris
+import pytest
+
+from esmvalcore.iris_helpers import var_name_constraint
+
+
+@pytest.fixture
+def cubes():
+    """Test cubes."""
+    cubes = iris.cube.CubeList([
+        iris.cube.Cube(0.0, var_name='a', long_name='a'),
+        iris.cube.Cube(0.0, var_name='a', long_name='b'),
+        iris.cube.Cube(0.0, var_name='c', long_name='d'),
+    ])
+    return cubes
+
+
+def test_var_name_constraint(cubes):
+    """Test :func:`esmvalcore.iris_helpers.var_name_constraint`."""
+    out_cubes = cubes.extract(var_name_constraint('a'))
+    assert out_cubes == iris.cube.CubeList([
+        iris.cube.Cube(0.0, var_name='a', long_name='a'),
+        iris.cube.Cube(0.0, var_name='a', long_name='b'),
+    ])
+    out_cubes = cubes.extract(var_name_constraint('b'))
+    assert out_cubes == iris.cube.CubeList([])
+    out_cubes = cubes.extract(var_name_constraint('c'))
+    assert out_cubes == iris.cube.CubeList([
+        iris.cube.Cube(0.0, var_name='c', long_name='d'),
+    ])
+    with pytest.raises(iris.exceptions.ConstraintMismatchError):
+        cubes.extract_strict(var_name_constraint('a'))
+    with pytest.raises(iris.exceptions.ConstraintMismatchError):
+        cubes.extract_strict(var_name_constraint('b'))
+    out_cube = cubes.extract_strict(var_name_constraint('c'))
+    assert out_cube == iris.cube.Cube(0.0, var_name='c', long_name='d')


### PR DESCRIPTION
This PR extends the fixes for `cl`, `cli` and `clw` for the CESM2 models (the original fix only flips the vertical coords, but not the data itself).

I also had to move the function `var_name_constraint` to a new module (`iris_helpers`) because of circular dependencies in `esmvaltool.cmor._fixes.shared` and `esmvaltool.preprocessor.shared`. I'm happy to rename that module if anybody knows a better name.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Related to #538 and #539.
