### PR TITLE
Fix mask fx dict handling not to fail if empty list in values

### DIFF
--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -135,6 +135,8 @@ def mask_landsea(cube, fx_variables, mask_out, always_use_ne_mask=False):
     if any(fx_files) and not always_use_ne_mask:
         fx_cubes = {}
         for fx_file in fx_files:
+            if not fx_file:
+                continue
             fxfile_members = os.path.basename(fx_file).split('_')
             for fx_root in ['sftlf', 'sftof']:
                 if fx_root in fxfile_members:
@@ -216,6 +218,8 @@ def mask_landseaice(cube, fx_variables, mask_out):
     fx_files = fx_variables.values()
     if any(fx_files):
         for fx_file in fx_files:
+            if not fx_file:
+                continue
             fx_cube = iris.load_cube(fx_file)
 
             if _check_dims(cube, fx_cube):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,10 +3,15 @@ Provides testing capabilities for :mod:`esmvaltool` package.
 
 """
 import unittest
-from functools import wraps
-from unittest import mock
 
 import numpy as np
+
+
+def assert_array_equal(a, b):
+    """Assert that array a equals array b."""
+    np.testing.assert_array_equal(a, b)
+    if np.ma.isMaskedArray(a) or np.ma.isMaskedArray(b):
+        np.testing.assert_array_equal(a.mask, b.mask)
 
 
 class Test(unittest.TestCase):
@@ -14,7 +19,6 @@ class Test(unittest.TestCase):
     Provides esmvaltool specific testing functionality.
 
     """
-
     def _remove_testcase_patches(self):
         """
         Helper method to remove per-testcase patches installed by
@@ -32,22 +36,22 @@ class Test(unittest.TestCase):
         """
         Install a patch to be removed automatically after the current test.
 
-        The patch is created with :func:`mock.patch`.
+        The patch is created with :func:`unittest.mock.patch`.
 
         Parameters
         ----------
         args : list
-            The parameters to be passed to :func:`mock.patch`.
+            The parameters to be passed to :func:`unittest.mock.patch`.
         kwargs : dict
-            The keyword parameters to be passed to :func:`mock.patch`.
+            The keyword parameters to be passed to :func:`unittest.mock.patch`.
 
         Returns
         -------
-            The substitute mock instance returned by :func:`patch.start`.
+            The substitute mock instance returned by :func:`unittest.patch.start`.
 
         """
         # Make the new patch and start it.
-        patch = mock.patch(*args, **kwargs)
+        patch = unittest.mock.patch(*args, **kwargs)
         start_result = patch.start()
 
         # Create the per-testcases control variable if it does not exist.
@@ -66,8 +70,5 @@ class Test(unittest.TestCase):
         # Return patch replacement object.
         return start_result
 
-    @wraps(np.testing.assert_array_equal)
     def assert_array_equal(self, a, b):
-        np.testing.assert_array_equal(a, b)
-        if np.ma.isMaskedArray(a) or np.ma.isMaskedArray(b):
-            np.testing.assert_array_equal(a.mask, b.mask)
+        assert_array_equal(a, b)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -47,7 +47,8 @@ class Test(unittest.TestCase):
 
         Returns
         -------
-            The substitute mock instance returned by :func:`unittest.patch.start`.
+            The substitute mock instance returned by
+            :func:`unittest.patch.start`.
 
         """
         # Make the new patch and start it.

