### PR TITLE
Add lazy 'engine' for multicube statistics

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -663,10 +663,15 @@ in the output file.
 Restrictive computation is also available by excluding  any set of models that
 the user will not want to include in the statistics (by setting ``exclude:
 [excluded models list]`` argument). The implementation has a few restrictions
-that apply to the input data: model datasets must have consistent shapes, and
-from a statistical point of view, this is needed since weights are not yet
-implemented; also higher dimensional data is not supported (i.e. anything with
-dimensionality higher than four: time, vertical axis, two horizontal axes).
+that apply to the input data: model datasets must have consistent shapes, apart
+from the time dimension; and cubes with more than four dimensions (time,
+vertical axis, two horizontal axes) are not supported.
+
+Input datasets may have different time coordinates. Statistics can be computed
+across overlapping times only (``span: overlap``) or across the full time span
+of the combined models (``span: full``). The preprocessor sets a common time
+coordinate on all datasets. As the number of days in a year may vary between
+calendars, (sub-)daily data with different calendars are not supported.
 
 Input datasets may have different time coordinates. The multi-model statistics
 preprocessor sets a common time coordinate on all datasets. As the number of
@@ -696,14 +701,12 @@ entry contains the resulting cube with the requested statistic operations.
 
 .. note::
 
-   Note that the multi-model array operations, albeit performed in
-   per-time/per-horizontal level loops to save memory, could, however, be
-   rather memory-intensive (since they are not performed lazily as
-   yet). The Section on :ref:`Memory use` details the memory intake
-   for different run scenarios, but as a thumb rule, for the multi-model
-   preprocessor, the expected maximum memory intake could be approximated as
-   the number of datasets multiplied by the average size in memory for one
-   dataset.
+   The multi-model array operations can be rather memory-intensive (since they
+   are not performed lazily as yet). The Section on :ref:`Memory use` details
+   the memory intake for different run scenarios, but as a thumb rule, for the
+   multi-model preprocessor, the expected maximum memory intake could be
+   approximated as the number of datasets multiplied by the average size in
+   memory for one dataset.
 
 .. _time operations:
 

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -456,17 +456,17 @@ Missing values masks
 --------------------
 
 Missing (masked) values can be a nuisance especially when dealing with
-multimodel ensembles and having to compute multimodel statistics; different
+multi-model ensembles and having to compute multi-model statistics; different
 numbers of missing data from dataset to dataset may introduce biases and
-artificially assign more weight to the datasets that have less missing
-data. This is handled in ESMValTool via the missing values masks: two types of
-such masks are available, one for the multimodel case and another for the
-single model case.
+artificially assign more weight to the datasets that have less missing data.
+This is handled in ESMValTool via the missing values masks: two types of such
+masks are available, one for the multi-model case and another for the single
+model case.
 
-The multimodel missing values mask (``mask_fillvalues``) is a preprocessor step
+The multi-model missing values mask (``mask_fillvalues``) is a preprocessor step
 that usually comes after all the single-model steps (regridding, area selection
 etc) have been performed; in a nutshell, it combines missing values masks from
-individual models into a multimodel missing values mask; the individual model
+individual models into a multi-model missing values mask; the individual model
 masks are built according to common criteria: the user chooses a time window in
 which missing data points are counted, and if the number of missing data points
 relative to the number of total data points in a window is less than a chosen
@@ -492,11 +492,11 @@ See also :func:`esmvalcore.preprocessor.mask_fillvalues`.
 Common mask for multiple models
 -------------------------------
 
-It is possible to use ``mask_fillvalues`` to create a combined multimodel
-mask (all the masks from all the analyzed models combined into a single
-mask); for that purpose setting the ``threshold_fraction`` to 0 will not
-discard any time windows, essentially keeping the original model masks and
-combining them into a single mask; here is an example:
+It is possible to use ``mask_fillvalues`` to create a combined multi-model mask
+(all the masks from all the analyzed models combined into a single mask); for
+that purpose setting the ``threshold_fraction`` to 0 will not discard any time
+windows, essentially keeping the original model masks and combining them into a
+single mask; here is an example:
 
 .. code-block:: yaml
 
