### PR TITLE
Default config-user path now set in config-user read function

### DIFF
--- a/esmvalcore/_config.py
+++ b/esmvalcore/_config.py
@@ -33,6 +33,8 @@ DIAGNOSTICS_PATH = find_diagnostics()
 
 def read_config_user_file(config_file, folder_name, options=None):
     """Read config user file and store settings in a dictionary."""
+    if not config_file:
+        config_file = '~/.esmvaltool/config-user.yml'
     config_file = os.path.abspath(
         os.path.expandvars(os.path.expanduser(config_file)))
     # Read user config file

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -361,8 +361,6 @@ class ESMValTool():
 
         recipe_name = os.path.splitext(os.path.basename(recipe))[0]
 
-        if not config_file:
-            config_file = '~/.esmvaltool/config-user.yml'
         cfg = read_config_user_file(config_file, recipe_name, kwargs)
 
         # Create run dir


### PR DESCRIPTION
A small fix that will make life easier for other parts of ESMValTool (like the cmorizer). 

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Required for ESMValGroup/ESMValTool#1657
