### PR TITLE
Release notes v2.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -46,7 +46,8 @@
         },
         {
             "affiliation": "DLR, Germany",
-            "name": "Schlund, Manuel"
+            "name": "Schlund, Manuel",
+            "orcid": "0000-0001-5251-0158"
         },
         {
             "affiliation": "BSC, Spain",
@@ -55,7 +56,8 @@
         },
         {
             "affiliation": "SMHI, Sweden",
-            "name": "Zimmermann, Klaus"
+            "name": "Zimmermann, Klaus",
+            "orcid": "0000-0003-3994-2057"
         },
         {
             "affiliation": "DLR, Germany",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -158,11 +158,11 @@ authors:
     "orcid": "https://orcid.org/0000-0003-0590-7843"
 
 cff-version: "1.0.3"
-date-released: 2020-07-15
+date-released: 2020-10-12
 doi: "10.5281/zenodo.3387139"
 license: "Apache-2.0"
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ESMValGroup/ESMValCore/"
 title: ESMValCore
-version: "v2.0.0"
+version: "v2.1.0"
 ...

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -51,6 +51,7 @@ authors:
     affiliation: "DLR, Germany"
     family-names: Schlund
     given-names: Manuel
+    orcid: "https://orcid.org/0000-0001-5251-0158"
   -
     affiliation: "BSC, Spain"
     family-names: Vegas-Regidor
@@ -60,6 +61,7 @@ authors:
     affiliation: "SMHI, Sweden"
     family-names: Zimmermann
     given-names: Klaus
+    orcid: "https://orcid.org/0000-0003-3994-2057"
   -
     affiliation: "DLR, Germany"
     family-names: Bock
@@ -90,6 +92,70 @@ authors:
     affiliation: "BSC, Spain"
     family-names: Loosveldt-Tomas
     given-names: Saskia
+  -
+    "affiliation": "NLeSC, Netherlands"
+    "family-names": "Smeets"
+    "given-names": "Stef"
+    "orcid": "https://orcid.org/0000-0002-5413-9038"
+  -
+    "affiliation": "NLeSC, Netherlands"
+    "family-names": "Camphuijsen"
+    "given-names": "Jaro"
+    "orcid": "https://orcid.org/0000-0002-8928-7831"
+  -
+    "affiliation": "University of Bremen, Germany"
+    "family-names": "Gier"
+    "given-names": "Bettina K."
+    "orcid": "https://orcid.org/0000-0002-2928-8664"
+  -
+    "affiliation": "University of Bremen, Germany"
+    "family-names": "Weigel"
+    "given-names": "Katja"
+    "orcid": "https://orcid.org/0000-0001-6133-7801"
+  -
+    "affiliation": "Institute for Atmospheric and Climate Science, ETH Zurich, Zurich, Switzerland"
+    "family-names": "Hauser"
+    "given-names": "Mathias"
+    "orcid": "https://orcid.org/0000-0002-0057-4878"
+  -
+    "affiliation": "Netherlands eScience Center"
+    "family-names": "Kalverla"
+    "given-names": "Peter"
+    "orcid": "https://orcid.org/0000-0002-5025-7862"
+  -
+    "affiliation": "University of Bremen, Germany"
+    "family-names": "Galytska"
+    "given-names": "Evgenia"
+    "orcid": "https://orcid.org/0000-0001-6575-1559"
+  -
+    "affiliation": "BSC, Spain"
+    "family-names": "Cos-Espuña"
+    "given-names": "Pep"
+  -
+    "affiliation": "Netherlands eScience Center"
+    "family-names": "Pelupessy"
+    "given-names": "Inti"
+    "orcid": "https://orcid.org/0000-0002-8024-0412"
+  -
+    "affiliation": "Max Planck Institute for Biogeochemistry, Germany"
+    "family-names": "Koirala"
+    "given-names": "Sujan"
+    "orcid": "https://orcid.org/0000-0001-5681-1986"
+  -
+    "affiliation": "Helmholtz-Zentrum Geesthacht, Germany "
+    "family-names": "Stacke"
+    "given-names": "Tobias"
+    "orcid": "https://orcid.org/0000-0003-4637-5337"
+  -
+    "affiliation": "Netherlands eScience Center"
+    "family-names": "Alidoost"
+    "given-names": "Sarah"
+    "orcid": "https://orcid.org/0000-0001-8407-6472"
+  -
+    "affiliation": "Barcelona Supercomputing Center"
+    "family-names": "Jury"
+    "given-names": "Martin"
+    "orcid": "https://orcid.org/0000-0003-0590-7843"
 
 cff-version: "1.0.3"
 date-released: 2020-07-15

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,66 @@
 Changelog
 =========
 
+v2.1.0
+------
+
+This release includes
+
+Bug fixes
+~~~~~~~~~
+
+-  Fix diagnostic filter (`#713 <https://github.com/ESMValGroup/ESMValCore/pull/713>`__) `Javier Vegas-Regidor <https://github.com/jvegasbsc>`__
+-  Set unit=1 if anomalies are standardized (`#727 <https://github.com/ESMValGroup/ESMValCore/pull/727>`__) `bascrezee <https://github.com/bascrezee>`__
+-  Fix crash for FGOALS-g2 variables without longitude coordinate (`#729 <https://github.com/ESMValGroup/ESMValCore/pull/729>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Improve variable alias managament (`#595 <https://github.com/ESMValGroup/ESMValCore/pull/595>`__) `Javier Vegas-Regidor <https://github.com/jvegasbsc>`__
+-  Fix area_statistics fx files loading (`#798 <https://github.com/ESMValGroup/ESMValCore/pull/798>`__) `Javier Vegas-Regidor <https://github.com/jvegasbsc>`__
+
+Documentation
+~~~~~~~~~~~~~
+
+-  Update v2.0.0 release notes with final additions (`#722 <https://github.com/ESMValGroup/ESMValCore/pull/722>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Update package description in setup.py (`#725 <https://github.com/ESMValGroup/ESMValCore/pull/725>`__) `Mattia Righi <https://github.com/mattiarighi>`__
+-  Add installation instructions for pip installation (`#735 <https://github.com/ESMValGroup/ESMValCore/pull/735>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Improve config-user documentation (`#740 <https://github.com/ESMValGroup/ESMValCore/pull/740>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Update the zenodo file with contributors (`#807 <https://github.com/ESMValGroup/ESMValCore/pull/807>`__) `Valeriu Predoi <https://github.com/valeriupredoi>`__
+-  Improve command line run documentation (`#721 <https://github.com/ESMValGroup/ESMValCore/pull/721>`__) `Javier Vegas-Regidor <https://github.com/jvegasbsc>`__
+-  Update the zenodo file with contributors (continued) (`#810 <https://github.com/ESMValGroup/ESMValCore/pull/810>`__) `Valeriu Predoi <https://github.com/valeriupredoi>`__
+
+Improvements
+~~~~~~~~~~~~
+
+-  Pin Yamale to v2 (`#718 <https://github.com/ESMValGroup/ESMValCore/pull/718>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Expanded cmor public API (`#714 <https://github.com/ESMValGroup/ESMValCore/pull/714>`__) `Manuel Schlund <https://github.com/schlunma>`__
+-  Reduce size of docker image (`#723 <https://github.com/ESMValGroup/ESMValCore/pull/723>`__) `Javier Vegas-Regidor <https://github.com/jvegasbsc>`__
+-  Add 'test' extra to installation, used by docker development tag (`#733 <https://github.com/ESMValGroup/ESMValCore/pull/733>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Correct dockerhub link (`#736 <https://github.com/ESMValGroup/ESMValCore/pull/736>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Create action-install-from-pypi.yml (`#734 <https://github.com/ESMValGroup/ESMValCore/pull/734>`__) `Valeriu Predoi <https://github.com/valeriupredoi>`__
+-  Add pre-commit for linting/formatting (`#766 <https://github.com/ESMValGroup/ESMValCore/pull/766>`__) `Stef Smeets <https://github.com/stefsmeets>`__
+-  Run tests in parallel and when building conda package (`#745 <https://github.com/ESMValGroup/ESMValCore/pull/745>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Readable exclude pattern for pre-commit (`#770 <https://github.com/ESMValGroup/ESMValCore/pull/770>`__) `Stef Smeets <https://github.com/stefsmeets>`__
+-  Github Actions Tests (`#732 <https://github.com/ESMValGroup/ESMValCore/pull/732>`__) `Valeriu Predoi <https://github.com/valeriupredoi>`__
+-  Remove isort setup to fix formatting conflict with yapf (`#778 <https://github.com/ESMValGroup/ESMValCore/pull/778>`__) `Stef Smeets <https://github.com/stefsmeets>`__
+-  Fix yapf-isort import formatting conflict (Fixes #777) (`#784 <https://github.com/ESMValGroup/ESMValCore/pull/784>`__) `Stef Smeets <https://github.com/stefsmeets>`__
+-  Sorted output for `esmvaltool recipes list` (`#790 <https://github.com/ESMValGroup/ESMValCore/pull/790>`__) `Stef Smeets <https://github.com/stefsmeets>`__
+-  Replace vmprof with vprof (`#780 <https://github.com/ESMValGroup/ESMValCore/pull/780>`__) `Valeriu Predoi <https://github.com/valeriupredoi>`__
+-  Update CMIP6 tables to 6.9.32 (`#706 <https://github.com/ESMValGroup/ESMValCore/pull/706>`__) `Javier Vegas-Regidor <https://github.com/jvegasbsc>`__
+-  Default config-user path now set in config-user read function (`#791 <https://github.com/ESMValGroup/ESMValCore/pull/791>`__) `Javier Vegas-Regidor <https://github.com/jvegasbsc>`__
+-  Add custom variable lweGrace (`#692 <https://github.com/ESMValGroup/ESMValCore/pull/692>`__) `bascrezee <https://github.com/bascrezee>`__
+
+Fixes for datasets
+~~~~~~~~~~~~~~~~~~
+
+-  Fix cmip6 models (`#629 <https://github.com/ESMValGroup/ESMValCore/pull/629>`__) `npgillett <https://github.com/npgillett>`__
+-  Fix siconca variable in EC-Earth3 and EC-Earth3-Veg models in amip simulation (`#702 <https://github.com/ESMValGroup/ESMValCore/pull/702>`__) `Evgenia Galytska <https://github.com/egalytska>`__
+
+Preprocessor
+~~~~~~~~~~~~
+
+-  Move cmor_check_data to early in preprocessing chain (`#743 <https://github.com/ESMValGroup/ESMValCore/pull/743>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Add RMS iris analysis operator to statistics preprocessor functions (`#747 <https://github.com/ESMValGroup/ESMValCore/pull/747>`__) `Pep Cos <https://github.com/pcosbsc>`__
+-  Add surface chlorophyll concentration as a derived variable (`#720 <https://github.com/ESMValGroup/ESMValCore/pull/720>`__) `sloosvel <https://github.com/sloosvel>`__
+-  Use dask to reduce memory consumption of extract_levels for masked data (`#776 <https://github.com/ESMValGroup/ESMValCore/pull/776>`__) `Valeriu Predoi <https://github.com/valeriupredoi>`__
+
 v2.0.0
 ------
 

--- a/esmvalcore/_version.py
+++ b/esmvalcore/_version.py
@@ -1,2 +1,2 @@
 """ESMValCore version."""
-__version__ = '2.0.0'
+__version__ = '2.1.0'

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -5,7 +5,7 @@
 # conda build package -c conda-forge -c esmvalgroup
 
 # Package version number
-{% set version = "2.0.0" %}
+{% set version = "2.1.0" %}
 
 package:
   name: esmvalcore


### PR DESCRIPTION
Changed release version to 2.1.0 in files containing it, added citations for the extra peeps we added previously in the zenodo file only and produced and added release notes.