@@ -530,13 +530,12 @@ Horizontal regridding
 
 Regridding is necessary when various datasets are available on a variety of
 `lat-lon` grids and they need to be brought together on a common grid (for
-various statistical operations e.g. multimodel statistics or for e.g. direct
+various statistical operations e.g. multi-model statistics or for e.g. direct
 inter-comparison or comparison with observational datasets). Regridding is
 conceptually a very similar process to interpolation (in fact, the regridder
 engine uses interpolation and extrapolation, with various schemes). The primary
 difference is that interpolation is based on sample data points, while
-regridding is based on the horizontal grid of another cube (the reference
-grid).
+regridding is based on the horizontal grid of another cube (the reference grid).
 
 The underlying regridding mechanism in ESMValTool uses the `cube.regrid()
 <https://scitools.org.uk/iris/docs/latest/iris/iris/cube.html#iris.cube.Cube.regrid>`_
@@ -651,20 +650,15 @@ Multi-model statistics
 ======================
 Computing multi-model statistics is an integral part of model analysis and
 evaluation: individual models display a variety of biases depending on model
-set-up, initial conditions, forcings and implementation; comparing model data
-to observational data, these biases have a significantly lower statistical
-impact when using a multi-model ensemble. ESMValTool has the capability of
-computing a number of multi-model statistical measures: using the preprocessor
-module ``multi_model_statistics`` will enable the user to ask for either a
-multi-model ``mean``, ``median``, ``max``, ``min``, ``std``, and / or
-``pXX.YY`` with a set of argument parameters passed to
-``multi_model_statistics``. Percentiles can be specified like ``p1.5`` or
-``p95``. The decimal point will be replaced by a dash in the output file.
-
-Note that current multimodel statistics in ESMValTool are local (not global),
-and are computed along the time axis. As such, can be computed across a common
-overlap in time (by specifying ``span: overlap`` argument) or across the full
-length in time of each model (by specifying ``span: full`` argument).
+set-up, initial conditions, forcings and implementation; comparing model data to
+observational data, these biases have a significantly lower statistical impact
+when using a multi-model ensemble. ESMValTool has the capability of computing a
+number of multi-model statistical measures: using the preprocessor module
+``multi_model_statistics`` will enable the user to ask for either a multi-model
+``mean``, ``median``, ``max``, ``min``, ``std``, and / or ``pXX.YY`` with a set
+of argument parameters passed to ``multi_model_statistics``. Percentiles can be
+specified like ``p1.5`` or ``p95``. The decimal point will be replaced by a dash
+in the output file.
 
 Restrictive computation is also available by excluding  any set of models that
 the user will not want to include in the statistics (by setting ``exclude:
@@ -681,7 +675,7 @@ days in a year may vary between calendars, (sub-)daily data are not supported.
 .. code-block:: yaml
 
     preprocessors:
-      multimodel_preprocessor:
+      multi_model_preprocessor:
         multi_model_statistics:
           span: overlap
           statistics: [mean, median]
@@ -702,11 +696,11 @@ entry contains the resulting cube with the requested statistic operations.
 
 .. note::
 
-   Note that the multimodel array operations, albeit performed in
+   Note that the multi-model array operations, albeit performed in
    per-time/per-horizontal level loops to save memory, could, however, be
    rather memory-intensive (since they are not performed lazily as
    yet). The Section on :ref:`Memory use` details the memory intake
-   for different run scenarios, but as a thumb rule, for the multimodel
+   for different run scenarios, but as a thumb rule, for the multi-model
    preprocessor, the expected maximum memory intake could be approximated as
    the number of datasets multiplied by the average size in memory for one
    dataset.
@@ -1512,14 +1506,14 @@ In the most general case, we can set upper limits on the maximum memory the
 analysis will require:
 
 
-``Ms = (R + N) x F_eff - F_eff`` - when no multimodel analysis is performed;
+``Ms = (R + N) x F_eff - F_eff`` - when no multi-model analysis is performed;
 
-``Mm = (2R + N) x F_eff - 2F_eff`` - when multimodel analysis is performed;
+``Mm = (2R + N) x F_eff - 2F_eff`` - when multi-model analysis is performed;
 
 where
 
 * ``Ms``: maximum memory for non-multimodel module
-* ``Mm``: maximum memory for multimodel module
+* ``Mm``: maximum memory for multi-model module
 * ``R``: computational efficiency of module; `R` is typically 2-3
 * ``N``: number of datasets
 * ``F_eff``: average size of data per dataset where ``F_eff = e x f x F``
@@ -1538,7 +1532,7 @@ where
 ``Mm = 1.5 x (N - 2)`` GB
 
 As a rule of thumb, the maximum required memory at a certain time for
-multimodel analysis could be estimated by multiplying the number of datasets by
+multi-model analysis could be estimated by multiplying the number of datasets by
 the average file size of all the datasets; this memory intake is high but also
 assumes that all data is fully realized in memory; this aspect will gradually
 change and the amount of realized data will decrease with the increase of

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -1,14 +1,10 @@
-"""multimodel statistics.
+"""Statistics across cubes.
 
-Functions for multi-model operations
-supports a multitude of multimodel statistics
-computations; the only requisite is the ingested
-cubes have (TIME-LAT-LON) or (TIME-PLEV-LAT-LON)
-dimensions; and obviously consistent units.
+This module contains functions to compute statistics across multiple cubes or
+products.
 
-It operates on different (time) spans:
-- full: computes stats on full dataset time;
-- overlap: computes common time overlap between datasets;
+Wrapper functions separate esmvalcore internals, operating on products, from
+generalized functions that operate on iris cubes.
 """
 
 import logging
@@ -295,66 +291,47 @@ def _assemble_data(cubes, statistic, span='overlap'):
     return stats_cube
 
 
-def multi_model_statistics(products, span, statistics, output_products=None):
-    """Compute multi-model statistics.
+def multicube_statistics(cubes, statistics, span):
+    """Compute statistics across input cubes.
 
-    Multimodel statistics computed along the time axis. Can be
-    computed across a common overlap in time (set span: overlap)
-    or across the full length in time of each model (set span: full).
-    Restrictive computation is also available by excluding any set of
-    models that the user will not want to include in the statistics
-    (set exclude: [excluded models list]).
+    This function deals with non-homogeneous cubes by taking the time union
+    (span='full') or intersection (span='overlap'), and extending or subsetting
+    the cubes as necessary. Apart from the time coordinate, cubes must have
+    consistent shapes.
 
-    Restrictions needed by the input data:
-    - model datasets must have consistent shapes,
-    - higher dimensional data is not supported (ie dims higher than four:
-    time, vertical axis, two horizontal axes).
+    This function operates directly on numpy (masked) arrays and rebuilds the
+    resulting cubes from scratch. Therefore, it is not suitable for lazy
+    evaluation. This function is restricted to maximum four-dimensional data:
+    time, vertical axis, two horizontal axes.
 
     Parameters
     ----------
-    products: list
-        list of data products or cubes to be used in multimodel stat
-        computation;
-        cube attribute of product is the data cube for computing the stats.
+    cubes: list
+        list of cubes across which the statistics will be computed;
+    statistics: list
+        statistical metrics to be computed. Available options: mean, median,
+        max, min, std, or pXX.YY (for percentile XX.YY; decimal part optional).
     span: str
         overlap or full; if overlap, statitsticss are computed on common time-
         span; if full, statistics are computed on full time spans, ignoring
         missing data.
-    output_products: dict
-        dictionary of output products. MUST be specified if products are NOT
-        cubes
-    statistics: list of str
-        list of statistical measure(s) to be computed. Available options:
-        mean, median, max, min, std, or pXX.YY (for percentile XX.YY; decimal
-        part optional).
 
     Returns
     -------
-    set or dict or list
-        `set` of data products if `output_products` is given
-        `dict` of cubes if `output_products` is not given
-        `list` of input cubes if there is no overlap between cubes when
-        using `span='overlap'`
+    dict
+        dictionary of statistics cubes with statistics' names as keys.
 
     Raises
     ------
     ValueError
         If span is neither overlap nor full.
     """
-    logger.debug('Multimodel statistics: computing: %s', statistics)
-    if len(products) < 2:
-        logger.info("Single dataset in list: will not compute statistics.")
-        return products
-    if output_products:
-        cubes = [cube for product in products for cube in product.cubes]
-        statistic_products = set()
-    else:
-        cubes = products
-        statistic_products = {}
+    logger.debug('Multicube statistics: computing: %s', statistics)
 
     # Reset time coordinates and make cubes share the same calendar
     _unify_time_coordinates(cubes)
 
+    # Check whether input is valid
     if span == 'overlap':
         # check if we have any time overlap
         times = [cube.coord('time').points for cube in cubes]
@@ -362,7 +339,7 @@ def multi_model_statistics(products, span, statistics, output_products=None):
         if len(overlap) <= 1:
             logger.info("Time overlap between cubes is none or a single point."
                         "check datasets: will not compute statistics.")
-            return products
+            return cubes
         logger.debug("Using common time overlap between "
                      "datasets to compute statistics.")
     elif span == 'full':
@@ -372,22 +349,89 @@ def multi_model_statistics(products, span, statistics, output_products=None):
             "Unexpected value for span {}, choose from 'overlap', 'full'".
             format(span))
 
