### PR TITLE
Pin scipy to less than 1.6.0 until ESMValGroup/ESMValCore/issues/927 gets resolved

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - graphviz
   - python>=3.6,<3.9  # if 3.7 lxml will not import correctly if <4.5.0
   - python-stratify
+  - scipy<1.6  # until ESMValGroup/ESMValCore/issues/927 gets resolved

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - graphviz
     - iris>=2.2.1
     - python-stratify
+    - scipy<1.6  # until ESMValGroup/ESMValCore/issues/927 gets resolved
     # Normally installed via pip:
     - cftime>=1.3.0  # years<999 get a 0 instead of empty space
     - cf-units

--- a/tests/integration/cmor/test_table.py
+++ b/tests/integration/cmor/test_table.py
@@ -364,7 +364,7 @@ class TestCustomInfo(unittest.TestCase):
         """Get none if a variable is not in the given table."""
         self.assertIsNone(self.variables_info.get_variable('Omon', 'badvar'))
 
-    def test_get_variable_tasConf5(self):
+    def test_get_variable_tasconf5(self):
         """Get tas variable."""
         CustomInfo()
         var = self.variables_info.get_variable('Amon', 'tasConf5')
@@ -373,7 +373,7 @@ class TestCustomInfo(unittest.TestCase):
                          'Near-Surface Air Temperature Uncertainty Range')
         self.assertEqual(var.units, 'K')
 
-    def test_get_variable_tasConf95(self):
+    def test_get_variable_tasconf95(self):
         """Get tas variable."""
         CustomInfo()
         var = self.variables_info.get_variable('Amon', 'tasConf95')


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValCore better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

-   Related to #927 - it doesn't close it, it addresses the test failure when the environment picks up `scipy=1.6.0`; the real closure needs to be addressed in the issue by identifying if the differences from the spline calculation are normal or not (I don't know this stuff)
-   the test naming change is there because new FLAKE is complaining, see [test result](https://app.circleci.com/pipelines/github/ESMValGroup/ESMValCore/3841/workflows/81e1cde0-1051-4b3a-a9a2-303df0a3fcb3/jobs/17567)

***

## Before you get started

-   \[ \] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[ \] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   \[ \] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   \[ \] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   \[ \] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[ \] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   \[ \] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   \[ \] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   \[ \] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
