### PR TITLE
Pin cftime>=1.3.0 to have newer string formatting in and fix two tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
+  - cftime>=1.3.0  # years<999 get a 0 instead of empty space
   - compilers
   - esmpy
   - iris>=2.2.1

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - iris>=2.2.1
     - python-stratify
     # Normally installed via pip:
+    - cftime>=1.3.0  # years<999 get a 0 instead of empty space
     - cf-units
     - cython  # required by cf-units but not automatically installed
     - esmpy

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
@@ -44,7 +44,7 @@ class TestAllVars(unittest.TestCase):
         time = cube.coord('time')
         dates = num2date(time.points, time.units.name, time.units.calendar)
         self.assertEqual(time.units.calendar, 'gregorian')
-        self.assertEqual(dates[0].strftime('%Y%m%d%H%M'), ' 30001161200')
+        self.assertEqual(dates[0].strftime('%Y%m%d%H%M'), '030001161200')
         self.assertEqual(dates[1].strftime('%Y%m%d%H%M'), '185001161200')
 
     def test_fix_metadata_if_not_time(self):

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
@@ -43,7 +43,7 @@ class TestAllVars(unittest.TestCase):
         time = cube.coord('time')
         dates = num2date(time.points, time.units.name, time.units.calendar)
         self.assertEqual(time.units.calendar, 'gregorian')
-        self.assertEqual(dates[0].strftime('%Y%m%d%H%M'), ' 30001161200')
+        self.assertEqual(dates[0].strftime('%Y%m%d%H%M'), '030001161200')
         self.assertEqual(dates[1].strftime('%Y%m%d%H%M'), '185001161200')
 
     def test_fix_metadata_if_not_time(self):


### PR DESCRIPTION
#876 

<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [ ] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [ ] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #876 
