### PR TITLE
temporary fix to an issue with cube intersection when cube has bounds

### DIFF
--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -61,7 +61,7 @@ def extract_region(cube, start_longitude, end_longitude, start_latitude,
             latitude=(start_latitude, end_latitude),
             ignore_bounds=True,
         )
-        # delete bounds: kluge for issue 799
+        # delete bounds: kluge for https://github.com/ESMValGroup/ESMValCore/issues/799
         # TODO remove the bounds handling after iris fix
         region_subset.coord("longitude").bounds = None
         region_subset = region_subset.intersection(longitude=(0., 360.))

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -61,7 +61,8 @@ def extract_region(cube, start_longitude, end_longitude, start_latitude,
             latitude=(start_latitude, end_latitude),
             ignore_bounds=True,
         )
-        # delete bounds: kluge for https://github.com/ESMValGroup/ESMValCore/issues/799
+        # delete bounds: kluge for
+        # issue here https://github.com/ESMValGroup/ESMValCore/issues/799
         # TODO remove the bounds handling after iris fix
         region_subset.coord("longitude").bounds = None
         region_subset = region_subset.intersection(longitude=(0., 360.))

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -61,7 +61,11 @@ def extract_region(cube, start_longitude, end_longitude, start_latitude,
             latitude=(start_latitude, end_latitude),
             ignore_bounds=True,
         )
+        # delete bounds: kluge for issue 799
+        # TODO remove the bounds handling after iris fix
+        region_subset.coord("longitude").bounds = None
         region_subset = region_subset.intersection(longitude=(0., 360.))
+        region_subset.coord("longitude").guess_bounds()
         return region_subset
     # Irregular grids
     lats = cube.coord('latitude').points


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #issue_number #799 and addresses an inherently iris issue firt posted in https://github.com/SciTools/iris/issues/3391
