### PR TITLE
Introduce a parallel loop to do esmpy regridding for many levels

### DIFF
--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -3,7 +3,6 @@
 
 import concurrent.futures
 import itertools
-import time as tr
 
 import ESMF
 import iris
@@ -227,7 +226,6 @@ def build_regridder_3d(src_rep, dst_rep, regrid_method, mask_threshold):
 
 def build_regridder(src_rep, dst_rep, method, mask_threshold=.99):
     """Build regridders from representants."""
-    t1 = tr.time()
     regrid_method = ESMF_REGRID_METHODS[method]
     if src_rep.ndim == 2:
         regridder = build_regridder_2d((src_rep, dst_rep), regrid_method,
@@ -235,8 +233,6 @@ def build_regridder(src_rep, dst_rep, method, mask_threshold=.99):
     elif src_rep.ndim == 3:
         regridder = build_regridder_3d(src_rep, dst_rep, regrid_method,
                                        mask_threshold)
-    t2 = tr.time()
-    print("ESMF REGRIDDER TIME for DIM", str(src_rep.ndim), t2 - t1)
     return regridder
 
 

--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -210,7 +210,7 @@ def build_regridder_3d(src_rep, dst_rep, regrid_method, mask_threshold):
                                       iter_pack,
                                       itertools.repeat(regrid_method),
                                       itertools.repeat(mask_threshold),
-                                      chunksize=100000000):
+                                      chunksize=100):
             esmf_regridders.append(regridder)
 
     def regridder(src):

--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -203,7 +203,6 @@ def build_regridder_3d(src_rep, dst_rep, regrid_method, mask_threshold):
     # get the iterator
     iter_pack = ((src_rep[level], dst_rep[level])
                  for level in range(no_levels))
-    print("Number of levels to be parallelized:", len(list(iter_pack)))
 
     # run regridder building in parallel
     with concurrent.futures.ProcessPoolExecutor(max_workers=8) as executor:

--- a/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
+++ b/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
@@ -455,7 +455,7 @@ class TestHelpers(tests.Test):
         self.cube.data = self.cube.data.data
         self.cube.field = mock.Mock()
         mock.sentinel.dst_rep.field = mock.Mock()
-        build_regridder_2d(self.cube, mock.sentinel.dst_rep,
+        build_regridder_2d((self.cube, mock.sentinel.dst_rep),
                            mock.sentinel.regrid_method, .99)
         expected_kwargs = {
             'src_mask_values': np.array([1]),
@@ -480,7 +480,7 @@ class TestHelpers(tests.Test):
         dst_rep = mock.MagicMock()
         src_rep.field = mock.MagicMock(data=self.data.copy())
         dst_rep.field = mock.MagicMock()
-        build_regridder_2d(src_rep, dst_rep, regrid_method, .99)
+        build_regridder_2d((src_rep, dst_rep), regrid_method, .99)
         expected_calls = [
             mock.call(src_mask_values=np.array([]),
                       dst_mask_values=np.array([]),
@@ -518,7 +518,7 @@ class TestHelpers(tests.Test):
         regrid_method = mock.sentinel.rm_bilinear
         src_rep = mock.MagicMock(data=self.data, dtype=np.float32)
         dst_rep = mock.MagicMock(shape=(4, 4))
-        regridder = build_regridder_2d(src_rep, dst_rep, regrid_method, .99)
+        regridder = build_regridder_2d((src_rep, dst_rep), regrid_method, .99)
         field_regridder.reset_mock()
         regridder(src_rep)
         field_regridder.assert_called_once_with(src_rep.field, dst_rep.field)
@@ -533,7 +533,7 @@ class TestHelpers(tests.Test):
         regrid_method = mock.sentinel.rm_bilinear
         src_rep = mock.MagicMock(data=self.data)
         dst_rep = mock.MagicMock(shape=(4, 4))
-        regridder = build_regridder_2d(src_rep, dst_rep, regrid_method, .99)
+        regridder = build_regridder_2d((src_rep, dst_rep), regrid_method, .99)
         field_regridder.reset_mock()
         regridder(self.cube)
         field_regridder.assert_called_once_with(src_rep.field, dst_rep.field)
@@ -547,7 +547,7 @@ class TestHelpers(tests.Test):
         dst_rep = mock.Mock(ndim=2)
         build_regridder(src_rep, dst_rep, 'nearest')
         mock_regridder_2d.assert_called_once_with(
-            src_rep, dst_rep, mock.sentinel.rm_nearest_stod, .99)
+            (src_rep, dst_rep), mock.sentinel.rm_nearest_stod, .99)
         mock_regridder_3d.assert_not_called()
 
     @mock.patch('esmvalcore.preprocessor._regrid_esmpy.build_regridder_3d')


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [ ] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #issue_number #724 

This PR introduces a parallel loop that assembles the esmpy regridders from multiple processes, this is needed because in the case of eg 75 levels one needs to wait forever and a half. This speeds up the regridder assembly from 400s to 1s :beer: 
