### PR TITLE
Overhaul concatenation and allow for correct concatenation of multiple overlapping datasets

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -186,12 +186,7 @@ def concatenate(cubes):
 
     if len(cubes) > 2:
         # order cubes by first time point
-        cubes_dict = {cube: cube.coord("time").points[0] for cube in cubes}
-        cubes_dict = {
-            k: v for k, v in sorted(cubes_dict.items(),
-                                    key=lambda item: item[1])
-        }
-        cubes = [item[0] for item in cubes_dict.items()]
+        cubes = sorted(cubes, key=lambda c: c.coord("time").cell(0).point)
 
         # iteratively concatenate starting with first cube
         result = cubes[0]

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -184,7 +184,7 @@ def concatenate(cubes):
     """Concatenate all cubes after fixing metadata."""
     _fix_cube_attributes(cubes)
 
-    if len(cubes) > 2:
+    if len(cubes) > 1:
         # order cubes by first time point
         cubes = sorted(cubes, key=lambda c: c.coord("time").cell(0).point)
 

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -181,7 +181,7 @@ def concatenate(cubes):
         try:
             cubes = sorted(cubes, key=lambda c: c.coord("time").cell(0).point)
         except iris.exceptions.CoordinateNotFoundError as exc:
-            msg = "One or both cubes {} is missing".format(cubes) + \
+            msg = "One or more cubes {} are missing".format(cubes) + \
                   " time coordinate: {}".format(str(exc))
             raise ValueError(msg)
 

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -185,8 +185,10 @@ def concatenate(cubes):
 
     if len(cubes) > 2:
         cubes_dict = {cube: cube.coord("time").points[0] for cube in cubes}
-        cubes_dict = OrderedDict({k: v for k, v in sorted(cubes_dict.items(),
-            key=lambda item: item[1])})
+        cubes_dict = OrderedDict(
+            {k: v for k, v in sorted(cubes_dict.items(),
+                                     key=lambda item: item[1])}
+        )
         cubes = [item[0] for item in cubes_dict.items()]
         concatenated = iris.cube.CubeList([cubes[0], cubes[1]]).concatenate()
         if len(concatenated) == 2:

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -184,6 +184,10 @@ def concatenate(cubes):
     _fix_cube_attributes(cubes)
 
     if len(cubes) > 2:
+        cubes_dict = {cube: cube.coord("time").points[0] for cube in cubes}
+        cubes_dict = OrderedDict({k: v for k, v in sorted(cubes_dict.items(),
+            key=lambda item: item[1])})
+        cubes = [item[0] for item in cubes_dict.items()]
         concatenated = iris.cube.CubeList([cubes[0], cubes[1]]).concatenate()
         if len(concatenated) == 2:
             concatenated = _by_two_concatenation(concatenated)

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -192,12 +192,6 @@ def concatenate(cubes):
         result = cubes[0]
         for cube in cubes[1:]:
             result = _by_two_concatenation([result, cube])
-    else:
-        result = iris.cube.CubeList(cubes).concatenate()
-        if len(result) == 2:
-            result = _by_two_concatenation(cubes)
-        else:
-            result = result[0]
 
     _fix_aux_factories(result)
 

--- a/tests/integration/preprocessor/_io/test_concatenate.py
+++ b/tests/integration/preprocessor/_io/test_concatenate.py
@@ -258,7 +258,7 @@ class TestConcatenate(unittest.TestCase):
         concatenated = _io.concatenate(self.raw_cubes)
         np.testing.assert_array_equal(
             concatenated.coord('time').points,
-            np.array([1., 2., 3., 4., 5., 6., 1000., 7000.]))
+            np.array([1., 2., 3., 200., 1000., 7000.]))
 
     def test_concatenate_with_overlap_same_start(self):
         """Test a more generic case."""
@@ -340,7 +340,7 @@ class TestConcatenate(unittest.TestCase):
             Cube([33., 55.],
                  var_name='sample',
                  dim_coords_and_dims=((time_coord, 0), )))
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             _io.concatenate(self.raw_cubes)
 
     def test_fail_on_units_concatenate_with_overlap(self):
@@ -379,6 +379,7 @@ class TestConcatenate(unittest.TestCase):
     def test_fail_metadata_differs(self):
         """Test exception raised if two cubes have different metadata."""
         self.raw_cubes[0].units = 'm'
