### PR TITLE
Fix overwritting in generic level check

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -410,7 +410,7 @@ class CMORCheck():
             if standard_name:
                 if not out_name:
                     self.report_error(
-                        f'Coordinate {name} '
+                        f'Generic level coordinate {key} '
                         'has wrong var_name.',
                     )
                 level = coordinate.generic_lev_coords[name]

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -385,6 +385,9 @@ class CMORCheck():
                                 self._does_msg, coordinate.name, 'exist')
 
     def _check_generic_level_dim_names(self, key, coordinate):
+        standard_name = None
+        out_name = None
+        name = None
         if coordinate.generic_lev_coords:
             for coord in coordinate.generic_lev_coords.values():
                 try:

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -391,26 +391,26 @@ class CMORCheck():
                     cube_coord = self._cube.coord(
                         var_name=coord.out_name
                     )
-                    coordinate.out_name = coord.out_name
+                    out_name = coord.out_name
                     if cube_coord.standard_name == coord.standard_name:
-                        coordinate.standard_name = coord.standard_name
-                        coordinate.name = coord.name
+                        standard_name = coord.standard_name
+                        name = coord.name
                 except iris.exceptions.CoordinateNotFoundError:
                     try:
                         cube_coord = self._cube.coord(
                             var_name=coord.standard_name
                         )
-                        coordinate.standard_name = coord.standard_name
-                        coordinate.name = coord.name
+                        standard_name = coord.standard_name
+                        name = coord.name
                     except iris.exceptions.CoordinateNotFoundError:
                         pass
-            if coordinate.standard_name:
-                if not coordinate.out_name:
+            if standard_name:
+                if not out_name:
                     self.report_error(
-                        f'Coordinate {coordinate.name} '
+                        f'Coordinate {name} '
                         'has wrong var_name.',
                     )
-                level = coordinate.generic_lev_coords[coordinate.name]
+                level = coordinate.generic_lev_coords[name]
                 level.generic_level = True
                 level.generic_lev_coords = self._cmor_var.coordinates[
                     key].generic_lev_coords
@@ -418,18 +418,18 @@ class CMORCheck():
                 self.report_debug_message(
                     f'Generic level coordinate {key} '
                     'will be checked against '
-                    f'{coordinate.name} coordinate information'
+                    f'{name} coordinate information'
                 )
             else:
-                if coordinate.out_name:
+                if out_name:
                     self.report_critical(
-                        f'Coordinate {coordinate.name} '
+                        f'Coordinate {name} '
                         'has wrong standard_name '
                         'or is not set.',
                     )
                 else:
                     self.report_critical(
-                        self._does_msg, coordinate.name, 'exist'
+                        self._does_msg, name, 'exist'
                     )
 
     def _check_coords(self):

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -426,7 +426,7 @@ class CMORCheck():
             else:
                 if out_name:
                     self.report_critical(
-                        f'Coordinate {name} '
+                        f'Generic level coordinate {key} '
                         'has wrong standard_name '
                         'or is not set.',
                     )

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -432,7 +432,7 @@ class CMORCheck():
                     )
                 else:
                     self.report_critical(
-                        self._does_msg, name, 'exist'
+                        self._does_msg, key, 'exist'
                     )
 
     def _check_coords(self):


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [x] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *
The previous implementation was working directly with the dict containing the CMOR information. This led to accidental overwritting of the dict values in some runs and ended up causing incorrect reporting of errors. Tested with several datasets  and variables and it seems that this issue does not happen anymore, but should be double checked of course. 

Closes #883 
