### PR TITLE
Fix yapf-isort import formatting conflict (Fixes #777)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,7 @@ parallel = true
 
 [pydocstyle]
 convention = numpy
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = true


### PR DESCRIPTION
Add trailing comma in isort config. Yapf respects the trailing comma and will not reformat the imports.


**Tasks**

-   [X] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [X] This pull request has a descriptive title that can be used in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.


If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #777
