### PR TITLE
set the multiprocessing distribution method from getgoing

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -4,6 +4,7 @@ import contextlib
 import datetime
 import errno
 import logging
+import multiprocessing as mp
 import numbers
 import os
 import pprint
@@ -22,6 +23,12 @@ import yaml
 from ._citation import _write_citation_files
 from ._config import DIAGNOSTICS_PATH, TAGS, replace_tags
 from ._provenance import TrackedFile, get_task_provenance
+
+
+# set the start method for multiprocessing
+# on OSX Darwin 10.14.6 it is None, leading to no process being executed
+if mp.get_start_method(allow_none=True) is None:
+    mp.set_start_method('fork', force=True)
 
 logger = logging.getLogger(__name__)
 

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -24,7 +24,6 @@ from ._citation import _write_citation_files
 from ._config import DIAGNOSTICS_PATH, TAGS, replace_tags
 from ._provenance import TrackedFile, get_task_provenance
 
-
 # set the start method for multiprocessing
 # on OSX Darwin 10.14.6 it is None, leading to no process being executed
 if mp.get_start_method(allow_none=True) is None:


### PR DESCRIPTION
This is needed because on OSX on Python 3.8 the start method is either `None` or is set to `spawn` (see https://github.com/saltstack/salt/issues/55847) - and tests are failing (well, one can not actually run with more than one process) see https://github.com/ESMValGroup/ESMValCore/runs/1116923215?check_suite_focus=true

<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #issue_number
