### PR TITLE
Add missing requests dependency

### DIFF
--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -53,6 +53,7 @@ requirements:
     - psutil
     - pydot
     - pyyaml
+    - requests
     - shapely
     - yamale==2.*  # in esmvalgroup channel
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ REQUIREMENTS = {
         'prov[dot]',
         'psutil',
         'pyyaml',
+        'requests',
         'scitools-iris>=2.2',
         'shapely[vectorized]',
         'stratify',


### PR DESCRIPTION
I have now in two different branches had CircleCI install fails because `requests` is not installed. It is not part of the requirements, so it does not get installed. But it does get used by two modules inside esmvalcore.

`esmvalcore/esmvalcore/cmor/tables/cmip6/scripts/createCMIP6CV.py`
`esmvalcore/esmvalcore/_citation.py`

It must have been missing all the time, maybe some sub-dependency depended on requests so the tests never picked it up. It should however be added to our dependencies.

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [ ] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #issue_number
