### PR TITLE
Solve bug in ACCESS1 dataset fix for calendar. 

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/access1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_0.py
@@ -31,7 +31,9 @@ class AllVars(Fix):
             except iris.exceptions.CoordinateNotFoundError:
                 continue
             else:
-                time.units = Unit(time.units.name, 'gregorian')
+                if time.units.calendar == 'proleptic_gregorian':
+                    time.convert_units("days since 1850-01-01", calendar='proleptic_gregorian')
+                    time.units = Unit(time.units.name, 'gregorian')
         return cubes
 
 

--- a/esmvalcore/cmor/_fixes/cmip5/access1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_0.py
@@ -32,7 +32,8 @@ class AllVars(Fix):
                 continue
             else:
                 if time.units.calendar == 'proleptic_gregorian':
-                    time.convert_units("days since 1850-01-01", calendar='proleptic_gregorian')
+                    time.convert_units("days since 1850-01-01",
+                                       calendar='proleptic_gregorian')
                     time.units = Unit(time.units.name, 'gregorian')
         return cubes
 

--- a/esmvalcore/cmor/_fixes/cmip5/access1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_0.py
@@ -32,9 +32,9 @@ class AllVars(Fix):
                 continue
             else:
                 if time.units.calendar == 'proleptic_gregorian':
-                    time.convert_units("days since 1850-01-01",
-                                       calendar='proleptic_gregorian')
-                    time.units = Unit(time.units.name, 'gregorian')
+                    time.convert_units(Unit("days since 1850-01-01",
+                                            calendar='proleptic_gregorian'))
+                time.units = Unit(time.units.name, 'gregorian')
         return cubes
 
 

--- a/esmvalcore/cmor/_fixes/cmip5/access1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_0.py
@@ -34,7 +34,7 @@ class AllVars(Fix):
                 if time.units.calendar == 'proleptic_gregorian':
                     time.convert_units(Unit("days since 1850-01-01",
                                             calendar='proleptic_gregorian'))
-                time.units = Unit(time.units.name, 'gregorian')
+                    time.units = Unit(time.units.name, 'gregorian')
         return cubes
 
 

--- a/esmvalcore/cmor/_fixes/cmip5/access1_3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_3.py
@@ -33,5 +33,7 @@ class AllVars(Fix):
             except iris.exceptions.CoordinateNotFoundError:
                 continue
             else:
-                time.units = Unit(time.units.name, 'gregorian')
+                if time.units.calendar == 'proleptic_gregorian':
+                    time.convert_units("days since 1850-01-01", calendar='proleptic_gregorian')
+                    time.units = Unit(time.units.name, 'gregorian')
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/access1_3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_3.py
@@ -34,6 +34,7 @@ class AllVars(Fix):
                 continue
             else:
                 if time.units.calendar == 'proleptic_gregorian':
-                    time.convert_units("days since 1850-01-01", calendar='proleptic_gregorian')
+                    time.convert_units("days since 1850-01-01",
+                                       calendar='proleptic_gregorian')
                     time.units = Unit(time.units.name, 'gregorian')
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/access1_3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_3.py
@@ -36,5 +36,5 @@ class AllVars(Fix):
                 if time.units.calendar == 'proleptic_gregorian':
                     time.convert_units(Unit("days since 1850-01-01",
                                             calendar='proleptic_gregorian'))
-                time.units = Unit(time.units.name, 'gregorian')
+                    time.units = Unit(time.units.name, 'gregorian')
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/access1_3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_3.py
@@ -34,7 +34,7 @@ class AllVars(Fix):
                 continue
             else:
                 if time.units.calendar == 'proleptic_gregorian':
-                    time.convert_units("days since 1850-01-01",
-                                       calendar='proleptic_gregorian')
-                    time.units = Unit(time.units.name, 'gregorian')
+                    time.convert_units(Unit("days since 1850-01-01",
+                                            calendar='proleptic_gregorian'))
+                time.units = Unit(time.units.name, 'gregorian')
         return cubes

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
@@ -19,7 +19,7 @@ class TestAllVars(unittest.TestCase):
         self.cube = Cube([1.0], var_name='co2', units='J')
         self.cube.add_aux_coord(
             AuxCoord(0, 'time', 'time', 'time',
-                     Unit('days since 1850-01-01', 'julian')))
+                     Unit('days since 0001-01-01', 'proleptic_gregorian')))
         self.fix = AllVars(None)
 
     def test_get(self):

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
@@ -1,8 +1,9 @@
 """Test fixes for ACCESS1-3."""
 import unittest
+from datetime import datetime
 
-from cf_units import Unit
-from iris.coords import AuxCoord
+from cf_units import Unit, date2num, num2date
+from iris.coords import DimCoord
 from iris.cube import Cube
 
 from esmvalcore.cmor._fixes.cmip5.access1_0 import Cl as BaseCl
@@ -15,10 +16,19 @@ class TestAllVars(unittest.TestCase):
 
     def setUp(self):
         """Prepare tests."""
-        self.cube = Cube([1.0], var_name='co2', units='J')
-        self.cube.add_aux_coord(
-            AuxCoord(0, 'time', 'time', 'time',
-                     Unit('days since 1850-01-01', 'julian')))
+        self.cube = Cube([1.0, 2.0], var_name='co2', units='J')
+        reference_dates = [
+            datetime(300, 1, 16, 12),  # e.g. piControl
+            datetime(1850, 1, 16, 12)  # e.g. historical
+        ]
+        esgf_time_units = {
+            'unit': 'days since 0001-01-01',
+            'calendar': 'proleptic_gregorian'
+        }
+        time_points = date2num(reference_dates, **esgf_time_units)
+        self.cube.add_dim_coord(
+            DimCoord(time_points, 'time', 'time', 'time',
+                     Unit(**esgf_time_units)), data_dim=0)
         self.fix = AllVars(None)
 
     def test_get(self):
@@ -28,9 +38,13 @@ class TestAllVars(unittest.TestCase):
             [AllVars(None)])
 
     def test_fix_metadata(self):
-        """Test calendar fix."""
+        """Test fix for bad calendar."""
         cube = self.fix.fix_metadata([self.cube])[0]
-        self.assertEqual(cube.coord('time').units.calendar, 'gregorian')
+        time = cube.coord('time')
+        dates = num2date(time.points, time.units.name, time.units.calendar)
+        self.assertEqual(time.units.calendar, 'gregorian')
+        self.assertEqual(dates[0].strftime('%Y%m%d%H%M'), ' 30001161200')
+        self.assertEqual(dates[1].strftime('%Y%m%d%H%M'), '185001161200')
 
     def test_fix_metadata_if_not_time(self):
         """Test calendar fix do not fail if no time coord present."""


### PR DESCRIPTION
The access1 datasets have time units `Unit('days since 0001-01-01', calendar='proleptic_gregorian')`. The existing fix only changes the calendar, but that results in a wrong interpretation of the time points, where the days are offset by ~2 days. This PR changes the time offset first to 'days since 1850-01-01', using `convert_units` to make sure that time points are updated as well. For the recent period (after 1582 or so), both calendars should be the same, and hence the calendar can now safely be changed to 'gregorian'.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [ ] ~Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.~
-   [ ] ~If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)~
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] ~Please use `yamllint` to check that your YAML files do not contain mistakes~
-   [ ] ~If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below~

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #669 
