### PR TITLE
Pin Python to less than 3.9

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - esmpy
   - iris>=2.2.1
   - graphviz
-  - python>=3.6  # if 3.7 lxml will not import correctly if <4.5.0
+  - python>=3.6,<3.9  # if 3.7 lxml will not import correctly if <4.5.0
   - python-stratify

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -29,13 +29,13 @@ build:
 requirements:
   build:
     - git
-    - python>=3.6
+    - python>=3.6,<3.9
     # Normally installed via pip:
     - pytest-runner
     - setuptools_scm
   run:
     # esmvaltool
-    - python>=3.6
+    - python>=3.6,<3.9
     - graphviz
     - iris>=2.2.1
     - python-stratify


### PR DESCRIPTION
https://github.com/ESMValGroup/ESMValCore/issues/869 - we're in the bogs with `python=3.9` and we need to fix that, until then we need a functional package; note that the latest environment throws 3 test fails as well, as seen from the GA tests [here](https://github.com/ESMValGroup/ESMValCore/runs/1431151389?check_suite_focus=true) - those need to be fixed, preferably in a different branch, let's get this one merged quickly before users start crying around. I'll have a look at those tests on Monday :+1:  - OK I figured it out - the tests are dying coz of #876 and are fixed in #878 :beer: 