### PR TITLE
Avoid hardcoded year in tests and add improvement to plev test case

### DIFF
--- a/tests/integration/cmor/_fixes/native6/test_era5.py
+++ b/tests/integration/cmor/_fixes/native6/test_era5.py
@@ -1,13 +1,22 @@
 """Tests for the fixes of ERA5."""
+import datetime
+
 import iris
 import numpy as np
 import pytest
 from cf_units import Unit
 
-from esmvalcore.cmor._fixes.native6.era5 import (AllVars, Evspsbl, Zg,
-                                                 get_frequency)
+from esmvalcore.cmor._fixes.native6.era5 import (
+    AllVars,
+    Evspsbl,
+    Zg,
+    get_frequency,
+)
 from esmvalcore.cmor.fix import Fix, fix_metadata
 from esmvalcore.cmor.table import CMOR_TABLES
+
+COMMENT = ('Contains modified Copernicus Climate Change Service Information '
+           f'{datetime.datetime.now().year}')
 
 
 def test_get_evspsbl_fix():
@@ -24,12 +33,16 @@ def test_get_zg_fix():
 
 def test_get_frequency_hourly():
     """Test cubes with hourly frequency."""
-    time = iris.coords.DimCoord([0, 1, 2],
-                                standard_name='time',
-                                units=Unit('hours since 1900-01-01'))
-    cube = iris.cube.Cube([1, 6, 3],
-                          var_name='random_var',
-                          dim_coords_and_dims=[(time, 0)])
+    time = iris.coords.DimCoord(
+        [0, 1, 2],
+        standard_name='time',
+        units=Unit('hours since 1900-01-01'),
+    )
+    cube = iris.cube.Cube(
+        [1, 6, 3],
+        var_name='random_var',
+        dim_coords_and_dims=[(time, 0)],
+    )
     assert get_frequency(cube) == 'hourly'
     cube.coord('time').convert_units('days since 1850-1-1 00:00:00.0')
     assert get_frequency(cube) == 'hourly'
@@ -37,12 +50,16 @@ def test_get_frequency_hourly():
 
 def test_get_frequency_monthly():
     """Test cubes with monthly frequency."""
-    time = iris.coords.DimCoord([0, 31, 59],
-                                standard_name='time',
-                                units=Unit('hours since 1900-01-01'))
-    cube = iris.cube.Cube([1, 6, 3],
-                          var_name='random_var',
-                          dim_coords_and_dims=[(time, 0)])
+    time = iris.coords.DimCoord(
+        [0, 31, 59],
+        standard_name='time',
+        units=Unit('hours since 1900-01-01'),
+    )
+    cube = iris.cube.Cube(
+        [1, 6, 3],
+        var_name='random_var',
+        dim_coords_and_dims=[(time, 0)],
+    )
     assert get_frequency(cube) == 'monthly'
     cube.coord('time').convert_units('days since 1850-1-1 00:00:00.0')
     assert get_frequency(cube) == 'monthly'
@@ -52,13 +69,17 @@ def test_get_frequency_fx():
     """Test cubes with time invariant frequency."""
     cube = iris.cube.Cube(1., long_name='Cube without time coordinate')
     assert get_frequency(cube) == 'fx'
-    time = iris.coords.DimCoord(0,
-                                standard_name='time',
-                                units=Unit('hours since 1900-01-01'))
-    cube = iris.cube.Cube([1],
-                          var_name='cube_with_length_1_time_coord',
-                          long_name='Geopotential',
-                          dim_coords_and_dims=[(time, 0)])
+    time = iris.coords.DimCoord(
+        0,
+        standard_name='time',
+        units=Unit('hours since 1900-01-01'),
+    )
+    cube = iris.cube.Cube(
+        [1],
+        var_name='cube_with_length_1_time_coord',
+        long_name='Geopotential',
+        dim_coords_and_dims=[(time, 0)],
+    )
     assert get_frequency(cube) == 'fx'
     cube.long_name = 'Not geopotential'
     with pytest.raises(ValueError):
@@ -66,20 +87,24 @@ def test_get_frequency_fx():
 
 
 def _era5_latitude():
-    return iris.coords.DimCoord(np.array([90., 0., -90.]),
-                                standard_name='latitude',
-                                long_name='latitude',
-                                var_name='latitude',
-                                units=Unit('degrees'))
+    return iris.coords.DimCoord(
+        np.array([90., 0., -90.]),
+        standard_name='latitude',
+        long_name='latitude',
+        var_name='latitude',
+        units=Unit('degrees'),
+    )
 
 
 def _era5_longitude():
