### PR TITLE
Add double quotes to script args in rerun screen message when using vprof profiling

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -435,7 +435,11 @@ class DiagnosticTask(BaseTask):
         rerun_msg = 'cd {}; '.format(cwd)
         if env:
             rerun_msg += ' '.join('{}="{}"'.format(k, env[k]) for k in env)
-        rerun_msg += ' ' + ' '.join(cmd)
+        if "vprof" in cmd:
+            script_args = ' "' + cmd[-1] + '"'
+            rerun_msg += ' ' + ' '.join(cmd[:-1]) + script_args
+        else:
+            rerun_msg += ' ' + ' '.join(cmd)
         logger.info("To re-run this diagnostic script, run:\n%s", rerun_msg)
 
         complete_env = dict(os.environ)
@@ -478,8 +482,7 @@ class DiagnosticTask(BaseTask):
         else:
             if self.settings['profile_diagnostic']:
                 script_file = cmd.pop()
-                combo_with_settings = ().join(['"', script_file, ' ',
-                                               str(settings_file), '"'])
+                combo_with_settings = script_file + ' ' + str(settings_file)
                 cmd.append(combo_with_settings)
             else:
                 cmd.append(settings_file)

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -478,7 +478,8 @@ class DiagnosticTask(BaseTask):
         else:
             if self.settings['profile_diagnostic']:
                 script_file = cmd.pop()
-                combo_with_settings = script_file + ' ' + str(settings_file)
+                combo_with_settings = ().join(['"', script_file, ' ',
+                                               str(settings_file), '"'])
                 cmd.append(combo_with_settings)
             else:
                 cmd.append(settings_file)


### PR DESCRIPTION
<!---
Please do not delete this text completely, but read the text below and keep items that seem relevant.
If in doubt, just keep everything and add your own text at the top.
--->

Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

**Tasks**

-   [x] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog
-   [ ] Add unit tests
-   [ ] Public functions should have a numpy-style docstring so they appear properly in the [API documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/api/esmvalcore.html). For all other functions a one line docstring is sufficient.
-   [ ] If writing a new/modified preprocessor function, please update the [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/preprocessor.html)
-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.
-   [ ] Please use `yamllint` to check that your YAML files do not contain mistakes
-   [ ] If you make backward incompatible changes to the recipe format, make a new pull request in the [ESMValTool repository](https://github.com/ESMValGroup/ESMValTool) and add the link below

If you need help with any of the tasks above, please do not hesitate to ask by commenting in the issue or pull request.

* * *

Closes #896 
