### PR TITLE
Avoid pytest version that crashes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ REQUIREMENTS = {
     # Test dependencies
     # Execute 'python setup.py test' to run tests
     'test': [
-        'pytest>=3.9',
+        'pytest>=3.9,!=6.0.0rc1',
         'pytest-cov',
         'pytest-env',
         'pytest-flake8',


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

The unit tests on CircleCI are failing with pytest==6.0.0rc1, so avoid that version.

**Tasks**

-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
