### PR TITLE
Replace vmprof with vprof

### DIFF
--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -96,16 +96,13 @@ with explanations in a commented line above each option:
   # the amount of memory available in your system.
   max_parallel_tasks: null
 
-  # Use a profiling tool for the diagnostic run [false]/true; profilers tell you where
-  # the stress points of the code are (high CPU usage, high memory intake etc);
-  # for this purpose we use vprof, see below for notes
-  profile_diagnostic: true
-
   # Path to custom config-developer file, to customise project configurations.
   # See config-developer.yml for an example. Set to None to use the default
   config_developer_file: null
 
-  # Get profiling information for diagnostics
+  # Use a profiling tool for the diagnostic run [false]/true
+  # A profiler tells you which functions in your code take most time to run.
+  # For this purpose we use vprof, see below for notes
   # Only available for Python diagnostics
   profile_diagnostic: false
 
@@ -152,12 +149,21 @@ downloaded at runtime.
    This setting is not for model or observational datasets, rather it is for
    data files used in plotting such as coastline descriptions and so on.
 
-The ``profile_diagnostic`` setting triggers profiling of Python diagnostics;
-this will give you information on the resources used while running the diagnostic
-(including execution time of different code blocks, memory, CPU usage); for this
-purpose we use `vprof <https://github.com/nvdv/vprof>`_. The profiler outputs
-a json file that can be used to extract the profiling information via e.g.
-``vprof --input-file esmvaltool_output/recipe_output/run/diagnostic/script/profile.json``.
+The ``profile_diagnostic`` setting triggers profiling of Python diagnostics,
+this will tell you which functions in the diagnostic took most time to run.
+For this purpose we use `vprof <https://github.com/nvdv/vprof>`_.
+For each diagnostic script in the recipe, the profiler writes a ``.json`` file
+that can be used to plot a
+`flame graph <https://queue.acm.org/detail.cfm?id=2927301>`__
+of the profiling information by running
+
+.. code-block:: bash
+
+  vprof --input-file esmvaltool_output/recipe_output/run/diagnostic/script/profile.json
+
+Note that it is also possible to use vprof to understand other resources used
+while running the diagnostic, including execution time of different code blocks
+and memory usage.
 
 A detailed explanation of the data finding-related sections of the
 ``config-user.yml`` (``rootpath`` and ``drs``) is presented in the
@@ -198,10 +204,10 @@ Users can get a copy of this file with default values by running
 
 .. code-block:: bash
 
-  ``esmvaltool config get-config-developer --path=${TARGET_FOLDER}``.
+  esmvaltool config get-config-developer --path=${TARGET_FOLDER}
 
 If the option ``--path`` is omitted, the file will be created in
-`${HOME}/.esmvaltool`
+```${HOME}/.esmvaltool``.
 
 .. note::
 
@@ -293,7 +299,7 @@ following documentation section:
 
 .. code-block:: yaml
 
-  documentation
+  documentation:
     authors:
       - demo_le
 

--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -96,6 +96,11 @@ with explanations in a commented line above each option:
   # the amount of memory available in your system.
   max_parallel_tasks: null
 
+  # Use a profiling tool for the diagnostic run [false]/true; profilers tell you where
+  # the stress points of the code are (high CPU usage, high memory intake etc);
+  # for this purpose we use vprof, see below for notes
+  profile_diagnostic: true
+
   # Path to custom config-developer file, to customise project configurations.
   # See config-developer.yml for an example. Set to None to use the default
   config_developer_file: null
@@ -146,6 +151,13 @@ downloaded at runtime.
 
    This setting is not for model or observational datasets, rather it is for
    data files used in plotting such as coastline descriptions and so on.
+
+The ``profile_diagnostic`` setting triggers profiling of Python diagnostics;
+this will give you information on the resources used while running the diagnostic
+(including execution time of different code blocks, memory, CPU usage); for this
+purpose we use `vprof<https://github.com/nvdv/vprof>`_. The profiler outputs
+a json file that can be used to extract the profiling information via e.g.
+``vprof --input-file esmvaltool_output/recipe_output/run/diagnostic/script/profile.json``.
 
 A detailed explanation of the data finding-related sections of the
 ``config-user.yml`` (``rootpath`` and ``drs``) is presented in the

--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -155,7 +155,7 @@ downloaded at runtime.
 The ``profile_diagnostic`` setting triggers profiling of Python diagnostics;
 this will give you information on the resources used while running the diagnostic
 (including execution time of different code blocks, memory, CPU usage); for this
-purpose we use `vprof<https://github.com/nvdv/vprof>`_. The profiler outputs
+purpose we use `vprof <https://github.com/nvdv/vprof>`_. The profiler outputs
 a json file that can be used to extract the profiling information via e.g.
 ``vprof --input-file esmvaltool_output/recipe_output/run/diagnostic/script/profile.json``.
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,5 @@ dependencies:
   - esmpy
   - iris>=2.2.1
   - graphviz
