### PR TITLE
Changed latitude longitude fix from Tas to AllVars.

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2.py
@@ -10,6 +10,41 @@ from ..shared import (add_scalar_depth_coord, add_scalar_height_coord,
 from .gfdl_esm4 import Siconc as Addtypesi
 
 
+class AllVars(Fix):
+    """Fixes latitude longitude bounds for all variables."""
+
+    def fix_metadata(self, cubes):
+        """
+
+        Fix latitude_bounds and longitude_bounds data type and round to 4 d.p.
+
+        Parameters
+        ----------
+        cubes : iris.cube.CubeList
+            Input cubes.
+
+        Returns
+        -------
+        iris.cube.CubeList
+
+        """
+        cube = self.get_cube_from_list(cubes)
+
+        for cube in cubes:
+            latitude = cube.coord('latitude')
+            if latitude.bounds is None:
+                latitude.guess_bounds()
+            latitude.bounds = latitude.bounds.astype(np.float64)
+            latitude.bounds = np.round(latitude.bounds, 4)
+            longitude = cube.coord('longitude')
+            if longitude.bounds is None:
+                longitude.guess_bounds()
+            longitude.bounds = longitude.bounds.astype(np.float64)
+            longitude.bounds = np.round(longitude.bounds, 4)
+
+        return cubes
+
+
 class Cl(Fix):
     """Fixes for ``cl``."""
 
@@ -112,8 +147,6 @@ class Tas(Fix):
         """
         Add height (2m) coordinate.
 
-        Fix latitude_bounds and longitude_bounds data type and round to 4 d.p.
-
         Parameters
         ----------
         cubes : iris.cube.CubeList
@@ -126,18 +159,6 @@ class Tas(Fix):
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_height_coord(cube)
-
-        for cube in cubes:
-            latitude = cube.coord('latitude')
-            if latitude.bounds is None:
-                latitude.guess_bounds()
-            latitude.bounds = latitude.bounds.astype(np.float64)
-            latitude.bounds = np.round(latitude.bounds, 4)
-            longitude = cube.coord('longitude')
-            if longitude.bounds is None:
-                longitude.guess_bounds()
-            longitude.bounds = longitude.bounds.astype(np.float64)
-            longitude.bounds = np.round(longitude.bounds, 4)
 
         return cubes
 

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2.py
@@ -10,41 +10,6 @@ from ..shared import (add_scalar_depth_coord, add_scalar_height_coord,
 from .gfdl_esm4 import Siconc as Addtypesi
 
 
-class AllVars(Fix):
-    """Fixes latitude longitude bounds for all variables."""
-
-    def fix_metadata(self, cubes):
-        """
-
-        Fix latitude_bounds and longitude_bounds data type and round to 4 d.p.
-
-        Parameters
-        ----------
-        cubes : iris.cube.CubeList
-            Input cubes.
-
-        Returns
-        -------
-        iris.cube.CubeList
-
-        """
-        cube = self.get_cube_from_list(cubes)
-
-        for cube in cubes:
-            latitude = cube.coord('latitude')
-            if latitude.bounds is None:
-                latitude.guess_bounds()
-            latitude.bounds = latitude.bounds.astype(np.float64)
-            latitude.bounds = np.round(latitude.bounds, 4)
-            longitude = cube.coord('longitude')
-            if longitude.bounds is None:
-                longitude.guess_bounds()
-            longitude.bounds = longitude.bounds.astype(np.float64)
-            longitude.bounds = np.round(longitude.bounds, 4)
-
-        return cubes
-
-
 class Cl(Fix):
     """Fixes for ``cl``."""
 
@@ -140,12 +105,12 @@ class Fgco2(Fix):
         return cubes
 
 
-class Tas(Fix):
+class Prw(Fix):
     """Fixes for tas."""
 
     def fix_metadata(self, cubes):
         """
-        Add height (2m) coordinate.
+        Fix latitude_bounds and longitude_bounds data type and round to 4 d.p.
 
         Parameters
         ----------
@@ -157,6 +122,43 @@ class Tas(Fix):
         iris.cube.CubeList
 
         """
+        for cube in cubes:
+            latitude = cube.coord('latitude')
+            if latitude.bounds is None:
+                latitude.guess_bounds()
+            latitude.bounds = latitude.bounds.astype(np.float64)
+            latitude.bounds = np.round(latitude.bounds, 4)
+            longitude = cube.coord('longitude')
+            if longitude.bounds is None:
+                longitude.guess_bounds()
+            longitude.bounds = longitude.bounds.astype(np.float64)
+            longitude.bounds = np.round(longitude.bounds, 4)
+
+        return cubes
+
+
+class Tas(Prw):
+    """Fixes for tas."""
+
+    def fix_metadata(self, cubes):
+        """
+        Add height (2m) coordinate.
+
+        Fix also done for prw.
+        Fix latitude_bounds and longitude_bounds data type and round to 4 d.p.
+
+        Parameters
+        ----------
+        cubes : iris.cube.CubeList
+            Input cubes.
+
+        Returns
+        -------
+        iris.cube.CubeList
+
+        """
+        super().fix_metadata(cubes)
+        # Specific code for tas
         cube = self.get_cube_from_list(cubes)
         add_scalar_height_coord(cube)
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValCore better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->
There is already a fix for the latitude and longitude bounds for the variable "tas" in esmvalcore/cmor/_fixes/cmip6/cesm2.py. Instead of only to "Tas" it should be applied to "AllVars". I found at least part of the same problem (bounds differ) the fix solves for "prw". It can be expected that it occurs also for other variables if e.g. different experiments from CESM2 are combined. The case I tested was combining historical and ssp585 for prw.

-   Closes/Fixes: #915
-   Link to documentation:

***

## Before you get started

-   \[ \] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   \[ \] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[ \] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   \[ \] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   \[ \] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   \[ \] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[ \] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[ \] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   \[ \] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   \[ \] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
