### PR TITLE
Use dask to reduce memory consumption of extract_levels for masked data

### DIFF
--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -436,7 +436,7 @@ def _vertical_interpolate(cube, src_levels, levels, interpolation,
     # force mask onto data as nan's
     if da.ma.getmaskarray(cube.core_data()).any():
         if cube.has_lazy_data():
-            cube.core_data()[da.ma.getmaskarray(cube.core_data())] = np.nan
+            cube.data = da.ma.filled(cube.core_data(), np.nan)
         else:
             cube.data[cube.data.mask] = np.nan
 

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -434,11 +434,7 @@ def _vertical_interpolate(cube, src_levels, levels, interpolation,
         src_levels.points, cube.shape, cube.coord_dims(src_levels))
 
     # force mask onto data as nan's
-    if da.ma.getmaskarray(cube.core_data()).any():
-        if cube.has_lazy_data():
-            cube.data = da.ma.filled(cube.core_data(), np.nan)
-        else:
-            cube.data[cube.data.mask] = np.nan
+    cube.data = da.ma.filled(cube.core_data(), np.nan)
 
     # Now perform the actual vertical interpolation.
     new_data = stratify.interpolate(

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -435,7 +435,7 @@ def _vertical_interpolate(cube, src_levels, levels, interpolation,
 
     # force mask onto data as nan's
     if da.ma.getmaskarray(cube.core_data()).any():
-        cube.core_data()[da.ma.getmaskarray(cube.core_data())] = np.nan
+        cube.core_data()[tuple(da.ma.getmaskarray(cube.core_data()))] = np.nan
 
     # Now perform the actual vertical interpolation.
     new_data = stratify.interpolate(

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -435,7 +435,10 @@ def _vertical_interpolate(cube, src_levels, levels, interpolation,
 
     # force mask onto data as nan's
     if da.ma.getmaskarray(cube.core_data()).any():
-        cube.core_data()[da.ma.getmaskarray(cube.core_data())] = np.nan
+        if cube.has_lazy_data():
+            cube.core_data()[da.ma.getmaskarray(cube.core_data())] = np.nan
+        else:
+            cube.data[cube.data.mask] = np.nan
 
     # Now perform the actual vertical interpolation.
     new_data = stratify.interpolate(

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 import numpy as np
 import stratify
 import iris
+from dask import array as da
 from iris.analysis import AreaWeighted, Linear, Nearest, UnstructuredNearest
 from iris.util import broadcast_to_shape
 
@@ -433,14 +434,14 @@ def _vertical_interpolate(cube, src_levels, levels, interpolation,
         src_levels.points, cube.shape, cube.coord_dims(src_levels))
 
     # force mask onto data as nan's
-    if np.ma.is_masked(cube.data):
-        cube.data[cube.data.mask] = np.nan
+    if da.ma.getmaskarray(cube.core_data()).any():
+        cube.core_data()[da.ma.getmaskarray(cube.core_data())] = np.nan
 
     # Now perform the actual vertical interpolation.
     new_data = stratify.interpolate(
         levels,
         src_levels_broadcast,
-        cube.data,
+        cube.core_data(),
         axis=z_axis,
         interpolation=interpolation,
         extrapolation=extrapolation)

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -435,7 +435,7 @@ def _vertical_interpolate(cube, src_levels, levels, interpolation,
 
     # force mask onto data as nan's
     if da.ma.getmaskarray(cube.core_data()).any():
-        cube.core_data()[tuple(da.ma.getmaskarray(cube.core_data()))] = np.nan
+        cube.core_data()[da.ma.getmaskarray(cube.core_data())] = np.nan
 
     # Now perform the actual vertical interpolation.
     new_data = stratify.interpolate(


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

**partially addressing** #775 

Mostly appreciated by ocean people, I noticed a memory consumption reduction by about 30% for level selection.
