### PR TITLE
added RMS iris analysis operator

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1000,7 +1000,7 @@ Parameters:
     * filter_type: the type of filter to be applied; default 'lowpass'.
       Available types: 'lowpass'.
     * filter_stats: the type of statistic to aggregate on the rolling window;
-      default 'sum'. Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'.
+      default 'sum'. Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
 
 Examples:
     * Lowpass filter with a monthly mean as operator:
@@ -1127,7 +1127,7 @@ Parameters:
 The function calculates the zonal statistics by applying an operator
 along the longitude coordinate. This function takes one argument:
 
-* ``operator``: Which operation to apply: mean, std_dev, median, min, max or sum
+* ``operator``: Which operation to apply: mean, std_dev, median, min, max, sum or rms.
 
 See also :func:`esmvalcore.preprocessor.zonal_means`.
 
@@ -1139,7 +1139,7 @@ The function calculates the meridional statistics by applying an
 operator along the latitude coordinate. This function takes one
 argument:
 
-* ``operator``: Which operation to apply: mean, std_dev, median, min, max or sum
+* ``operator``: Which operation to apply: mean, std_dev, median, min, max, sum or rms.
 
 See also :func:`esmvalcore.preprocessor.meridional_means`.
 

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -798,7 +798,7 @@ This function produces statistics for each day in the dataset.
 
 Parameters:
     * operator: operation to apply. Accepted values are 'mean',
-      'median', 'std_dev', 'min', 'max' and 'sum'. Default is 'mean'
+      'median', 'std_dev', 'min', 'max', 'sum' and 'rms'. Default is 'mean'
 
 See also :func:`esmvalcore.preprocessor.daily_statistics`.
 
@@ -811,7 +811,7 @@ This function produces statistics for each month in the dataset.
 
 Parameters:
     * operator: operation to apply. Accepted values are 'mean',
-      'median', 'std_dev', 'min', 'max' and 'sum'. Default is 'mean'
+      'median', 'std_dev', 'min', 'max', 'sum' and 'rms'. Default is 'mean'
 
 See also :func:`esmvalcore.preprocessor.monthly_statistics`.
 
@@ -831,7 +831,7 @@ December and remove such biased initial datapoints.
 
 Parameters:
     * operator: operation to apply. Accepted values are 'mean',
-      'median', 'std_dev', 'min', 'max' and 'sum'. Default is 'mean'
+      'median', 'std_dev', 'min', 'max', 'sum' and 'rms'. Default is 'mean'
 
 See also :func:`esmvalcore.preprocessor.seasonal_mean`.
 
@@ -844,7 +844,7 @@ This function produces statistics for each year.
 
 Parameters:
     * operator: operation to apply. Accepted values are 'mean',
-      'median', 'std_dev', 'min', 'max' and 'sum'. Default is 'mean'
+      'median', 'std_dev', 'min', 'max', 'sum' and 'rms'. Default is 'mean'
 
 See also :func:`esmvalcore.preprocessor.annual_statistics`.
 
@@ -857,7 +857,7 @@ This function produces statistics for each decade.
 
 Parameters:
     * operator: operation to apply. Accepted values are 'mean',
-      'median', 'std_dev', 'min', 'max' and 'sum'. Default is 'mean'
+      'median', 'std_dev', 'min', 'max', 'sum' and 'rms'. Default is 'mean'
 
 See also :func:`esmvalcore.preprocessor.decadal_statistics`.
 
@@ -871,7 +871,7 @@ This function produces statistics for the whole dataset. It can produce scalars
 
 Parameters:
     * operator: operation to apply. Accepted values are 'mean', 'median',
-      'std_dev', 'min', 'max' and 'sum'. Default is 'mean'
+      'std_dev', 'min', 'max', 'sum' and 'rms'. Default is 'mean'
 
     * period: define the granularity of the statistics: get values for the
       full period, for each month or day of year.
@@ -1152,7 +1152,7 @@ areas of the region. This function takes the argument, ``operator``: the name
 of the operation to apply.
 
 This function can be used to apply several different operations in the
-horizontal plane: mean, standard deviation, median variance, minimum and maximum.
+horizontal plane: mean, standard deviation, median, variance, minimum, maximum and root mean square.
 
 Note that this function is applied over the entire dataset. If only a specific
 region, depth layer or time period is required, then those regions need to be

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -99,7 +99,8 @@ def zonal_statistics(cube, operator):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
+        Available operators:
+            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
 
     Returns
     -------
@@ -133,7 +134,8 @@ def meridional_statistics(cube, operator):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
+        Available operators:
+            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
 
     Returns
     -------

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -99,8 +99,8 @@ def zonal_statistics(cube, operator):
 
     operator: str, optional
         Select operator to apply.
-        Available operators:
-            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'.
 
     Returns
     -------
@@ -134,8 +134,8 @@ def meridional_statistics(cube, operator):
 
     operator: str, optional
         Select operator to apply.
-        Available operators:
-            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'.
 
     Returns
     -------

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -99,7 +99,7 @@ def zonal_statistics(cube, operator):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'.
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
 
     Returns
     -------
@@ -133,7 +133,7 @@ def meridional_statistics(cube, operator):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'.
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'.
 
     Returns
     -------
@@ -224,6 +224,8 @@ def area_statistics(cube, operator, fx_variables=None):
     +------------+--------------------------------------------------+
     | `max`      | Maximum value                                    |
     +------------+--------------------------------------------------+
+    | `rms`      | Area weighted root mean square.                  |
+    +------------+--------------------------------------------------+
 
     Parameters
     ----------