--- a/tests/integration/preprocessor/_mask/test_mask.py
+++ b/tests/integration/preprocessor/_mask/test_mask.py
@@ -6,13 +6,11 @@ module.
 
 """
 
-import os
 import tempfile
 import unittest
 
 import iris
 import numpy as np
-import pytest
 
 import tests
 from esmvalcore.preprocessor import (PreprocessorFile, mask_fillvalues,
@@ -24,7 +22,6 @@ def create_temporary_file():
     temp_file = tempfile.NamedTemporaryFile().name + "_sftlf_mask.nc"
 
     return temp_file
-
 
 
 class Test(tests.Test):

--- a/tests/integration/preprocessor/_mask/test_mask.py
+++ b/tests/integration/preprocessor/_mask/test_mask.py
@@ -54,6 +54,30 @@ class Test(tests.Test):
         self.mock_data = np.ma.empty((4, 3, 3))
         self.mock_data[:] = 10.
 
+    def test_components_fx_dict(self):
+        """Test compatibility of unput fx dictionary."""
+        iris.save(self.fx_mask, 'sftlf_test.nc')
+        new_cube_land = iris.cube.Cube(self.new_cube_data,
+                                       dim_coords_and_dims=self.coords_spec)
+        result_land = mask_landsea(
+            new_cube_land,
+            {'sftlf': 'sftlf_test.nc', 'sftof': []},
+            'land'
+        )
+        assert isinstance(result_land, iris.cube.Cube)
+        os.remove('sftlf_test.nc')
+
+        iris.save(self.fx_mask, 'sftgif_test.nc')
+        new_cube_ice = iris.cube.Cube(self.new_cube_data,
+                                      dim_coords_and_dims=self.coords_spec)
+        result_ice = mask_landseaice(
+            new_cube_ice,
+            {'sftgif': 'sftgif_test.nc', 'sftof': []},
+            'ice'
+        )
+        assert isinstance(result_ice, iris.cube.Cube)
+        os.remove('sftgif_test.nc')
+
     def test_mask_landsea(self):
         """Test mask_landsea func."""
         iris.save(self.fx_mask, 'sftlf_test.nc')

--- a/tests/integration/preprocessor/_mask/test_mask.py
+++ b/tests/integration/preprocessor/_mask/test_mask.py
@@ -55,7 +55,7 @@ class Test(tests.Test):
         self.mock_data[:] = 10.
 
     def test_components_fx_dict(self):
-        """Test compatibility of unput fx dictionary."""
+        """Test compatibility of input fx dictionary."""
         iris.save(self.fx_mask, 'sftlf_test.nc')
         new_cube_land = iris.cube.Cube(self.new_cube_data,
                                        dim_coords_and_dims=self.coords_spec)

--- a/tests/integration/preprocessor/_mask/test_mask.py
+++ b/tests/integration/preprocessor/_mask/test_mask.py
@@ -6,27 +6,18 @@ module.
 
 """
 
-import tempfile
-import unittest
-
 import iris
 import numpy as np
+import pytest
 
-import tests
 from esmvalcore.preprocessor import (PreprocessorFile, mask_fillvalues,
                                      mask_landsea, mask_landseaice)
+from tests import assert_array_equal
 
 
-def create_temporary_file():
-    """Create a temporary file with pytest tmp_path."""
-    temp_file = tempfile.NamedTemporaryFile().name + "_sftlf_mask.nc"
-
-    return temp_file
-
-
-class Test(tests.Test):
+class Test:
     """Test class."""
-
+    @pytest.fixture(autouse=True)
     def setUp(self):
         """Assemble a stock cube."""
         fx_data = np.empty((3, 3))
@@ -60,33 +51,39 @@ class Test(tests.Test):
         self.mock_data = np.ma.empty((4, 3, 3))
         self.mock_data[:] = 10.
 
-    def test_components_fx_dict(self):
+    def test_components_fx_dict(self, tmp_path):
         """Test compatibility of input fx dictionary."""
-        sftlf_file = create_temporary_file()
+        sftlf_file = str(tmp_path / 'sftlf_mask.nc')
         iris.save(self.fx_mask, sftlf_file)
         new_cube_land = iris.cube.Cube(self.new_cube_data,
                                        dim_coords_and_dims=self.coords_spec)
         result_land = mask_landsea(
             new_cube_land,
-            {'sftlf': sftlf_file, 'sftof': []},
-            'land'
+            {
+                'sftlf': sftlf_file,
+                'sftof': [],
+            },
+            'land',
         )
         assert isinstance(result_land, iris.cube.Cube)
 
-        sftgif_file = create_temporary_file().replace("sftlf", "sftgif")
+        sftgif_file = str(tmp_path / 'sftgif_mask.nc')
         iris.save(self.fx_mask, sftgif_file)
         new_cube_ice = iris.cube.Cube(self.new_cube_data,
                                       dim_coords_and_dims=self.coords_spec)
         result_ice = mask_landseaice(
             new_cube_ice,
-            {'sftgif': sftgif_file, 'sftof': []},
-            'ice'
+            {
+                'sftgif': sftgif_file,
+                'sftof': [],
+            },
+            'ice',
         )
         assert isinstance(result_ice, iris.cube.Cube)
 
-    def test_mask_landsea(self):
+    def test_mask_landsea(self, tmp_path):
         """Test mask_landsea func."""
