### PR TITLE
Remove code needed for Python <3.6

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -3,7 +3,6 @@ import fnmatch
 import logging
 import os
 import re
-from collections import OrderedDict
 from copy import deepcopy
 from pprint import pformat
 
@@ -35,58 +34,16 @@ logger = logging.getLogger(__name__)
 TASKSEP = os.sep
 
 
-def ordered_safe_load(stream):
-    """Load a YAML file using OrderedDict instead of dict."""
-    class OrderedSafeLoader(yaml.SafeLoader):
-        """Loader class that uses OrderedDict to load a map."""
-    def construct_mapping(loader, node):
-        """Load a map as an OrderedDict."""
-        loader.flatten_mapping(node)
-        return OrderedDict(loader.construct_pairs(node))
-
-    OrderedSafeLoader.add_constructor(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)
-
-    return yaml.load(stream, OrderedSafeLoader)
-
-
-def load_raw_recipe(filename):
-    """Check a recipe file and return it in raw form."""
-    # Note that many checks can only be performed after the automatically
-    # computed entries have been filled in by creating a Recipe object.
-    check.recipe_with_schema(filename)
-    with open(filename, 'r') as file:
-        contents = file.read()
-        raw_recipe = yaml.safe_load(contents)
-        raw_recipe['preprocessors'] = ordered_safe_load(contents).get(
-            'preprocessors', {})
-
-    check.diagnostics(raw_recipe['diagnostics'])
-    return raw_recipe
-
-
 def read_recipe_file(filename, config_user, initialize_tasks=True):
     """Read a recipe from file."""
-    raw_recipe = load_raw_recipe(filename)
+    check.recipe_with_schema(filename)
+    with open(filename, 'r') as file:
+        raw_recipe = yaml.safe_load(file)
+
     return Recipe(raw_recipe,
                   config_user,
                   initialize_tasks,
                   recipe_file=filename)
-
-
-def _get_value(key, datasets):
-    """Get a value for key by looking at the other datasets."""
-    values = {dataset[key] for dataset in datasets if key in dataset}
-
-    if len(values) > 1:
-        raise RecipeError("Ambiguous values {} for property {}".format(
-            values, key))
-
-    value = None
-    if len(values) == 1:
-        value = values.pop()
-
-    return value
 
 
 def _add_cmor_info(variable, override=False):
@@ -976,6 +933,7 @@ class Recipe:
     def _initialize_diagnostics(self, raw_diagnostics, raw_datasets):
         """Define diagnostics in recipe."""
         logger.debug("Retrieving diagnostics from recipe")
+        check.diagnostics(raw_diagnostics)
 
         diagnostics = {}
 

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -3,7 +3,6 @@ import copy
 import logging
 import os
 import shutil
-from collections import OrderedDict
 from itertools import groupby
 from warnings import catch_warnings, filterwarnings
 
@@ -300,19 +299,6 @@ def cleanup(files, remove=None):
     return files
 
 
-def _ordered_safe_dump(data, stream):
-    """Write data containing OrderedDicts to yaml file."""
-    class _OrderedDumper(yaml.SafeDumper):
-        pass
-
-    def _dict_representer(dumper, data):
-        return dumper.represent_mapping(
-            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
-
-    _OrderedDumper.add_representer(OrderedDict, _dict_representer)
-    return yaml.dump(data, stream, _OrderedDumper)
-
-
 def write_metadata(products, write_ncl=False):
     """Write product metadata to file."""
     output_files = []
@@ -325,7 +311,7 @@ def write_metadata(products, write_ncl=False):
                 p.attributes.get('dataset', ''),
             ),
         )
-        metadata = OrderedDict()
+        metadata = {}
         for product in sorted_products:
             if isinstance(product.attributes.get('exp'), (list, tuple)):
                 product.attributes = dict(product.attributes)
@@ -337,7 +323,7 @@ def write_metadata(products, write_ncl=False):
         output_filename = os.path.join(output_dir, 'metadata.yml')
         output_files.append(output_filename)
         with open(output_filename, 'w') as file:
-            _ordered_safe_dump(metadata, file)
+            yaml.safe_dump(metadata, file)
         if write_ncl:
             output_files.append(_write_ncl_metadata(output_dir, metadata))
 

--- a/tests/unit/preprocessor/_weighting/test_weighting_landsea_fraction.py
+++ b/tests/unit/preprocessor/_weighting/test_weighting_landsea_fraction.py
@@ -1,5 +1,4 @@
 """Unit tests for :mod:`esmvalcore.preprocessor._weighting`."""
-from collections import OrderedDict
 from unittest import mock
 
 import iris
@@ -31,27 +30,27 @@ CUBE_4 = iris.cube.Cube(
 )
 FRAC_SFTLF = np.array([0.1, 0.0, 1.0])
 FRAC_SFTOF = np.array([0.0, 1.0, 0.5, 0.3])
-EMPTY_FX_FILES = OrderedDict([
-    ('sftlf', []),
-    ('sftof', []),
-])
-L_FX_FILES = OrderedDict([
-    ('sftlf', 'not/a/real/path'),
-    ('sftof', []),
-])
-O_FX_FILES = OrderedDict([
-    ('sftlf', []),
-    ('sftof', 'not/a/real/path'),
-])
-FX_FILES = OrderedDict([
-    ('sftlf', 'not/a/real/path'),
-    ('sftof', 'i/was/mocked'),
-])
-WRONG_FX_FILES = OrderedDict([
-    ('wrong', 'test'),
-    ('sftlf', 'not/a/real/path'),
-    ('sftof', 'i/was/mocked'),
-])
+EMPTY_FX_FILES = {
+    'sftlf': [],
+    'sftof': [],
+}
+L_FX_FILES = {
+    'sftlf': 'not/a/real/path',
+    'sftof': [],
+}
+O_FX_FILES = {
+    'sftlf': [],
+    'sftof': 'not/a/real/path',
+}
+FX_FILES = {
+    'sftlf': 'not/a/real/path',
+    'sftof': 'i/was/mocked',
+}
+WRONG_FX_FILES = {
+    'wrong': 'test',
+    'sftlf': 'not/a/real/path',
+    'sftof': 'i/was/mocked',
+}
 
 LAND_FRACTION = [
     (CUBE_3, {}, [], None, ["No fx files given"]),


### PR DESCRIPTION
This pull request removes code needed for Python versions we no longer support: `dict`s are ordered since Python 3.6, so there is no need to use an `OrderedDict` anymore.

It also removes the function `esmvalcore._recipe._get_value`, which was not used for anything anymore.
