### PR TITLE
Added fixes for hybrid level coordinates of CESM2 models

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2.py
@@ -1,12 +1,16 @@
 """Fixes for CESM2 model."""
 from shutil import copyfile
 
-from netCDF4 import Dataset
 import numpy as np
+from netCDF4 import Dataset
 
 from ..fix import Fix
-from ..shared import (add_scalar_depth_coord, add_scalar_height_coord,
-                      add_scalar_typeland_coord, add_scalar_typesea_coord)
+from ..shared import (
+    add_scalar_depth_coord,
+    add_scalar_height_coord,
+    add_scalar_typeland_coord,
+    add_scalar_typesea_coord,
+)
 from .gfdl_esm4 import Siconc as Addtypesi
 
 
@@ -23,27 +27,6 @@ class Cl(Fix):
             'atmosphere_hybrid_sigma_pressure_coordinate')
         dataset.close()
         return new_path
-
-    def fix_data(self, cube):
-        """Fix data.
-
-        Fixed ordering of vertical coordinate.
-
-        Parameters
-        ----------
-        cube: iris.cube.Cube
-            Input cube to fix.
-
-        Returns
-        -------
-        iris.cube.Cube
-
-        """
-        (z_axis,) = cube.coord_dims(cube.coord(axis='Z', dim_coords=True))
-        indices = [slice(None)] * cube.ndim
-        indices[z_axis] = slice(None, None, -1)
-        cube = cube[tuple(indices)]
-        return cube
 
     def fix_file(self, filepath, output_dir):
         """Fix hybrid pressure coordinate.
@@ -76,6 +59,30 @@ class Cl(Fix):
         dataset.variables['b_bnds'][:] = dataset.variables['b_bnds'][::-1, :]
         dataset.close()
         return new_path
+
+    def fix_metadata(self, cubes):
+        """Fix ``atmosphere_hybrid_sigma_pressure_coordinate``.
+
+        See discussion in #882 for more details on that.
+
+        Parameters
+        ----------
+        cubes : iris.cube.CubeList
+            Input cubes.
+
+        Returns
+        -------
+        iris.cube.CubeList
+
+        """
+        cube = self.get_cube_from_list(cubes)
+        lev_coord = cube.coord(var_name='lev')
+        a_coord = cube.coord(var_name='a')
+        b_coord = cube.coord(var_name='b')
+        lev_coord.points = a_coord.core_points() + b_coord.core_points()
+        lev_coord.bounds = a_coord.core_bounds() + b_coord.core_bounds()
+        lev_coord.units = '1'
+        return cubes
 
 
 Cli = Cl

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm.py
@@ -7,6 +7,7 @@ import iris
 import numpy as np
 import pytest
 
+from esmvalcore.cmor._fixes.cmip6.cesm2 import Cl as BaseCl
 from esmvalcore.cmor._fixes.cmip6.cesm2 import Tas as BaseTas
 from esmvalcore.cmor._fixes.cmip6.cesm2_waccm import Cl, Cli, Clw, Tas
 from esmvalcore.cmor.fix import Fix
@@ -16,6 +17,11 @@ def test_get_cl_fix():
     """Test getting of fix."""
     fix = Fix.get_fixes('CMIP6', 'CESM2-WACCM', 'Amon', 'cl')
     assert fix == [Cl(None)]
+
+
+def test_cl_fix():
+    """Test fix for ``cl``."""
+    assert issubclass(Cl, BaseCl)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7, 6),


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

This PR adds fixes for `cl`, `cli` and `clw` for the CESM2 models.

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [x] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [x] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [x] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes ESMValGroup/ESMValTool#1903.