+    # Compute statistics
+    statistics_cubes = {}
     for statistic in statistics:
-        # Compute statistic
         statistic_cube = _assemble_data(cubes, statistic, span)
+        statistics_cubes[statistic] = statistic_cube
 
-        if output_products:
-            # Add to output product and log provenance
-            statistic_product = output_products[statistic]
-            statistic_product.cubes = [statistic_cube]
-            for product in products:
-                statistic_product.wasderivedfrom(product)
-            logger.info("Generated %s", statistic_product)
-            statistic_products.add(statistic_product)
-        else:
-            statistic_products[statistic] = statistic_cube
+    return statistics_cubes
 
-    if output_products:
-        products |= statistic_products
-        return products
-    return statistic_products
+
+def _multiproduct_statistics(products,
+                             statistics,
+                             output_products,
+                             span='overlap'):
+    """Compute statistics across ESMValCore products.
+
+    Extract cubes from products, calculate the statistics across cubes and
+    assign the resulting output cubes to the output_products.
+
+    This function separates the ESMValCore internals (products) from the actual
+    statistics function that operates on Iris cubes.
+
+    Parameters
+    ----------
+    products: list
+        list of PreprocessorFile's
+    statistics: list
+        list of strings describing the statistics that will be computed
+    output_products: dict
+        dict of PreprocessorFile's with statistic names as keys.
+    span: str
+        'full' or 'overlap', whether to calculate the statistics on the time
+        union ('full') or time intersection ('overlap') of the cubes.
+
+    Returns
+    -------
+    set
+        set of PreprocessorFiles containing the computed statistics cubes.
+    """
+    # Extract cubes from products
+    cubes = [cube for product in products for cube in product.cubes]
+
+    # Compute statistics
+    if len(cubes) < 2:
+        logger.info('Found only 1 cube; no statistics computed for %r',
+                    list(products)[0])
+        statistics_cubes = {statistic: cubes[0] for statistic in statistics}
+    else:
+        statistics_cubes = multicube_statistics(cubes=cubes,
+                                                statistics=statistics,
+                                                span=span)
+
+    # Add cubes to output products and log provenance
+    statistics_products = set()
+    for statistic, cube in statistics_cubes.items():
+        statistics_product = output_products[statistic]
+        statistics_product.cubes = [cube]
+
+        for product in products:
+            statistics_product.wasderivedfrom(product)
+
+        logger.info("Generated %s", statistics_product)
+        statistics_products.add(statistics_product)
+
+    return statistics_products
+
+
+def multi_model_statistics(products: set,
+                           statistics: list,
+                           output_products: set,
+                           span: str = 'overlap'):
+    """Entry point for ESMValCore's multi-model statistics preprocessor.
+
+    Compute statistics across cubes from different models.
+
+    See Also
+    --------
+    multicube_statistics : core statistics function.
+    """
+    statistics_products = _multiproduct_statistics(
+        products=products,
+        statistics=statistics,
+        output_products=output_products,
+        span=span,
+    )
+
+    return statistics_products

