### PR TITLE
Preprocessor module to compute and store ACSIS indicators

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -657,12 +657,21 @@ def _update_extract_shape(settings, config_user):
 
 def _update_acsis_indices(settings, config_user):
     """Update the ACSIS indices calculator to output in work_dir."""
-    # set target dir to save
-    settings['acsis_indices']['target_dir'] = config_user['work_dir']
-    if not os.path.isdir(config_user['work_dir']):
-        os.makedirs(config_user['work_dir'])
+    # get moc_variable and vn_variable
+    moc_variable = settings['acsis_indices'].get('moc_variable')
+    if not moc_variable:
+        logger.warning(
+            "acsis_indices: setting default moc variable to moc_mar_hc10")
+        moc_variable = 'moc_mar_hc10'
+    settings['acsis_indices']['moc_variable'] = moc_variable
+    vn_variable = settings['acsis_indices'].get('vn_variable')
+    if not vn_variable:
+        logger.warning(
+            "acsis_indices: setting default vn variable to UM_0_fc8_vn405")
+        vn_variable = 'UM_0_fc8_vn405'
+    settings['acsis_indices']['vn_variable'] = vn_variable
 
-    # check for moc_file
+    # check for moc_file and assign variable
     moc_file = settings['acsis_indices'].get('moc_file')
     if not moc_file:
         raise RecipeError(
@@ -673,9 +682,16 @@ def _update_acsis_indices(settings, config_user):
                 config_user['auxiliary_data_dir'],
                 moc_file,
             )
-            settings['acsis_indices']['moc_file'] = moc_file
+        if os.path.isfile(moc_file):
+            logger.info("Using file for {}: {}".format(moc_variable,
+                                                       moc_file))
+        else:
+            raise RecipeError("File {} for {} does not exist.".format(
+                                  moc_file,
+                                  moc_variable))
+        settings['acsis_indices']['moc_file'] = moc_file
 
-    # check for vn_file
+    # check for vn_file and assign variable
     vn_file = settings['acsis_indices'].get('vn_file')
     if not vn_file:
         raise RecipeError(
@@ -686,7 +702,13 @@ def _update_acsis_indices(settings, config_user):
                 config_user['auxiliary_data_dir'],
                 vn_file,
             )
-            settings['acsis_indices']['vn_file'] = vn_file
+        if os.path.isfile(vn_file):
+            logger.info("Using file for {}: {}".format(vn_variable,
+                                                       vn_file))
+        else:
+            raise RecipeError("File {} for {} does not exist.".format(
+                                  vn_file,
+                                  vn_variable))
 
 
 def _match_products(products, variables):

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -655,6 +655,40 @@ def _update_extract_shape(settings, config_user):
         check.extract_shape(settings['extract_shape'])
 
 
+def _update_acsis_indices(settings, config_user):
+    """Update the ACSIS indices calculator to output in work_dir."""
+    # set target dir to save
+    settings['acsis_indices']['target_dir'] = config_user['work_dir']
+    if not os.path.isdir(config_user['work_dir']):
+        os.makedirs(config_user['work_dir'])
+
+    # check for moc_file
+    moc_file = settings['acsis_indices'].get('moc_file')
+    if not moc_file:
+        raise RecipeError(
+            "acsis_indices: did not find any input option for moc_file")
+    else:
+        if not os.path.exists(moc_file):
+            moc_file = os.path.join(
+                config_user['auxiliary_data_dir'],
+                moc_file,
+            )
+            settings['acsis_indices']['moc_file'] = moc_file
+
+    # check for vn_file
+    vn_file = settings['acsis_indices'].get('vn_file')
+    if not vn_file:
+        raise RecipeError(
+            "acsis_indices: did not find any input option for vn_file")
+    else:
+        if not os.path.exists(vn_file):
+            vn_file = os.path.join(
+                config_user['auxiliary_data_dir'],
+                vn_file,
+            )
+            settings['acsis_indices']['vn_file'] = vn_file
+
+
 def _match_products(products, variables):
     """Match a list of input products to output product attributes."""
     grouped_products = {}
@@ -723,6 +757,7 @@ def _get_preprocessor_products(variables,
             config_user=config_user,
         )
         _update_extract_shape(settings, config_user)
