### PR TITLE
Produce a readable warning if ancestors are a string instead of a list.

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -583,8 +583,8 @@ class DiagnosticTask(BaseTask):
                 logger.warning(
                     "Ancestor file(s) %s specified for recording provenance "
                     "of %s, created by diagnostic script %s in task %s is "
-                    "a string instead of a list", ancestor_files, filename,
-                    self.script, self.name)
+                    "a string but should be a list of strings", ancestor_files,
+                    filename, self.script, self.name)
                 ancestor_files = [ancestor_files]
             for ancestor_file in ancestor_files:
                 if ancestor_file in ancestor_products:

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -579,6 +579,14 @@ class DiagnosticTask(BaseTask):
                     self.script, self.name)
                 valid = False
             ancestors = set()
+            if isinstance(ancestor_files, str):
+                valid = False
+                logger.warning(
+                    "Ancestor file(s) %s specified for recording provenance "
+                    "of %s, created by diagnostic script %s in task %s is "
+                    "a string instead of a list", ancestor_files, filename,
+                     self.script, self.name)
+                ancestor_files = [ancestor_files] 
             for ancestor_file in ancestor_files:
                 if ancestor_file in ancestor_products:
                     ancestors.add(ancestor_products[ancestor_file])

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -580,13 +580,12 @@ class DiagnosticTask(BaseTask):
                 valid = False
             ancestors = set()
             if isinstance(ancestor_files, str):
-                valid = False
                 logger.warning(
                     "Ancestor file(s) %s specified for recording provenance "
                     "of %s, created by diagnostic script %s in task %s is "
                     "a string instead of a list", ancestor_files, filename,
-                     self.script, self.name)
-                ancestor_files = [ancestor_files] 
+                    self.script, self.name)
+                ancestor_files = [ancestor_files]
             for ancestor_file in ancestor_files:
                 if ancestor_file in ancestor_products:
                     ancestors.add(ancestor_products[ancestor_file])


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

Tested with recipe_hyint.yml (how do I make a unit test?).

Documentation is not effected because it should just change a warning? 
* * *

Closes  #686 and helps to create better readable warnings for some of the warnings reported in e.g https://github.com/ESMValGroup/ESMValTool/issues/1716 