@@ -231,7 +233,7 @@ def area_statistics(cube, operator, fx_variables=None):
             Input cube.
         operator: str
             The operation, options: mean, median, min, max, std_dev, sum,
-            variance
+            variance, rms.
         fx_variables: dict
             dictionary of field:filename for the fx_variables
 

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -40,9 +40,9 @@ def get_iris_analysis_operation(operator):
     ------
     ValueError
         operator not in allowed operators list.
-        allowed operators: mean, median, std_dev, sum, variance, min, max
+        allowed operators: mean, median, std_dev, sum, variance, min, max, rms
     """
-    operators = ['mean', 'median', 'std_dev', 'sum', 'variance', 'min', 'max']
+    operators = ['mean', 'median', 'std_dev', 'sum', 'variance', 'min', 'max', 'rms']
     operator = operator.lower()
     if operator not in operators:
         raise ValueError("operator {} not recognised. "
@@ -66,4 +66,4 @@ def operator_accept_weights(operator):
         bool: True if operator support weights, False otherwise
 
     """
-    return operator.lower() in ('mean', 'sum')
+    return operator.lower() in ('mean', 'sum', 'rms')

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -42,7 +42,9 @@ def get_iris_analysis_operation(operator):
         operator not in allowed operators list.
         allowed operators: mean, median, std_dev, sum, variance, min, max, rms
     """
-    operators = ['mean', 'median', 'std_dev', 'sum', 'variance', 'min', 'max', 'rms']
+    operators = [
+        'mean', 'median', 'std_dev', 'sum', 'variance', 'min', 'max', 'rms'
+    ]
     operator = operator.lower()
     if operator not in operators:
         raise ValueError("operator {} not recognised. "

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -195,8 +195,8 @@ def daily_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators:
-            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'
 
     Returns
     -------
@@ -229,8 +229,8 @@ def monthly_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators:
-            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'
 
     Returns
     -------
@@ -260,8 +260,8 @@ def seasonal_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators:
-            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'
 
     Returns
     -------
@@ -316,8 +316,8 @@ def annual_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators:
-            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'
 
     Returns
     -------
@@ -349,8 +349,8 @@ def decadal_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators:
-            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'
 
     Returns
     -------
@@ -389,8 +389,8 @@ def climate_statistics(cube, operator='mean', period='full'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators:
-            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'
 
     period: str, optional
         Period to compute the statistic over.

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -682,7 +682,8 @@ def timeseries_filter(cube, window, span,
         Available types: 'lowpass'.
     filter_stats: str, optional
         Type of statistic to aggregate on the rolling window; default 'sum'.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min',
+        'max', 'rms'
 
     Returns
     -------

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -195,7 +195,8 @@ def daily_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators:
+            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -228,7 +229,8 @@ def monthly_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators:
+            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -258,7 +260,8 @@ def seasonal_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators:
+            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -313,7 +316,8 @@ def annual_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators:
+            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -345,7 +349,8 @@ def decadal_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators:
+            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -384,7 +389,8 @@ def climate_statistics(cube, operator='mean', period='full'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
+        Available operators:
+            'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     period: str, optional
         Period to compute the statistic over.

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -195,7 +195,7 @@ def daily_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -228,7 +228,7 @@ def monthly_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -258,7 +258,7 @@ def seasonal_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -313,7 +313,7 @@ def annual_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -345,7 +345,7 @@ def decadal_statistics(cube, operator='mean'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     Returns
     -------
@@ -384,7 +384,7 @@ def climate_statistics(cube, operator='mean', period='full'):
 
     operator: str, optional
         Select operator to apply.
-        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max'
+        Available operators: 'mean', 'median', 'std_dev', 'sum', 'min', 'max', 'rms'
 
     period: str, optional
         Period to compute the statistic over.

--- a/tests/unit/preprocessor/_area/test_area.py
+++ b/tests/unit/preprocessor/_area/test_area.py
@@ -107,6 +107,12 @@ class Test(tests.Test):
         expected = np.array([1.])
         self.assert_array_equal(result.data, expected)
 
+    def test_area_statistics_rms(self):
+        """Test for area rms of a 2D field."""
+        result = area_statistics(self.grid, 'rms')
+        expected = np.array([1.])
+        self.assert_array_equal(result.data, expected)
+
     def test_extract_region(self):
         """Test for extracting a region from a 2D field."""
         result = extract_region(self.grid, 1.5, 2.5, 1.5, 2.5)

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -372,6 +372,17 @@ class TestClimatology(tests.Test):
         expected = np.array([1.])
         assert_array_equal(result.data, expected)
 
+    def test_time_rms(self):
+        """Test for time rms of a 1D field."""
+        data = np.arange((3))
+        times = np.array([15., 45., 75.])
+        bounds = np.array([[0., 30.], [30., 60.], [60., 90.]])
+        cube = self._create_cube(data, times, bounds)
+
+        result = climate_statistics(cube, operator='rms')
+        expected = np.array([(5/3)**0.5])
+        assert_array_equal(result.data, expected)
+
 
 class TestSeasonalStatistics(tests.Test):
     """Test :func:`esmvalcore.preprocessor._time.seasonal_statistics`"""


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Adding RMS iris analysis operator (which allow Area Weighting) to the preprocessor. This allows computing root mean squares in the _area.py and _time.py preprocessors.

**Tasks**
-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

* * *

closes https://github.com/ESMValGroup/ESMValCore/issues/739