+        _update_acsis_indices(settings, config_user)
         _update_weighting_settings(settings, variable)
         _update_fx_settings(settings=settings,
                             variable=variable,

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -657,6 +657,9 @@ def _update_extract_shape(settings, config_user):
 
 def _update_acsis_indices(settings, config_user):
     """Update the ACSIS indices calculator to output in work_dir."""
+    if 'acsis_indices' not in settings:
+        return
+
     # get moc_variable and vn_variable
     moc_variable = settings['acsis_indices'].get('moc_variable')
     if not moc_variable:

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -13,6 +13,7 @@ from ._area import (area_statistics, extract_named_regions, extract_region,
 from ._derive import derive
 from ._detrend import detrend
 from ._download import download
+from ._indices import acsis_indices
 from ._io import (_get_debug_filename, cleanup, concatenate, load, save,
                   write_metadata)
 from ._mask import (mask_above_threshold, mask_below_threshold,
@@ -51,6 +52,8 @@ __all__ = [
     'extract_time',
     'extract_season',
     'extract_month',
+    # Compute indices
+    'acsis_indices',
     # Data reformatting/CMORization
     'fix_data',
     # Level extraction

--- a/esmvalcore/preprocessor/_indices.py
+++ b/esmvalcore/preprocessor/_indices.py
@@ -1,0 +1,105 @@
+"""Module to compute various fixed indices."""
+import logging
+import os
+from datetime import datetime
+
+import iris
+import numpy as np
+import yaml
+
+from ._area import extract_region
+from ._regrid import extract_levels
+from ._time import annual_statistics, extract_season
+
+seasons = ['DJF', 'MAM', 'JJA', 'SON']
+MOC_VARIABLE = 'moc_mar_hc10'
+AIRPRESS_VARIABLE = 'UM_0_fc8_vn405'
+
+# set up logging
+logger = logging.getLogger(__name__)
+
+def _extract_u850(cube):
+    """
+    Get jet speed and jet latitude.
+
+    Extract eastern wind u at 850 hPa 15-75N lat.
+    Extract mean 0-60W lon. Mean on LON. Extract season.
+    Return each season's cube in a dictionary.
+    """
+    # extract 300-360W lon; 15-75N lat region; CMOR coords standards
+    cube = extract_region(cube, 0., 60., 15., 75.)
+
+    # extract 850 hPa
+    cube = extract_levels(cube, 85000., 'linear')
+
+    # collapse-mean on lon
+    cube = cube.collapsed(['longitude'], iris.analysis.MEAN)
+
+    # extract seasons
+    seasonal_dict = {
+        season: extract_season(cube, season) for season in seasons
+    }
+
+    return seasonal_dict
+
+
+def _get_jets(seasonal_dict):
+    """Take seasonal dictionary and get jets dicts (speeds and lats)."""
+    # remove non-seasons and sub-dimensional data
+    seasonal_dict = {k: v for k, v in seasonal_dict.items() if v is not None}
+    seasonal_dict = {
+        k: v for k, v in seasonal_dict.items() if len(v.data.shape) >= 2
+    }
+
+    # get jet speeds
+    jet_speeds = {
+        season: np.amax(seasonal_dict[season].data,
+                        axis=1) for season in seasonal_dict.keys()
+    }
+
+    # get the jet latitudes
+    jet_lats = {}
+    for season, _ in seasonal_dict.items():
+        cube = seasonal_dict[season]
+        jet_lat = np.empty((cube.data.shape[0], ))
+        max_ind = np.argmax(cube.data, axis=1)
+        jet_lat[max_ind[0]] = cube.coord('latitude').points[max_ind[1]]
+        jet_lats[season] = jet_lat
+
+    return jet_speeds, jet_lats
+
+
+def _djf_greenland_iceland(data_file, var_constraint, season):
+    """Get the DJF mean for Greenland-Iceland."""
+    cube = iris.load(data_file, constraints=var_constraint)[0]
+    greenland_map = extract_region(cube, 25., 35., 30., 40.)
+    iceland_map = extract_region(cube, 15., 25., 60., 70.)
+    greenland = greenland_map.collapsed(['longitude', 'latitude'],
+                                        iris.analysis.MEAN)
+    iceland = iceland_map.collapsed(['longitude', 'latitude'],
+                                    iris.analysis.MEAN)
+
+    # get cubes of interest
+    greenland_djf = extract_season(greenland, season)
+    iceland_djf = extract_season(iceland, season)
+    diff = greenland - iceland
+    season_geo_diff = extract_season(diff, season)
+
+    return season_geo_diff
+
+
+def _moc_vn(moc_file, vn_file):
+    """Compute yearly means for moc and vn."""
+    # moc
+    moc_constraint = iris.Constraint(
+        cube_func=(lambda c: c.var_name == MOC_VARIABLE))
+    moc_cube = iris.load(moc_file, constraints=moc_constraint)[0]
+    annual_moc = annual_statistics(moc_cube)
+
+    # vn405
+    vn_constraint = iris.Constraint(
+        cube_func=(lambda c: c.var_name == AIRPRESS_VARIABLE))
+    vn_cube = iris.load(vn_file, constraints=vn_constraint)[0]
+    annual_vn = annual_statistics(vn_cube)
+
+    return annual_moc, annual_vn

--- a/esmvalcore/preprocessor/_indices.py
+++ b/esmvalcore/preprocessor/_indices.py
@@ -94,7 +94,7 @@ def _djf_greenland_iceland(data_file, var_constraint, season):
     diff = greenland - iceland
     season_geo_diff = extract_season(diff, season)
 
-    return season_geo_diff
+    return greenland_djf, iceland_djf, season_geo_diff
 
 
 def _moc_vn(moc_file, vn_file):
@@ -111,7 +111,12 @@ def _moc_vn(moc_file, vn_file):
     vn_cube = iris.load(vn_file, constraints=vn_constraint)[0]
     annual_vn = annual_statistics(vn_cube)
 
-    return annual_moc, annual_vn
+    # greenland-iceland
+    greenland_djf, iceland_djf, season_geo_diff = \
+        _djf_greenland_iceland(vn_file, vn_constraint, SEASON)
+
+    return (annual_moc, annual_vn,
+        greenland_djf, iceland_djf, season_geo_diff)
 
 
 def acsis_indices(cube, moc_file, vn_file):
@@ -141,5 +146,11 @@ def acsis_indices(cube, moc_file, vn_file):
         iris.save(jet_speeds[season], 'u850_{}_jet-speeds.nc'.format(season))
         iris.save(jet_lats[season], 'u850_{}_jet-latitudes.nc'.format(season))
 
-    # moc-vn
-
+    # moc-vn-greenland-iceland
+    (annual_moc, annual_vn,
+     greenland_djf, iceland_djf, season_geo_diff) = _moc_vn(moc_file, vn_file)
+    iris.save(annual_moc, 'annual_moc.nc')
+    iris.save(annual_vn, 'annual_vn.nc')
+    iris.save(greenland_djf, 'greenland_djf.nc')
+    iris.save(iceland_djf, 'iceland_djf.nc')
+    iris.save(season_geo_diff, 'iceland_greenland.nc')

--- a/esmvalcore/preprocessor/_indices.py
+++ b/esmvalcore/preprocessor/_indices.py
@@ -64,11 +64,8 @@ def _get_jets(seasonal_dict):
     for season, _ in seasonal_dict.items():
         cube = seasonal_dict[season]
         jet_lat = np.empty((cube.data.shape[0], ))
-        t_ax, l_ax = cube.data.shape
-        for t_idx in range(t_ax):
-            for l_idx in range(l_ax):
-                if cube.data[t_idx, l_idx] == jet_speeds[season][t_idx]:
-                    jet_lat[t_idx] = cube.coord('latitude').points[l_idx]
+        idx = np.argmax(cube.data, axis=1)
+        jet_lat = cube.coord('latitude').points[idx]
         jet_lat_cube = iris.cube.Cube(
             jet_lat,
             dim_coords_and_dims=[],

--- a/tests/unit/preprocessor/_indices/test_indices.py
+++ b/tests/unit/preprocessor/_indices/test_indices.py
@@ -65,4 +65,4 @@ class Test(tests.Test):
         extracted = _extract_u850(self.cube)
         jets, lats = _get_jets(extracted)
         np.testing.assert_equal(jets["DJF"].data, np.ma.array([1., 8.]))
-        np.testing.assert_equal(lats["DJF"].data, np.array([25., 4.]))
+        np.testing.assert_equal(lats["DJF"].data, np.array([15., 25.]))

--- a/tests/unit/preprocessor/_indices/test_indices.py
+++ b/tests/unit/preprocessor/_indices/test_indices.py
@@ -1,0 +1,68 @@
+"""Unit test for :func:`esmvalcore.preprocessor._indices`."""
+import iris
+import numpy as np
+from cf_units import Unit
+
+import tests
+from esmvalcore.preprocessor._indices import _extract_u850, _get_jets
+
+
+class Test(tests.Test):
+    """Test class for preprocessor/_multimodel.py."""
+
+    def setUp(self):
+        """Prepare tests."""
+        coord_sys = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
+        data = np.ma.ones((3, 3, 3, 3))
+        data[1, 1, 1, 1] = 22.
+        data[0, 2, 1, 1] = 33.
+
+        time = iris.coords.DimCoord([15, 45, 75],
+                                    standard_name='time',
+                                    bounds=[[1., 30.],
+                                            [30., 60.],
+                                            [60., 90.]],
+                                    units=Unit(
+                                        'days since 1950-01-01',
+                                        calendar='gregorian'))
+        zcoord = iris.coords.DimCoord([70000., 85000., 100000.],
+                                      standard_name='air_pressure',
+                                      long_name='air_pressure',
+                                      units='m',
+                                      attributes={'positive': 'down'})
+        lons = iris.coords.DimCoord([1.5, 2.5, 3.5],
+                                    standard_name='longitude',
+                                    long_name='longitude',
+                                    bounds=[[1., 2.], [2., 3.], [3., 4.]],
+                                    units='degrees_east',
+                                    coord_system=coord_sys)
+        lats = iris.coords.DimCoord([15., 25., 35.],
+                                    standard_name='latitude',
+                                    long_name='latitude',
+                                    bounds=[[10., 20.],
+                                            [20., 30.],
+                                            [30., 40.]],
+                                    units='degrees_north',
+                                    coord_system=coord_sys)
+
+        coords_spec = [(time, 0), (zcoord, 1), (lats, 2), (lons, 3)]
+        self.cube = iris.cube.Cube(data, dim_coords_and_dims=coords_spec)
+
+    def test_extract_u850(self):
+        """Test extract_u850 func."""
+        self.cube.coord("air_pressure").guess_bounds()
+        result = _extract_u850(self.cube)
+        expected_djf = np.ma.array([[1., 1., 1.], [1., 8., 1.]])
+        expected_mam = np.ma.array([1., 1., 1.])
+        np.testing.assert_equal(result["DJF"].data, expected_djf)
+        np.testing.assert_equal(result["MAM"].data, expected_mam)
+        np.testing.assert_equal(result["JJA"], None)
+        np.testing.assert_equal(result["SON"], None)
+
+    def test_get_jets(self):
+        """Test _get_jets func."""
+        self.cube.coord("air_pressure").guess_bounds()
+        extracted = _extract_u850(self.cube)
+        jets, lats = _get_jets(extracted)
+        np.testing.assert_equal(jets["DJF"], np.ma.array([1., 8.]))
+        np.testing.assert_equal(lats["DJF"], np.array([25., 4.]))

--- a/tests/unit/preprocessor/_indices/test_indices.py
+++ b/tests/unit/preprocessor/_indices/test_indices.py
@@ -64,5 +64,5 @@ class Test(tests.Test):
         self.cube.coord("air_pressure").guess_bounds()
         extracted = _extract_u850(self.cube)
         jets, lats = _get_jets(extracted)
-        np.testing.assert_equal(jets["DJF"], np.ma.array([1., 8.]))
-        np.testing.assert_equal(lats["DJF"], np.array([25., 4.]))
+        np.testing.assert_equal(jets["DJF"].data, np.ma.array([1., 8.]))
+        np.testing.assert_equal(lats["DJF"].data, np.array([25., 4.]))

--- a/tests/unit/preprocessor/_indices/test_indices.py
+++ b/tests/unit/preprocessor/_indices/test_indices.py
@@ -1,10 +1,18 @@
 """Unit test for :func:`esmvalcore.preprocessor._indices`."""
+import os
+import tempfile
+
 import iris
 import numpy as np
+import pytest
 from cf_units import Unit
 
 import tests
-from esmvalcore.preprocessor._indices import _extract_u850, _get_jets
+from esmvalcore.preprocessor._indices import (acsis_indices,
+                                              _add_attribute,
+                                              _djf_greenland_iceland,
+                                              _extract_u850, _get_jets,
+                                              _load_cube, _moc_vn)
 
 
 class Test(tests.Test):
@@ -46,7 +54,91 @@ class Test(tests.Test):
                                     coord_system=coord_sys)
 
         coords_spec = [(time, 0), (zcoord, 1), (lats, 2), (lons, 3)]
-        self.cube = iris.cube.Cube(data, dim_coords_and_dims=coords_spec)
+        self.cube = iris.cube.Cube(data, var_name='sample',
+                                   dim_coords_and_dims=coords_spec)
+
+    def _create_sample_full_cube(self):
+        """Create full map cube to select desired regions."""
+        cube = iris.cube.Cube(np.zeros((4, 180, 360)),
+                              var_name='co2', units='J')
+        cube.data[1] = 33.
+        cube.add_dim_coord(
+            iris.coords.DimCoord(
+                np.array([10., 40., 70., 110.]),
+                standard_name='time',
+                units=Unit('days since 1950-01-01 00:00:00',
+                           calendar='gregorian'),
+            ),
+            0,
+        )
+        cube.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(-90., 90., 1.),
+                standard_name='latitude',
+                units='degrees',
+            ),
+            1,
+        )
+        cube.add_dim_coord(
+            iris.coords.DimCoord(
+                np.arange(0., 360., 1.),
+                standard_name='longitude',
+                units='degrees',
+            ),
+            2,
+        )
+
+        cube.coord("time").guess_bounds()
+        cube.coord("longitude").guess_bounds()
+        cube.coord("latitude").guess_bounds()
+
+        return cube
+
+    def _create_sample_full_3d_cube(self):
+        """Create a cube with z-lan-lat coords."""
+        cube = iris.cube.Cube(np.zeros((4, 3, 180, 360)),
+                              var_name='co2', units='J')
+        base_cube = self._create_sample_full_cube()
+        cube.add_dim_coord(base_cube.coord("time"), 0)
+        cube.add_dim_coord(base_cube.coord("latitude"), 2)
+        cube.add_dim_coord(base_cube.coord("longitude"), 3)
+        cube.add_dim_coord(iris.coords.DimCoord([70000., 85000., 100000.],
+                                      standard_name='air_pressure',
+                                      long_name='air_pressure',
+                                      units='m',
+                                      attributes={'positive': 'down'}), 1)
+        return cube
+
+    def _save_cube(self, cube):
+        descriptor, temp_file = tempfile.mkstemp('.nc')
+        os.close(descriptor)
+        iris.save(cube, temp_file)
+        return temp_file
+
+    def test_load_cube(self):
+        """Test _load_cube func."""
+        cube = self.cube
+        temp_file = self._save_cube(cube)
+        result_cube = _load_cube(temp_file, 'sample')
+        expected_cube = cube
+        np.testing.assert_equal(result_cube.data, expected_cube.data)
+        np.testing.assert_equal(result_cube.var_name, expected_cube.var_name)
+
+    def test_load_cube_fail(self):
+        """Test fail of _load_cube func."""
+        cube = self.cube
+        temp_file = self._save_cube(cube)
+        msg = "No variable cow found in file {}".format(temp_file)
+        with pytest.raises(ValueError) as err_exp:
+            _load_cube(temp_file, 'cow')
+        assert str(err_exp.value) == msg
+
+    def test_add_attribute(self):
+        """Test _add_attribute func."""
+        cube = self.cube
+        result = _add_attribute(cube, [22, 22], 'cow')
+        assert 'cow' in cube.attributes
+        assert cube.attributes['cow'] == [22, 22]
 
     def test_extract_u850(self):
         """Test extract_u850 func."""
@@ -64,5 +156,50 @@ class Test(tests.Test):
         self.cube.coord("air_pressure").guess_bounds()
         extracted = _extract_u850(self.cube)
         jets, lats = _get_jets(extracted)
-        np.testing.assert_equal(jets["DJF"].data, np.ma.array([1., 8.]))
-        np.testing.assert_equal(lats["DJF"].data, np.array([15., 25.]))
+        np.testing.assert_equal(jets["DJF"], np.ma.array([1., 8.]))
+        np.testing.assert_equal(lats["DJF"], np.array([15., 25.]))
+
+    def test_djf_greenland_iceland(self):
+        """Test _djf_greenland_iceland func."""
+        cube = self._create_sample_full_cube()
+        temp_file = self._save_cube(cube)
+        greenland, iceland, gre_ice = _djf_greenland_iceland(temp_file,
+                                                             "co2",
+                                                             "DJF")
+        np.testing.assert_equal(greenland.data, np.array([0., 33.]))
+        np.testing.assert_equal(iceland.data, np.array([0., 33.]))
+        np.testing.assert_equal(gre_ice.data, np.array([0., 0.]))
+
+    def test_moc_vn(self):
+        """Test _moc_vn func."""
+        moc_cube = self._create_sample_full_cube()
+        moc_cube.var_name = "moc"
+        vn_cube = self._create_sample_full_cube()
+        vn_cube.var_name = "vn"
+        moc_file = self._save_cube(moc_cube)
+        vn_file = self._save_cube(vn_cube)
+        (annual_moc,
+         annual_vn,
+         greenland_djf,
+         iceland_djf,
+         season_geo_diff) = _moc_vn(moc_file, vn_file, "moc", "vn")
+        np.testing.assert_equal(annual_moc.data[0], 8.25)
+        np.testing.assert_equal(annual_moc.data.shape, (1, 180, 360))
+        np.testing.assert_equal(annual_vn.data[0], 8.25)
+        np.testing.assert_equal(annual_vn.data.shape, (1, 180, 360))
+        np.testing.assert_equal(greenland_djf.data, np.array([0., 33.]))
+        np.testing.assert_equal(iceland_djf.data, np.array([0., 33.]))
+        np.testing.assert_equal(season_geo_diff.data, np.ma.array([0., 0.]))
+
+    def test_acsis_indices(self):
+        """Test acsis mainfunc."""
+        cube = self._create_sample_full_3d_cube()
+        moc_cube = self._create_sample_full_3d_cube()
+        moc_cube.var_name = "moc"
+        vn_cube = self._create_sample_full_3d_cube()
+        vn_cube.var_name = "vn"
+        moc_file = self._save_cube(moc_cube)
+        vn_file = self._save_cube(vn_cube)
+        result = acsis_indices(cube, moc_file, vn_file, "moc", "vn")
+        assert 'max_annual_moc' in cube.attributes
+        assert 'max_annual_vn' in cube.attributes


### PR DESCRIPTION
Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [ ] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes {Link to corresponding issue}

**SUMMARY**

Compute and store ACSIS indicators as presented to me by @ed-hawkins - this is done now in a nice way via a preprocessor module with minimum effort and input from the user; the way they can invoke it is via an entry in the recipe:

```yaml
preprocessors:
  acsis:
    acsis_indices:
      moc_file: /home/users/valeriu/esmvaltool_ACSIS_example/moc_transports.nc
      vn_file: /home/users/valeriu/esmvaltool_ACSIS_example/hadslp2r.pp
      moc_variable: moc_mar_hc10
      vn_variable: UM_0_fc8_vn405
```

note that files can be stored and read from by the code from the `auxiliary_data_dir` and also the variables can be anything the user wishes and if they are not specified then the defaults are `moc_mar_hc10` and `UM_0_fc8_vn405`; the module computes the currently implemented ACSIS indicators and attaches them to the OBS6 file that were computed with as attributes.

**TODO** (still)

I need to improve testing and write documentation.