--- a/tests/sample_data/multimodel_statistics/test_multimodel.py
+++ b/tests/sample_data/multimodel_statistics/test_multimodel.py
@@ -8,7 +8,8 @@ import iris
 import numpy as np
 import pytest
 
-from esmvalcore.preprocessor import extract_time, multi_model_statistics
+from esmvalcore.preprocessor import extract_time
+from esmvalcore.preprocessor._multimodel import multicube_statistics
 
 esmvaltool_sample_data = pytest.importorskip("esmvaltool_sample_data")
 
@@ -118,11 +119,11 @@ def timeseries_cubes_day(request):
     return cube_dict
 
 
-def multimodel_test(cubes, span, statistic):
+def multimodel_test(cubes, statistic, span):
     """Run multimodel test with some simple checks."""
     statistics = [statistic]
 
-    result = multi_model_statistics(cubes, span=span, statistics=statistics)
+    result = multicube_statistics(cubes, statistics=statistics, span=span)
     assert isinstance(result, dict)
     assert statistic in result
 
@@ -139,7 +140,7 @@ def multimodel_regression_test(cubes, span, name):
     are being written.
     """
     statistic = 'mean'
-    result = multimodel_test(cubes, span=span, statistic=statistic)
+    result = multimodel_test(cubes, statistic=statistic, span=span)
     result_cube = result[statistic]
 
     filename = Path(__file__).with_name(f'{name}-{span}-{statistic}.nc')

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -4,6 +4,7 @@ import unittest
 
 import iris
 import numpy as np
+import pytest
 from cf_units import Unit
 
 import tests
@@ -15,6 +16,7 @@ from esmvalcore.preprocessor._multimodel import (
     _put_in_cube,
     _unify_time_coordinates,
     multicube_statistics,
+    multicube_statistics_iris,
 )
 
 
@@ -127,6 +129,29 @@ class Test(tests.Test):
                                      span='overlap')
         expected_ovlap_mean = np.ma.ones((2, 3, 2, 2))
         self.assert_array_equal(stats['mean'].data, expected_ovlap_mean)
+
+    def test_multicube_statistics_fail(self):
+        data = [self.cube1, self.cube1 * 2.0]
+        with pytest.raises(ValueError):
+            multicube_statistics(data,
+                                 span='overlap',
+                                 statistics=['non-existant'])
+
+    def test_multicube_statistics_iris(self):
+        data = [self.cube1, self.cube1 * 2.0]
+        statistics = ['mean', 'min', 'max']
+        stats = multicube_statistics_iris(data, statistics=statistics)
+        expected_mean = np.ma.ones((2, 3, 2, 2)) * 1.5
+        expected_min = np.ma.ones((2, 3, 2, 2)) * 1.0
+        expected_max = np.ma.ones((2, 3, 2, 2)) * 2.0
+        self.assert_array_equal(stats['mean'].data, expected_mean)
+        self.assert_array_equal(stats['min'].data, expected_min)
+        self.assert_array_equal(stats['max'].data, expected_max)
+
+    def test_multicube_statistics_iris_fail(self):
+        data = [self.cube1, self.cube1 * 2.0]
+        with pytest.raises(ValueError):
+            multicube_statistics_iris(data, statistics=['non-existent'])
 
     def test_compute_std(self):
         """Test statistic."""

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -7,17 +7,19 @@ import numpy as np
 from cf_units import Unit
 
 import tests
-from esmvalcore.preprocessor import multi_model_statistics
-from esmvalcore.preprocessor._multimodel import (_assemble_data,
-                                                 _compute_statistic,
-                                                 _get_time_slice, _plev_fix,
-                                                 _put_in_cube,
-                                                 _unify_time_coordinates)
+from esmvalcore.preprocessor._multimodel import (
+    _assemble_data,
+    _compute_statistic,
+    _get_time_slice,
+    _plev_fix,
+    _put_in_cube,
+    _unify_time_coordinates,
+    multicube_statistics,
+)
 
 
 class Test(tests.Test):
     """Test class for preprocessor/_multimodel.py."""
-
     def setUp(self):
         """Prepare tests."""
         # Make various time arrays
@@ -92,7 +94,9 @@ class Test(tests.Test):
 
     def test_compute_full_statistic_mon_cube(self):
         data = [self.cube1, self.cube2]
-        stats = multi_model_statistics(data, 'full', ['mean'])
+        stats = multicube_statistics(cubes=data,
+                                     statistics=['mean'],
+                                     span='full')
         expected_full_mean = np.ma.ones((5, 3, 2, 2))
         expected_full_mean.mask = np.ones((5, 3, 2, 2))
         expected_full_mean.mask[1] = False
@@ -100,7 +104,9 @@ class Test(tests.Test):
 
     def test_compute_full_statistic_yr_cube(self):
         data = [self.cube4, self.cube5]
-        stats = multi_model_statistics(data, 'full', ['mean'])
+        stats = multicube_statistics(cubes=data,
+                                     statistics=['mean'],
+                                     span='full')
         expected_full_mean = np.ma.ones((4, 3, 2, 2))
         expected_full_mean.mask = np.zeros((4, 3, 2, 2))
         expected_full_mean.mask[2:4] = True
@@ -108,13 +114,17 @@ class Test(tests.Test):
 
     def test_compute_overlap_statistic_mon_cube(self):
         data = [self.cube1, self.cube1]
-        stats = multi_model_statistics(data, 'overlap', ['mean'])
+        stats = multicube_statistics(cubes=data,
+                                     statistics=['mean'],
+                                     span='overlap')
         expected_ovlap_mean = np.ma.ones((2, 3, 2, 2))
         self.assert_array_equal(stats['mean'].data, expected_ovlap_mean)
 
     def test_compute_overlap_statistic_yr_cube(self):
         data = [self.cube4, self.cube4]
-        stats = multi_model_statistics(data, 'overlap', ['mean'])
+        stats = multicube_statistics(cubes=data,
+                                     statistics=['mean'],
+                                     span='overlap')
         expected_ovlap_mean = np.ma.ones((2, 3, 2, 2))
         self.assert_array_equal(stats['mean'].data, expected_ovlap_mean)
 


### PR DESCRIPTION
## Description
This PR adds an alternative function for computing statistics across cubes. It relies on existing Iris functionality to concatenate cubes along a new auxiliary dimension, and then calculate the statistics across that new dimension. 

This function supports lazy evaluation. It is also less error prone since much of the work is passed on to Iris. It is less flexible when the input cubes are not homogeneous. Therefore, it cannot immediately replace the existing function. However, it is very well suited for the ensemble statistics function we are developing in #673. Anticipating #744 and follow-up actions in #781, we can gradually work towards this 'engine' for multi-model statistics as well. 

- Follows up on #949 
- Related to #781 
- Related to #673

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [x] N/A YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [x] N/A Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
