### PR TITLE
Fixing unit for derived variable rsnstcsnorm to prevent overcorrection2

### DIFF
--- a/esmvalcore/preprocessor/_derive/rsnstcsnorm.py
+++ b/esmvalcore/preprocessor/_derive/rsnstcsnorm.py
@@ -5,7 +5,7 @@ authors:
 
 """
 from iris import Constraint
-
+from cf_units import Unit
 from ._baseclass import DerivedVariableBase
 
 
@@ -53,5 +53,6 @@ class DerivedVariable(DerivedVariableBase):
 
         rsnstcsnorm_cube = (((rsdt_cube - rsutcs_cube) -
                              (rsdscs_cube - rsuscs_cube)) / rsdt_cube) * 100.0
+        rsnstcsnorm_cube.units = Unit('percent')
 
         return rsnstcsnorm_cube

--- a/tests/unit/preprocessor/_derive/test_rsntcsnorm.py
+++ b/tests/unit/preprocessor/_derive/test_rsntcsnorm.py
@@ -1,0 +1,39 @@
+"""Test derivation of `rsntcs`."""
+import iris
+import numpy as np
+import pytest
+
+import esmvalcore.preprocessor._derive.rsnstcsnorm as rsnstcsnorm
+
+
+@pytest.fixture
+def cubes():
+    # names
+    rsdscs_name = \
+        'surface_downwelling_shortwave_flux_in_air_assuming_clear_sky'
+    rsdt_name = 'toa_incoming_shortwave_flux'
+    rsuscs_name = 'surface_upwelling_shortwave_flux_in_air_assuming_clear_sky'
+    rsutcs_name = 'toa_outgoing_shortwave_flux_assuming_clear_sky'
+
+    # cubes
+    rsdscs_cube = iris.cube.Cube([[1.0, 2.0], [0.0, -2.0]],
+                                 standard_name=rsdscs_name)
+    rsdt_cube = iris.cube.Cube([[1.0, 2.0], [2.0, -2.0]],
+                               standard_name=rsdt_name)
+    rsuscs_cube = iris.cube.Cube([[1.0, 2.0], [0.0, -2.0]],
+                                 standard_name=rsuscs_name)
+    rsutcs_cube = iris.cube.Cube([[5.0, -1.2], [0.8, -3.0]],
+                                 standard_name=rsutcs_name)
+    return iris.cube.CubeList([rsdscs_cube, rsdt_cube,
+                               rsuscs_cube, rsutcs_cube])
+
+
+def test_rsntcs_calculation(cubes):
+    # Actual derivation of rsnstcsnorm
+    # rsnstcsnorm_cube = (((rsdt_cube - rsutcs_cube) -
+    #                      (rsdscs_cube - rsuscs_cube)) / rsdt_cube) * 100.0
+    derived_var = rsnstcsnorm.DerivedVariable()
+    out_cube = derived_var.calculate(cubes)
+    np.testing.assert_allclose(out_cube.data,
+                               np.array([[-400.,  160.], [60., -50.0]]))
+    assert out_cube.units == '%'


### PR DESCRIPTION
Fixing unit for derived variable rsnstcsnorm to prevent over correction caused by changes of #754. This time based on master. Sorry, the other branch (fix_derived_var_rsnstcsnorm) should be deleted.

<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Contributes to close ESMValTool issue ESMValGroup/ESMValTool#1875 for recipe recipe_deangelis15nat.yml
