### PR TITLE
Expanded cmor public API

### DIFF
--- a/doc/api/esmvalcore.cmor.rst
+++ b/doc/api/esmvalcore.cmor.rst
@@ -8,10 +8,15 @@ Checking compliance
 
 .. automodule:: esmvalcore.cmor.check
 
-Fixing issues 
--------------
+Automatically fixing issues
+---------------------------
 
 .. automodule:: esmvalcore.cmor.fix
+
+Functions for fixing issues
+---------------------------
+
+.. automodule:: esmvalcore.cmor.fixes
 
 Using CMOR tables
 -----------------

--- a/esmvalcore/cmor/__init__.py
+++ b/esmvalcore/cmor/__init__.py
@@ -1,10 +1,1 @@
 """CMOR module."""
-
-from esmvalcore.cmor._fixes.shared import (add_plev_from_altitude,
-                                           add_sigma_factory)
-
-
-__all__ = [
-    'add_plev_from_altitude',
-    'add_sigma_factory',
-]

--- a/esmvalcore/cmor/__init__.py
+++ b/esmvalcore/cmor/__init__.py
@@ -1,1 +1,10 @@
-"""CMOR module"""
+"""CMOR module."""
+
+from esmvalcore.cmor._fixes.shared import (add_plev_from_altitude,
+                                           add_sigma_factory)
+
+
+__all__ = [
+    'add_plev_from_altitude',
+    'add_sigma_factory',
+]

--- a/esmvalcore/cmor/fixes.py
+++ b/esmvalcore/cmor/fixes.py
@@ -1,0 +1,8 @@
+"""Functions for fixing specific issues with datasets."""
+
+from ._fixes.shared import add_plev_from_altitude, add_sigma_factory
+
+__all__ = [
+    'add_plev_from_altitude',
+    'add_sigma_factory',
+]

--- a/tests/unit/cmor/test_fixes.py
+++ b/tests/unit/cmor/test_fixes.py
@@ -1,0 +1,12 @@
+"""Test individual fix functions."""
+import pytest
+
+import esmvalcore.cmor.fixes
+
+
+@pytest.mark.parametrize('func', [
+    'add_plev_from_altitude',
+    'add_sigma_factory',
+])
+def test_imports(func):
+    assert func in esmvalcore.cmor.fixes.__all__


### PR DESCRIPTION
Added `add_plev_from_altitude` and `add_sigma_factory` to public API necessary for ESMValGroup/ESMValTool#1585. Needs to be included for the `v2.0.0` release.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Necessary for ESMValGroup/ESMValTool#1585.