-    return iris.coords.DimCoord(np.array([0, 180, 359.75]),
-                                standard_name='longitude',
-                                long_name='longitude',
-                                var_name='longitude',
-                                units=Unit('degrees'),
-                                circular=True)
+    return iris.coords.DimCoord(
+        np.array([0, 180, 359.75]),
+        standard_name='longitude',
+        long_name='longitude',
+        var_name='longitude',
+        units=Unit('degrees'),
+        circular=True,
+    )
 
 
 def _era5_time(frequency):
@@ -89,14 +114,28 @@ def _era5_time(frequency):
         timestamps = [788928, 788929, 788930]
     elif frequency == 'monthly':
         timestamps = [788928, 789672, 790344]
-    return iris.coords.DimCoord(np.array(timestamps, dtype='int32'),
-                                standard_name='time',
-                                long_name='time',
-                                var_name='time',
-                                units=Unit(
-                                    'hours since 1900-01-01'
-                                    '00:00:00.0',
-                                    calendar='gregorian'))
+    return iris.coords.DimCoord(
+        np.array(timestamps, dtype='int32'),
+        standard_name='time',
+        long_name='time',
+        var_name='time',
+        units=Unit('hours since 1900-01-01'
+                   '00:00:00.0', calendar='gregorian'),
+    )
+
+
+def _era5_plev():
+    values = np.array([
+        1,
+        1000,
+    ])
+    return iris.coords.DimCoord(
+        values,
+        long_name="pressure",
+        units=Unit("millibars"),
+        var_name="level",
+        attributes={'positive': 'down'},
+    )
 
 
 def _era5_data(frequency):
@@ -106,24 +145,26 @@ def _era5_data(frequency):
 
 
 def _cmor_latitude():
-    return iris.coords.DimCoord(np.array([-90., 0., 90.]),
-                                standard_name='latitude',
-                                long_name='Latitude',
-                                var_name='lat',
-                                units=Unit('degrees_north'),
-                                bounds=np.array([[-90., -45.], [-45., 45.],
-                                                 [45., 90.]]))
+    return iris.coords.DimCoord(
+        np.array([-90., 0., 90.]),
+        standard_name='latitude',
+        long_name='Latitude',
+        var_name='lat',
+        units=Unit('degrees_north'),
+        bounds=np.array([[-90., -45.], [-45., 45.], [45., 90.]]),
+    )
 
 
 def _cmor_longitude():
-    return iris.coords.DimCoord(np.array([0, 180, 359.75]),
-                                standard_name='longitude',
-                                long_name='Longitude',
-                                var_name='lon',
-                                units=Unit('degrees_east'),
-                                bounds=np.array([[-0.125, 90.], [90., 269.875],
-                                                 [269.875, 359.875]]),
-                                circular=True)
+    return iris.coords.DimCoord(
+        np.array([0, 180, 359.75]),
+        standard_name='longitude',
+        long_name='Longitude',
+        var_name='lon',
+        units=Unit('degrees_east'),
+        bounds=np.array([[-0.125, 90.], [90., 269.875], [269.875, 359.875]]),
+        circular=True,
+    )
 
 
 def _cmor_time(mip, bounds=None, shifted=False):
@@ -159,8 +200,12 @@ def _cmor_aux_height(value):
                                 attributes={'positive': 'up'})
 
 
