### PR TITLE
Make CircleCI badge specific to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/esmvaltool/badge/?version=latest)](https://esmvaltool.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3387139.svg)](https://doi.org/10.5281/zenodo.3387139)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ESMValGroup?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![CircleCI](https://circleci.com/gh/ESMValGroup/ESMValCore.svg?style=svg)](https://circleci.com/gh/ESMValGroup/ESMValCore)
+[![CircleCI](https://circleci.com/gh/ESMValGroup/ESMValCore/tree/master.svg?style=svg)](https://circleci.com/gh/ESMValGroup/ESMValCore/tree/master)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/5d496dea9ef64ec68e448a6df5a65783)](https://www.codacy.com/gh/ESMValGroup/ESMValCore?utm_source=github.com&utm_medium=referral&utm_content=ESMValGroup/ESMValCore&utm_campaign=Badge_Coverage)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/5d496dea9ef64ec68e448a6df5a65783)](https://www.codacy.com/gh/ESMValGroup/ESMValCore?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ESMValGroup/ESMValCore&amp;utm_campaign=Badge_Grade)
 [![Docker Build Status](https://img.shields.io/docker/build/esmvalgroup/esmvalcore.svg)](https://hub.docker.com/r/esmvalgroup/esmvalcore/)
@@ -19,7 +19,7 @@ Please have a look at the
 [documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/quickstart/install.html)
 to get started.
 
-## Using the ESMValCore package to run recipes 
+## Using the ESMValCore package to run recipes
 
 The ESMValCore package provides the `esmvaltool` command, which can be used to run
 [recipes](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/overview.html)


### PR DESCRIPTION
Make CircleCI badge specific to master branch, so the status shown in README.md reflects the current state of the master branch.