### PR TITLE
Fix crash for FGOALS-g2 variables without longitude coordinate

### DIFF
--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -443,7 +443,7 @@ def round_coordinates(cubes, decimals=5, coord_names=None):
         if not coord_names:
             coords = cube.coords(dim_coords=True)
         else:
-            coords = [cube.coord(name) for name in coord_names]
+            coords = [cube.coord(c) for c in coord_names if cube.coords(c)]
         for coord in coords:
             coord.points = da.round(da.asarray(coord.core_points()), decimals)
             if coord.bounds is not None:

--- a/tests/integration/cmor/_fixes/cmip5/test_fgoals_g2.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_fgoals_g2.py
@@ -45,6 +45,11 @@ class TestAll(unittest.TestCase):
                          'day since 1-01-01 00:00:00.000000')
         self.assertEqual(time.units.calendar, 'gregorian')
 
+    def test_fix_metadata_dont_fail_if_not_longitude(self):
+        """Test calendar fix."""
+        self.cube.remove_coord('longitude')
+        self.fix.fix_metadata([self.cube])
+
     def test_fix_metadata_dont_fail_if_not_time(self):
         """Test calendar fix."""
         self.cube.remove_coord('time')


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Closes #728 

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
