### PR TITLE
Add pandas as a requirement for building the documentation

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,6 +3,7 @@ fiona
 netCDF4
 numba
 numpy
+pandas
 pillow
 prov[dot]
 pyyaml


### PR DESCRIPTION
The documentation test has been broken since https://github.com/ESMValGroup/ESMValCore/pull/562 was merged. This pull request fixes it by adding `pandas` to the list of packages that readthedocs needs to install.

**Tasks**

-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