-        sftlf_file = create_temporary_file()
+        sftlf_file = str(tmp_path / 'sftlf_mask.nc')
         iris.save(self.fx_mask, sftlf_file)
         new_cube_land = iris.cube.Cube(self.new_cube_data,
                                        dim_coords_and_dims=self.coords_spec)
@@ -94,10 +91,16 @@ class Test(tests.Test):
                                       dim_coords_and_dims=self.coords_spec)
 
         # mask with fx files
-        result_land = mask_landsea(new_cube_land,
-                                   {'sftlf': sftlf_file}, 'land')
-        result_sea = mask_landsea(new_cube_sea,
-                                  {'sftlf': sftlf_file}, 'sea')
+        result_land = mask_landsea(
+            new_cube_land,
+            {'sftlf': sftlf_file},
+            'land',
+        )
+        result_sea = mask_landsea(
+            new_cube_sea,
+            {'sftlf': sftlf_file},
+            'sea',
+        )
         expected = np.ma.empty((3, 3))
         expected.data[:] = 200.
         expected.mask = np.ones((3, 3), bool)
@@ -106,30 +109,36 @@ class Test(tests.Test):
         np.ma.set_fill_value(result_land.data, 1e+20)
         np.ma.set_fill_value(result_sea.data, 1e+20)
         np.ma.set_fill_value(expected, 1e+20)
-        self.assert_array_equal(result_land.data, expected)
+        assert_array_equal(result_land.data, expected)
         expected.mask = np.zeros((3, 3), bool)
         expected.mask[1, 2] = True
-        self.assert_array_equal(result_sea.data, expected)
+        assert_array_equal(result_sea.data, expected)
 
         # Mask with shp files although sftlf is available
         new_cube_land = iris.cube.Cube(self.new_cube_data,
                                        dim_coords_and_dims=self.coords_spec)
         new_cube_sea = iris.cube.Cube(self.new_cube_data,
                                       dim_coords_and_dims=self.coords_spec)
-        result_land = mask_landsea(new_cube_land, {'sftlf': sftlf_file},
-                                   'land',
-                                   always_use_ne_mask=True)
-        result_sea = mask_landsea(new_cube_sea, {'sftlf': sftlf_file},
-                                  'sea',
-                                  always_use_ne_mask=True)
+        result_land = mask_landsea(
+            new_cube_land,
+            {'sftlf': sftlf_file},
+            'land',
+            always_use_ne_mask=True,
+        )
+        result_sea = mask_landsea(
+            new_cube_sea,
+            {'sftlf': sftlf_file},
+            'sea',
+            always_use_ne_mask=True,
+        )
 
         # Bear in mind all points are in the ocean
         np.ma.set_fill_value(result_land.data, 1e+20)
         np.ma.set_fill_value(result_sea.data, 1e+20)
         expected.mask = np.zeros((3, 3), bool)
-        self.assert_array_equal(result_land.data, expected)
+        assert_array_equal(result_land.data, expected)
         expected.mask = np.ones((3, 3), bool)
