### PR TITLE
Reduce size of docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,21 +2,11 @@
 # docker build -t ${TAG_OF_YOUR_CHOICE} . -f docker/Dockerfile
 FROM continuumio/miniconda3
 
-# update the conda packages
-RUN conda update -y conda pip
-
-
-# install environment packages
-COPY . /home/root/source
-WORKDIR /home/root/source
+COPY . /src/ESMValCore
+WORKDIR /src/ESMValCore
 RUN ls
-RUN conda env update --name base --file environment.yml
-RUN pip install .
-RUN conda clean --all -y
-RUN rm -r /home/root/source
-
-# run tests
-RUN esmvaltool -h
+RUN conda update -y conda pip && conda env update --name base --file environment.yml && conda clean --all -y
+RUN pip install . && pip cache purge
 
 ENTRYPOINT ["esmvaltool"]
 CMD ["-h"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,6 @@ FROM continuumio/miniconda3
 
 COPY . /src/ESMValCore
 WORKDIR /src/ESMValCore
-RUN ls
 RUN conda update -y conda pip && conda env update --name base --file environment.yml && conda clean --all -y
 RUN pip install . && pip cache purge
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
-# To build this container, go to ESMValCore root folder and execute :
-# docker build -t ${TAG_OF_YOUR_CHOICE} . -f docker/Dockerfile
+# To build this container, go to ESMValCore root folder and execute:
+# docker build -t esmvalcore:latest . -f docker/Dockerfile
 FROM continuumio/miniconda3
 
-COPY . /src/ESMValCore
 WORKDIR /src/ESMValCore
+COPY environment.yml .
 RUN conda update -y conda pip && conda env update --name base --file environment.yml && conda clean --all -y
+COPY . .
 RUN pip install . && pip cache purge
 
 ENTRYPOINT ["esmvaltool"]
-CMD ["-h"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,9 +1,9 @@
-# To build this container, go to ESMValCore root folder and execute :
-# docker build -t ${TAG_OF_YOUR_CHOICE} . -f docker/Dockerfile.dev
+# To build this container, go to ESMValCore root folder and execute:
+# docker build -t esmvalcore:development . -f docker/Dockerfile.dev
 FROM continuumio/miniconda3
 
-COPY . /src/ESMValCore
 WORKDIR /src/ESMValCore
-
+COPY environment.yml .
 RUN conda update -y conda pip && conda env update --name base --file environment.yml && conda clean --all -y
+COPY . .
 RUN pip install .[test] && pip uninstall esmvalcore -y && pip cache purge

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -2,19 +2,8 @@
 # docker build -t ${TAG_OF_YOUR_CHOICE} . -f docker/Dockerfile.dev
 FROM continuumio/miniconda3
 
-# update the conda packages
-RUN conda update -y conda pip
+COPY . /src/ESMValCore
+WORKDIR /src/ESMValCore
 
-# Copy source
-COPY . /home/root/source
-WORKDIR /home/root/source
-
-# Install
-RUN apt-get update
-RUN conda env update --name base --file environment.yml
-RUN pip install -e .[test]
-RUN pip uninstall esmvalcore -y
-
-# Clean up
-RUN rm -r /home/root/source
-RUN conda clean --all -y
+RUN conda update -y conda pip && conda env update --name base --file environment.yml && conda clean --all -y
+RUN pip install .[test] && pip uninstall esmvalcore -y && pip cache purge

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ REQUIREMENTS = {
     # Test dependencies
     # Execute 'python setup.py test' to run tests
     'test': [
-        'pytest>=3.9,!=6.0.0rc1',
+        'pytest>=3.9,!=6.0.0rc1,!=6.0.0',
         'pytest-cov',
         'pytest-env',
         'pytest-flake8',


### PR DESCRIPTION
This is a small refactor of the docker file that reduces the size of the docker image from 1.1 GB to ~800 MB (as stated in Docker Hub). 


**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *


