### PR TITLE
Update codacy coverage reporter to fix coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  coverage-reporter: codacy/coverage-reporter@11.1.1
+  coverage-reporter: codacy/coverage-reporter@11.4.1
 
 commands:
   check_changes:


### PR DESCRIPTION
The codacy coverage reporter (silently!) fails as it cannot find curl. Updating to a newer version that also supports wget.

**Tasks**

-   [ ] [Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do, if you haven't done so already (and add the link at the bottom)
-   [x] This pull request has a descriptive title that can be used in a changelog

-   [x] Circle/CI tests pass. Status can be seen below your pull request. If the tests are failing, click the link to find out why.
-   [x] Codacy code quality checks pass. Status can be seen below your pull request. If there is an error, click the link to find out why. If you suspect Codacy may be wrong, please ask by commenting.