-        self.assert_array_equal(result_sea.data, expected)
+        assert_array_equal(result_sea.data, expected)
 
         # mask with shp files
         new_cube_land = iris.cube.Cube(self.new_cube_data,
@@ -143,35 +152,35 @@ class Test(tests.Test):
         np.ma.set_fill_value(result_land.data, 1e+20)
         np.ma.set_fill_value(result_sea.data, 1e+20)
         expected.mask = np.zeros((3, 3), bool)
-        self.assert_array_equal(result_land.data, expected)
+        assert_array_equal(result_land.data, expected)
         expected.mask = np.ones((3, 3), bool)
-        self.assert_array_equal(result_sea.data, expected)
+        assert_array_equal(result_sea.data, expected)
 
-    def test_mask_landseaice(self):
+    def test_mask_landseaice(self, tmp_path):
         """Test mask_landseaice func."""
-        sftgif_file = create_temporary_file().replace("sftlf", "sftgif")
+        sftgif_file = str(tmp_path / 'sftgif_mask.nc')
         iris.save(self.fx_mask, sftgif_file)
         new_cube_ice = iris.cube.Cube(self.new_cube_data,
                                       dim_coords_and_dims=self.coords_spec)
-        result_ice = mask_landseaice(new_cube_ice,
-                                     {'sftgif': sftgif_file}, 'ice')
+        result_ice = mask_landseaice(new_cube_ice, {'sftgif': sftgif_file},
+                                     'ice')
         expected = np.ma.empty((3, 3))
         expected.data[:] = 200.
         expected.mask = np.ones((3, 3), bool)
         expected.mask[1, 2] = False
         np.ma.set_fill_value(result_ice.data, 1e+20)
         np.ma.set_fill_value(expected, 1e+20)
-        self.assert_array_equal(result_ice.data, expected)
+        assert_array_equal(result_ice.data, expected)
 
-    def test_mask_fillvalues(self):
+    def test_mask_fillvalues(self, tmp_path):
         """Test the fillvalues mask: func mask_fillvalues."""
         data_1 = data_2 = self.mock_data
         data_2.mask = np.ones((4, 3, 3), bool)
         coords_spec = [(self.times, 0), (self.lats, 1), (self.lons, 2)]
         cube_1 = iris.cube.Cube(data_1, dim_coords_and_dims=coords_spec)
         cube_2 = iris.cube.Cube(data_2, dim_coords_and_dims=coords_spec)
-        filename_1 = tempfile.NamedTemporaryFile().name + '.nc'
-        filename_2 = tempfile.NamedTemporaryFile().name + '.nc'
+        filename_1 = str(tmp_path / 'file1.nc')
+        filename_2 = str(tmp_path / 'file2.nc')
         product_1 = PreprocessorFile(attributes={'filename': filename_1},
                                      settings={})
         product_1.cubes = [cube_1]
@@ -188,10 +197,10 @@ class Test(tests.Test):
                 result_1 = product.cubes[0]
             if product.filename == filename_2:
                 result_2 = product.cubes[0]
-        self.assert_array_equal(result_2.data.mask, data_2.mask)
-        self.assert_array_equal(result_1.data, data_1)
+        assert_array_equal(result_2.data.mask, data_2.mask)
+        assert_array_equal(result_1.data, data_1)
 
-    def test_mask_fillvalues_zero_threshold(self):
+    def test_mask_fillvalues_zero_threshold(self, tmp_path):
         """Test the fillvalues mask: func mask_fillvalues for 0-threshold"""
         data_1 = self.mock_data
         data_2 = self.mock_data[0:3]
@@ -205,17 +214,15 @@ class Test(tests.Test):
         coords_spec2 = [(self.time2, 0), (self.lats, 1), (self.lons, 2)]
         cube_1 = iris.cube.Cube(data_1, dim_coords_and_dims=coords_spec)
         cube_2 = iris.cube.Cube(data_2, dim_coords_and_dims=coords_spec2)
-        filename_1 = tempfile.NamedTemporaryFile().name + '.nc'
-        filename_2 = tempfile.NamedTemporaryFile().name + '.nc'
+        filename_1 = str(tmp_path / 'file1.nc')
+        filename_2 = str(tmp_path / 'file2.nc')
         product_1 = PreprocessorFile(attributes={'filename': filename_1},
                                      settings={})
         product_1.cubes = [cube_1]
         product_2 = PreprocessorFile(attributes={'filename': filename_2},
                                      settings={})
         product_2.cubes = [cube_2]
-        results = mask_fillvalues({product_1, product_2},
-                                  0.,
-                                  min_value=-1.e20)
+        results = mask_fillvalues({product_1, product_2}, 0., min_value=-1.e20)
         result_1, result_2 = None, None
         for product in results:
             if product.filename == filename_1:
@@ -223,13 +230,11 @@ class Test(tests.Test):
             if product.filename == filename_2:
                 result_2 = product.cubes[0]
         # identical masks
-        self.assert_array_equal(result_2.data[0, ...].mask,
-                                result_1.data[0, ...].mask)
+        assert_array_equal(
+            result_2.data[0, ...].mask,
+            result_1.data[0, ...].mask,
+        )
         # identical masks with cumluative
         cumulative_mask = cube_1[1:2].data.mask | cube_2[1:2].data.mask
-        self.assert_array_equal(result_1[1:2].data.mask, cumulative_mask)
-        self.assert_array_equal(result_2[2:3].data.mask, cumulative_mask)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert_array_equal(result_1[1:2].data.mask, cumulative_mask)
+        assert_array_equal(result_2[2:3].data.mask, cumulative_mask)


### PR DESCRIPTION
Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes https://github.com/ESMValGroup/ESMValCore/issues/658 - cheers, Tina for a nice concise issue and even providing a solution! :beer: 