-def _cmor_height(value):
-    return iris.coords.DimCoord(value,
+def _cmor_plev():
+    values = np.array([
+        100000.0,
+        100.0,
+    ])
+    return iris.coords.DimCoord(values,
                                 long_name="pressure",
                                 standard_name="air_pressure",
                                 units=Unit("Pa"),
@@ -181,8 +226,11 @@ def clt_era5_hourly():
         long_name='cloud cover fraction',
         var_name='cloud_cover',
         units='unknown',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -192,20 +240,19 @@ def clt_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'clt')
     time = _cmor_time('E1hr', bounds=True)
     data = _cmor_data('E1hr') * 100
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -216,8 +263,11 @@ def evspsbl_era5_hourly():
         long_name='total evapotranspiration',
         var_name='e',
         units='unknown',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -227,20 +277,19 @@ def evspsbl_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'evspsbl')
     time = _cmor_time('E1hr', shifted=True, bounds=True)
     data = _cmor_data('E1hr') * 1000 / 3600.
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -251,8 +300,11 @@ def evspsblpot_era5_hourly():
         long_name='potential evapotranspiration',
         var_name='epot',
         units='unknown',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -262,20 +314,19 @@ def evspsblpot_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'evspsblpot')
     time = _cmor_time('E1hr', shifted=True, bounds=True)
     data = _cmor_data('E1hr') * 1000 / 3600.
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -286,8 +337,11 @@ def mrro_era5_hourly():
         long_name='runoff',
         var_name='runoff',
         units='m',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -297,20 +351,19 @@ def mrro_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'mrro')
     time = _cmor_time('E1hr', shifted=True, bounds=True)
     data = _cmor_data('E1hr') * 1000 / 3600.
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -321,8 +374,11 @@ def orog_era5_hourly():
         long_name='geopotential height',
         var_name='zg',
         units='m**2 s**-2',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -331,19 +387,15 @@ def orog_cmor_fx():
     cmor_table = CMOR_TABLES['native6']
     vardef = cmor_table.get_variable('fx', 'orog')
     data = _cmor_data('fx') / 9.80665
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(_cmor_latitude(), 0),
-                                               (_cmor_longitude(), 1)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[(_cmor_latitude(), 0), (_cmor_longitude(), 1)],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -354,8 +406,11 @@ def pr_era5_monthly():
         long_name='total_precipitation',
         var_name='tp',
         units='m',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -365,20 +420,19 @@ def pr_cmor_amon():
     vardef = cmor_table.get_variable('Amon', 'pr')
     time = _cmor_time('Amon', bounds=True)
     data = _cmor_data('Amon') * 1000. / 3600. / 24.
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -389,8 +443,11 @@ def pr_era5_hourly():
         long_name='total_precipitation',
         var_name='tp',
         units='m',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -400,20 +457,19 @@ def pr_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'pr')
     time = _cmor_time('E1hr', bounds=True, shifted=True)
     data = _cmor_data('E1hr') * 1000. / 3600.
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -424,8 +480,11 @@ def prsn_era5_hourly():
         long_name='snow',
         var_name='snow',
         units='unknown',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -435,20 +494,19 @@ def prsn_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'prsn')
     time = _cmor_time('E1hr', shifted=True, bounds=True)
     data = _cmor_data('E1hr') * 1000 / 3600.
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -459,8 +517,11 @@ def ptype_era5_hourly():
         long_name='snow',
         var_name='snow',
         units='unknown',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -470,19 +531,18 @@ def ptype_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'ptype')
     time = _cmor_time('E1hr', shifted=False, bounds=True)
     data = _cmor_data('E1hr')
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          units=1,
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        units=1,
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     cube.coord('latitude').long_name = 'latitude'
     cube.coord('longitude').long_name = 'longitude'
     return iris.cube.CubeList([cube])
@@ -495,8 +555,11 @@ def rlds_era5_hourly():
         long_name='surface thermal radiation downwards',
         var_name='ssrd',
         units='J m**-2',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -515,12 +578,8 @@ def rlds_cmor_e1hr():
                                                (_cmor_latitude(), 1),
                                                (_cmor_longitude(), 2)],
                           attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020',
-                              'positive':
-                              'down'
+                              'comment': COMMENT,
+                              'positive': 'down',
                           })
     return iris.cube.CubeList([cube])
 
@@ -532,8 +591,11 @@ def rls_era5_hourly():
         long_name='runoff',
         var_name='runoff',
         units='W m-2',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -548,16 +610,14 @@ def rls_cmor_e1hr():
                           var_name=vardef.short_name,
                           standard_name=vardef.standard_name,
                           units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
+                          dim_coords_and_dims=[
+                              (time, 0),
+                              (_cmor_latitude(), 1),
+                              (_cmor_longitude(), 2),
+                          ],
                           attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020',
-                              'positive':
-                              'down'
+                              'comment': COMMENT,
+                              'positive': 'down',
                           })
     return iris.cube.CubeList([cube])
 
@@ -569,8 +629,11 @@ def rsds_era5_hourly():
         long_name='solar_radiation_downwards',
         var_name='rlwd',
         units='J m**-2',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -589,12 +652,8 @@ def rsds_cmor_e1hr():
                                                (_cmor_latitude(), 1),
                                                (_cmor_longitude(), 2)],
                           attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020',
-                              'positive':
-                              'down'
+                              'comment': COMMENT,
+                              'positive': 'down',
                           })
     return iris.cube.CubeList([cube])
 
@@ -626,12 +685,8 @@ def rsdt_cmor_e1hr():
                                                (_cmor_latitude(), 1),
                                                (_cmor_longitude(), 2)],
                           attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020',
-                              'positive':
-                              'down'
+                              'comment': COMMENT,
+                              'positive': 'down',
                           })
     return iris.cube.CubeList([cube])
 
@@ -643,8 +698,11 @@ def rss_era5_hourly():
         long_name='net_solar_radiation',
         var_name='ssr',
         units='J m**-2',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -663,12 +721,8 @@ def rss_cmor_e1hr():
                                                (_cmor_latitude(), 1),
                                                (_cmor_longitude(), 2)],
                           attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020',
-                              'positive':
-                              'down'
+                              'comment': COMMENT,
+                              'positive': 'down',
                           })
     return iris.cube.CubeList([cube])
 
