### PR TITLE
pin hdf5 to more than 1.10.5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - compilers
   - esmpy
+  - hdf5>1.10.5
   - iris>=2.2.1
   - graphviz
   - python>=3.6  # if 3.7 lxml will not import correctly if <4.5.0

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     # esmvaltool
     - python>=3.6
     - graphviz
+    - hdf5>1.10.5
     - iris>=2.2.1
     - python-stratify
     # Normally installed via pip:


### PR DESCRIPTION
Now playing the waiting game see if we still get those segfaults. Ran the tests 4 times (nevermind, I need to rerun them, I forgot to edit meta.yml pffft), no sign of segfaulting. There is, however, an issue in ESMValTool - there is a dependency there that does not like `hdf5=1.10.6` or higher - we need to figure that out otherwise we're stuck with a very old `hdf5` and that's not good; it's not NCL since I've been in touch with the guys there and all's fixed on their side, see https://github.com/NCAR/ncl/issues/133