### PR TITLE
Reduce the size of conda package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
             dpkg -l > /logs/versions.txt
             conda env export -n base > /logs/build_environment.yml
             # Build conda package
-            conda build . -c conda-forge -c esmvalgroup > /logs/build_log.txt
+            conda build package -c conda-forge -c esmvalgroup > /logs/build_log.txt
       - store_artifacts:
           path: /logs
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -193,7 +193,7 @@ All tests should pass before making a release.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The version number is stored in ``esmvalcore/_version.py``,
-``meta.yaml``, ``CITATION.cff``. Make sure to update all files. See
+``package/meta.yaml``, ``CITATION.cff``. Make sure to update all files. See
 https://semver.org for more information on choosing a version number.
 
 3. Make the release on GitHub
@@ -212,11 +212,11 @@ Follow these steps to create a new conda package:
 
 -  Check out the tag corresponding to the release,
    e.g. \ ``git checkout v2.0.0b6``
--  Edit meta.yaml and uncomment the lines starting with ``git_rev`` and
+-  Edit package/meta.yaml and uncomment the lines starting with ``git_rev`` and
    ``git_url``, remove the line starting with ``path`` in the ``source``
    section.
 -  Activate the base environment ``conda activate base``
--  Run ``conda build . -c conda-forge -c esmvalgroup`` to build the
+-  Run ``conda build package -c conda-forge -c esmvalgroup`` to build the
    conda package
 -  If the build was successful, upload the package to the esmvalgroup
    conda channel,

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -1,8 +1,8 @@
 # Conda build recipe
 ---
 
-# Build command:
-# conda build . -c conda-forge -c esmvalgroup
+# Build command (run this from the root of the repository):
+# conda build package -c conda-forge -c esmvalgroup
 
 # Package version number
 {% set version = "2.0.0b9" %}
@@ -16,7 +16,7 @@ source:
   # git_rev: v{{ version }}
   # git_url: https://github.com/ESMValGroup/ESMValCore.git
   # Use this line instead of the above to test building without a release:
-  path: .
+  path: ..
 
 build:
   # Increment the build number when building a new conda package of the same


### PR DESCRIPTION
When creating a conda package, all files that are in the same directory as meta.yaml are copied into the package. This resulted in very large conda packages. By moving meta.yaml to it's own directory, we can create much smaller conda packages. I already used that to build the past few conda packages, but this pull request actually implements that.

**Tasks**

-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
