### PR TITLE
Add 'test' extra to installation, used by docker development tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,6 +203,7 @@ setup(
     tests_require=REQUIREMENTS['test'],
     extras_require={
         'develop': REQUIREMENTS['develop'] + REQUIREMENTS['test'],
+        'test': REQUIREMENTS['test'],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

The `development` docker container uses a [test] extra, but it was not provided by setup.py.

**Tasks**

-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