-  - libunwind  # Needed for Python3.7+
   - python>=3.6  # if 3.7 lxml will not import correctly if <4.5.0
   - python-stratify

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -303,7 +303,7 @@ class DiagnosticTask(BaseTask):
             if self.settings['profile_diagnostic']:
                 profile_file = Path(self.settings['run_dir']) / 'profile.bin'
                 args['py'] = [
-                    '-m', 'vmprof', '--lines', '-o',
+                    '-m', 'vprof', '--lines', '-o',
                     str(profile_file)
                 ]
 

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -303,8 +303,8 @@ class DiagnosticTask(BaseTask):
             if self.settings['profile_diagnostic']:
                 profile_file = Path(self.settings['run_dir']) / 'profile.bin'
                 args['py'] = [
-                    '-m', 'vprof', '--lines', '-o',
-                    str(profile_file)
+                    '-m', 'vprof', '-o',
+                    str(profile_file), '-c', 'p'
                 ]
 
             ext = script_file.suffix.lower()[1:]
@@ -488,7 +488,12 @@ class DiagnosticTask(BaseTask):
         if ext == '.ncl':
             env['settings'] = settings_file
         else:
-            cmd.append(settings_file)
+            if self.settings['profile_diagnostic']:
+                script_file = cmd.pop()
+                combo_with_settings = script_file + ' ' + str(settings_file)
+                cmd.append(combo_with_settings)
+            else:
+                cmd.append(settings_file)
 
         process = self._start_diagnostic_script(cmd, env)
 

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -304,7 +304,7 @@ class DiagnosticTask(BaseTask):
                 profile_file = Path(self.settings['run_dir']) / 'profile.json'
                 args['py'] = [
                     '-m', 'vprof', '-o',
-                    str(profile_file), '-c', 'p'
+                    str(profile_file), '-c', 'c'
                 ]
 
             ext = script_file.suffix.lower()[1:]

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -301,7 +301,7 @@ class DiagnosticTask(BaseTask):
                 'ncl': ['-n', '-p'],
             }
             if self.settings['profile_diagnostic']:
-                profile_file = Path(self.settings['run_dir']) / 'profile.bin'
+                profile_file = Path(self.settings['run_dir']) / 'profile.json'
                 args['py'] = [
                     '-m', 'vprof', '-o',
                     str(profile_file), '-c', 'p'

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -36,7 +36,6 @@ requirements:
   run:
     # esmvaltool
     - python>=3.6
-    - libunwind  # specifically for Python3.7+
     - graphviz
     - iris>=2.2.1
     - python-stratify

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ REQUIREMENTS = {
         'prospector[with_pyroma]!=1.1.6.3,!=1.1.6.4',
         'sphinx>2',
         'sphinx_rtd_theme',
-        'vmprof',
+        'vprof',
         'yamllint',
         'yapf',
     ],

--- a/tests/unit/task/test_diagnostic_task.py
+++ b/tests/unit/task/test_diagnostic_task.py
@@ -88,7 +88,7 @@ def test_initialize_cmd(ext_profile, cmd, tmp_path, monkeypatch):
     if ext == '.py' and profile:
         cmd.append(str(run_dir / 'profile.json'))
         cmd.append('-c')
-        cmd.append('p')
+        cmd.append('c')
     cmd.append(str(script))
     assert task.cmd == cmd
 

--- a/tests/unit/task/test_diagnostic_task.py
+++ b/tests/unit/task/test_diagnostic_task.py
@@ -86,7 +86,7 @@ def test_initialize_cmd(ext_profile, cmd, tmp_path, monkeypatch):
 
     # Append filenames to expected command
     if ext == '.py' and profile:
-        cmd.append(str(run_dir / 'profile.bin'))
+        cmd.append(str(run_dir / 'profile.json'))
         cmd.append('-c')
         cmd.append('p')
     cmd.append(str(script))

--- a/tests/unit/task/test_diagnostic_task.py
+++ b/tests/unit/task/test_diagnostic_task.py
@@ -46,7 +46,7 @@ def test_initialize_env(ext, tmp_path, monkeypatch):
 CMD = {
     # ext, profile: expected command
     ('.py', False): ['python'],
-    ('.py', True): ['python', '-m', 'vmprof', '--lines', '-o'],
+    ('.py', True): ['python', '-m', 'vprof', '-o'],
     ('.ncl', False): ['ncl', '-n', '-p'],
     ('.ncl', True): ['ncl', '-n', '-p'],
     ('.R', False): ['Rscript'],
@@ -87,8 +87,9 @@ def test_initialize_cmd(ext_profile, cmd, tmp_path, monkeypatch):
     # Append filenames to expected command
     if ext == '.py' and profile:
         cmd.append(str(run_dir / 'profile.bin'))
+        cmd.append('-c')
+        cmd.append('p')
     cmd.append(str(script))
-
     assert task.cmd == cmd
 
 


### PR DESCRIPTION
**SUMMARY**

This PR kills two birds with one stone: replaced the profiler from `vmprof` to `vprof` that according to @bouweandela in #765 is more maintained and removes the need for `libunwind` as dependency that causes issues on OSX as detailed in #779 

<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #765 and #779 
