### PR TITLE
Support automatically closing issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
     Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
 -->
 
--   Closes/Fixes: #issue_number
+-   Closes #issue_number
 -   Link to documentation:
 
 ***


### PR DESCRIPTION
When you fill the current pull request template, the associated issue will not be automatically closed. This pull request updates the template so issues are automatically closed by GitHub when the linked pull request is merged.