### PR TITLE
Updated references to documentation (now docs.esmvaltool.org)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,17 @@
-Before you start, please read [CONTRIBUTING.md](https://github.com/ESMValGroup/ESMValCore/blob/master/CONTRIBUTING.md).
+<!---
+Please do not delete this text completely, but read the text below and keep items that seem relevant.
+If in doubt, just keep everything and add your own text at the top.
+--->
+
+Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).
 
 **Tasks**
 
 -   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
 -   [ ] This pull request has a descriptive title that can be used in a changelog
 -   [ ] Add unit tests
--   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
--   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html)
+-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
+-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
 -   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
 -   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
 -   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
@@ -16,4 +21,4 @@ If you need help with any of the tasks above, please do not hesitate to ask by c
 
 * * *
 
-Closes {Link to corresponding issue}
+Closes #issue_number

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributions are very welcome
 
-Please read our [contribution guidelines](https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/contributing.html).
+Please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The ESMValCore package provides various functions for:
     custom configuration file.
 
 -   Install the [ESMValTool](https://github.com/ESMValGroup/ESMValTool)
-    to run [ESMValTool recipes and diagnostics](https://esmvaltool.readthedocs.io/en/latest/recipes/index.html)
+    to run [ESMValTool recipes and diagnostics](https://docs.esmvaltool.org/en/latest/recipes/index.html)
 
 -   Run e.g. `esmvaltool -c ~/config-user.yml examples/recipe_python.yml` after
     downloading the necessary data.
@@ -59,7 +59,7 @@ The ESMValCore package provides various functions for:
 ## Getting help
 
 The easiest way to get help if you cannot find the answer in the documentation
-on [readthedocs](https://esmvaltool.readthedocs.io), is to open an
+on [readthedocs](https://docs.esmvaltool.org), is to open an
 [issue on GitHub](https://github.com/ESMValGroup/ESMValCore/issues).
 
 ## Contributing

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -419,9 +419,9 @@ intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'esmvaltool':
-    ('https://esmvaltool.readthedocs.io/en/%s/' % rtd_version, None),
+    ('https://docs.esmvaltool.org/en/%s/' % rtd_version, None),
     'esmvalcore':
-    ('https://esmvaltool.readthedocs.io/projects/esmvalcore/en/%s/' %
+    ('https://docs.esmvaltool.org/projects/ESMValCore/en/%s/' %
      rtd_version, None),
 }
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -52,7 +52,7 @@ The standard document on best practices for Python code is
 documentation. We make use of `numpy style
 docstrings <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html>`__
 to document Python functions that are visible on
-`readthedocs <https://esmvaltool.readthedocs.io>`__.
+`readthedocs <https://docs.esmvaltool.org>`__.
 
 Most formatting issues in Python code can be fixed automatically by
 running the commands
@@ -108,14 +108,14 @@ What should be documented
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Any code documentation that is visible on
-`readthedocs <https://esmvaltool.readthedocs.io>`__ should be well
+`readthedocs <https://docs.esmvaltool.org>`__ should be well
 written and adhere to the standards for documentation for the respective
 language. Note that there is no need to write extensive documentation
 for functions that are not visible on readthedocs. However, adding a one
 line docstring describing what a function does is always a good idea.
 When making changes/introducing a new preprocessor function, also update
 the `preprocessor
-documentation <https://esmvaltool.readthedocs.io/projects/esmvalcore/en/latest/esmvalcore/preprocessor.html>`__.
+documentation <https://docs.esmvaltool.org/projects/ESMValCore/en/latest/recipe/preprocessor.html>`__.
 
 How to build the documentation locally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/develop/fixing_data.rst
+++ b/doc/develop/fixing_data.rst
@@ -23,7 +23,7 @@ known errors that can be fixed automatically.
   Implementing CMORization as a fix removes this redundancy, as the fixes are applied 'on the fly' when
   running a recipe. **ERA5** is the first dataset for which this 'CMORization on the fly' is supported.
   For more information about CMORization, see:
-  `Contributing a CMORizing script for an observational dataset <https://esmvaltool.readthedocs.io/en/latest/esmvaldiag/observations.html>`_.
+  `Contributing a CMORizing script for an observational dataset <https://docs.esmvaltool.org/en/latest/input.html#observations>`_.
 
 Fix structure
 =============

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -18,7 +18,7 @@ CORE DEVELOPMENT TEAM AND CONTACTS:
   Klaus Zimmermann (SMHI, Sweden - klaus.zimmermann@smhi.se)
 
 For further help, please read the documentation at
-http://esmvaltool.readthedocs.io. Have fun!
+http://docs.esmvaltool.org. Have fun!
 """
 
 # ESMValTool main script


### PR DESCRIPTION
Changed references to documentation from esmvaltool.readthedocs.io to docs.esmvaltool.org. This closes https://github.com/ESMValGroup/ESMValCore/issues/315.