### PR TITLE
Add requests as a dependency

### DIFF
--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -53,6 +53,7 @@ requirements:
     - psutil
     - pydot
     - pyyaml
+    - requests
     - shapely
     - yamale==2.*  # in esmvalgroup channel
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ REQUIREMENTS = {
         'prov[dot]',
         'psutil',
         'pyyaml',
+        'requests',
         'scitools-iris>=2.2',
         'shapely[vectorized]',
         'stratify',


### PR DESCRIPTION
Add requests as a dependency, because it's missing from the list of dependencies and it's used:

https://github.com/ESMValGroup/ESMValCore/blob/02b8f668e89cabae656978b44faa1bb27f7158be/esmvalcore/_citation.py#L8

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes

* * *

Closes #851