@@ -680,8 +734,11 @@ def tas_era5_hourly():
         long_name='2m_temperature',
         var_name='t2m',
         units='K',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -699,12 +756,7 @@ def tas_cmor_e1hr():
                           dim_coords_and_dims=[(time, 0),
                                                (_cmor_latitude(), 1),
                                                (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+                          attributes={'comment': COMMENT})
     cube.add_aux_coord(_cmor_aux_height(2.))
     return iris.cube.CubeList([cube])
 
@@ -716,8 +768,11 @@ def tas_era5_monthly():
         long_name='2m_temperature',
         var_name='t2m',
         units='K',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -725,37 +780,39 @@ def tas_era5_monthly():
 def tas_cmor_amon():
     cmor_table = CMOR_TABLES['native6']
     vardef = cmor_table.get_variable('Amon', 'tas')
-    time = _cmor_time('Amon',  bounds=True)
+    time = _cmor_time('Amon', bounds=True)
     data = _cmor_data('Amon')
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     cube.add_aux_coord(_cmor_aux_height(2.))
     return iris.cube.CubeList([cube])
 
 
 def zg_era5_monthly():
     time = _era5_time('monthly')
-    data = np.ones((3, 1, 3, 3))
+    data = np.ones((3, 2, 3, 3))
     cube = iris.cube.Cube(
         data,
         long_name='geopotential height',
         var_name='zg',
         units='m**2 s**-2',
-        dim_coords_and_dims=[(time, 0), ((_cmor_height(100.), 1)),
-                             (_era5_latitude(), 2),
-                             (_era5_longitude(), 3)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_plev(), 1),
+            (_era5_latitude(), 2),
+            (_era5_longitude(), 3),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -763,24 +820,23 @@ def zg_era5_monthly():
 def zg_cmor_amon():
     cmor_table = CMOR_TABLES['native6']
     vardef = cmor_table.get_variable('Amon', 'zg')
-    time = _cmor_time('Amon',  bounds=True)
-    data = np.ones((3, 1, 3, 3))
+    time = _cmor_time('Amon', bounds=True)
+    data = np.ones((3, 2, 3, 3))
     data = data / 9.80665
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_height(100.), 1),
-                                               (_cmor_latitude(), 2),
-                                               (_cmor_longitude(), 3)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_plev(), 1),
+            (_cmor_latitude(), 2),
+            (_cmor_longitude(), 3),
+        ],
+        attributes={'comment': COMMENT},
+    )
     return iris.cube.CubeList([cube])
 
 
@@ -791,8 +847,11 @@ def tasmax_era5_hourly():
         long_name='maximum 2m temperature',
         var_name='mx2t',
         units='K',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -802,20 +861,19 @@ def tasmax_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'tasmax')
     time = _cmor_time('E1hr', shifted=True, bounds=True)
     data = _cmor_data('E1hr')
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     cube.add_aux_coord(_cmor_aux_height(2.))
     return iris.cube.CubeList([cube])
 
@@ -827,8 +885,11 @@ def tasmin_era5_hourly():
         long_name='minimum 2m temperature',
         var_name='mn2t',
         units='K',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -838,20 +899,19 @@ def tasmin_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'tasmin')
     time = _cmor_time('E1hr', shifted=True, bounds=True)
     data = _cmor_data('E1hr')
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     cube.add_aux_coord(_cmor_aux_height(2.))
     return iris.cube.CubeList([cube])
 
@@ -863,8 +923,11 @@ def uas_era5_hourly():
         long_name='10m_u_component_of_wind',
         var_name='u10',
         units='m s-1',
-        dim_coords_and_dims=[(time, 0), (_era5_latitude(), 1),
-                             (_era5_longitude(), 2)],
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
     )
     return iris.cube.CubeList([cube])
 
@@ -874,20 +937,19 @@ def uas_cmor_e1hr():
     vardef = cmor_table.get_variable('E1hr', 'uas')
     time = _cmor_time('E1hr')
     data = _cmor_data('E1hr')
-    cube = iris.cube.Cube(data.astype('float32'),
-                          long_name=vardef.long_name,
-                          var_name=vardef.short_name,
-                          standard_name=vardef.standard_name,
-                          units=Unit(vardef.units),
-                          dim_coords_and_dims=[(time, 0),
-                                               (_cmor_latitude(), 1),
-                                               (_cmor_longitude(), 2)],
-                          attributes={
-                              'comment':
-                              'Contains modified '
-                              'Copernicus Climate Change Service '
-                              'Information 2020'
-                          })
+    cube = iris.cube.Cube(
+        data.astype('float32'),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={'comment': COMMENT},
+    )
     cube.add_aux_coord(_cmor_aux_height(10.))
     return iris.cube.CubeList([cube])
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValCore better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

Fixes #920

Changes here:
- Avoid hardcoded year 2020 in the comment
- Add more realistic pressure levels to test variable `zg`

***

## Before you get started

-   \[x\] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   \[x\] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[x\] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   \[ \] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[ \] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[ \] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