+        self.raw_cubes[1].units = 'K'
         with self.assertRaises(ValueError):
             _io.concatenate(self.raw_cubes)
 

--- a/tests/integration/preprocessor/_io/test_concatenate.py
+++ b/tests/integration/preprocessor/_io/test_concatenate.py
@@ -312,6 +312,26 @@ class TestConcatenate(unittest.TestCase):
         with self.assertRaises(ConcatenateError):
             _io.concatenate(cubes_single_ovlp)
 
+    def test_concatenate_no_time_coords(self):
+        """Test a more generic case."""
+        time_coord_1 = DimCoord([1.5, 5., 7.],
+                                var_name='time',
+                                standard_name='time',
+                                units='days since 1950-01-01')
+        cube1 = Cube([33., 55., 77.],
+                     var_name='sample',
+                     dim_coords_and_dims=((time_coord_1, 0), ))
+        ap_coord_2 = DimCoord([1., 5., 7.],
+                              var_name='air_pressure',
+                              standard_name='air_pressure',
+                              units='m',
+                              attributes={'positive': 'down'})
+        cube2 = Cube([33., 55., 77.],
+                     var_name='sample',
+                     dim_coords_and_dims=((ap_coord_2, 0), ))
+        with self.assertRaises(ValueError):
+            _io.concatenate([cube1, cube2])
+
     def test_concatenate_with_order(self):
         """Test a more generic case."""
         time_coord_1 = DimCoord([1.5, 2., 5., 7.],

--- a/tests/integration/preprocessor/_io/test_concatenate.py
+++ b/tests/integration/preprocessor/_io/test_concatenate.py
@@ -370,7 +370,7 @@ class TestConcatenate(unittest.TestCase):
             Cube([33., 55.],
                  var_name='sample',
                  dim_coords_and_dims=((time_coord, 0), )))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             _io.concatenate(self.raw_cubes)
 
     def test_fail_on_units_concatenate_with_overlap(self):

--- a/tests/integration/preprocessor/_io/test_concatenate.py
+++ b/tests/integration/preprocessor/_io/test_concatenate.py
@@ -253,12 +253,22 @@ class TestConcatenate(unittest.TestCase):
 
     def test_concatenate_with_overlap_2(self):
         """Test a more generic case."""
-        self._add_cube([65., 75.], [3., 200.])
-        self._add_cube([65., 75.], [1000., 7000.])
+        self._add_cube([65., 75., 100.], [9., 10., 11.])
+        self._add_cube([65., 75., 100.], [7., 8., 9.])
         concatenated = _io.concatenate(self.raw_cubes)
         np.testing.assert_array_equal(
             concatenated.coord('time').points,
-            np.array([1., 2., 3., 200., 1000., 7000.]))
+            np.array([1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11.]))
+
+    def test_concatenate_with_overlap_3(self):
+        """Test a more generic case."""
+        self._add_cube([65., 75., 100.], [9., 10., 11.])
+        self._add_cube([65., 75., 100., 100., 100., 112.],
+                       [7., 8., 9., 10., 11., 12.])
+        concatenated = _io.concatenate(self.raw_cubes)
+        np.testing.assert_array_equal(
+            concatenated.coord('time').points,
+            np.array([1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.]))
 
     def test_concatenate_with_overlap_same_start(self):
         """Test a more generic case."""


### PR DESCRIPTION
Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes https://github.com/ESMValGroup/ESMValCore/issues/574

**Summary**

- continuation of the previous implementation of concatenation of two overlapping cubes
- handles corner case situations as @mwjury has noticed in https://github.com/ESMValGroup/ESMValCore/issues/574
- fixed one bug in testing (that was due to bad implementation of the function in `_io.py`)

**New Features**

- handles a list of cubes to be concatenated of form `[A, B, C, D...]` with any sort of overlap in time between the cubes
- turns off `iris`'s faulty automatic concatenation of eg `[A, B, D]` with a massive gap between B and D and inability of previous implementation to plug the gap with C
- if the cubes are `[A, B, D, C...]` and B and D don't have an overlap but C or later cubes overlap, it will still work

**Tagline**

- probably the mother of all concatenations we've ever had :grin: 
