### PR TITLE
Fixed bug in time weights calculation

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -172,14 +172,13 @@ def get_time_weights(cube):
         Array of time weights for averaging.
     """
     time = cube.coord('time')
-    coord_dims = cube.coord_dims('time')
     time_weights = time.bounds[..., 1] - time.bounds[..., 0]
     time_weights = time_weights.squeeze()
-    if coord_dims == ():
-        time_weights = np.broadcast_to(time_weights, cube.shape)
+    if time_weights.shape == ():
+        time_weights = da.broadcast_to(time_weights, cube.shape)
     else:
         time_weights = iris.util.broadcast_to_shape(time_weights, cube.shape,
-                                                    coord_dims)
+                                                    cube.coord_dims('time'))
     return time_weights
 
 

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -172,8 +172,14 @@ def get_time_weights(cube):
         Array of time weights for averaging.
     """
     time = cube.coord('time')
-    time_thickness = time.bounds[..., 1] - time.bounds[..., 0]
-    time_weights = time_thickness * da.ones_like(cube.data)
+    coord_dims = cube.coord_dims('time')
+    time_weights = time.bounds[..., 1] - time.bounds[..., 0]
+    time_weights = time_weights.squeeze()
+    if coord_dims == ():
+        time_weights = np.broadcast_to(time_weights, cube.shape)
+    else:
+        time_weights = iris.util.broadcast_to_shape(time_weights, cube.shape,
+                                                    coord_dims)
     return time_weights
 
 

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -3,7 +3,6 @@
 import copy
 import unittest
 
-import dask.array as da
 import iris
 import iris.coord_categorisation
 import iris.coords


### PR DESCRIPTION
This PR fixes the the bug in the calculation of the time weights introduced by #684. I know that this implementation does not use `dask` anymore, but unfortunately [`iris.util.broadcast_to_shape`](https://scitools.org.uk/iris/docs/latest/iris/iris/util.html#iris.util.broadcast_to_shape) does not support `dask`.

This needs to be included for `v2.0.0`.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #694.