### PR TITLE
Update CircleCi cache key on build changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - checkout
       - check_changes
       - restore_cache:
-          key: install-{{ .Branch }}
+          key: install-{{ .Branch }}-{{ checksum "setup.py" }}
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -73,7 +73,7 @@ jobs:
             pytest -n 2
             esmvaltool version
       - save_cache:
-          key: install-{{ .Branch }}
+          key: install-{{ .Branch }}-{{ checksum "setup.py" }}
           paths:
             - "/opt/conda/pkgs"
             - ".eggs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: test-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: test-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "environment.yml" }}
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -35,7 +35,7 @@ jobs:
             pip install .[test]
             pytest -n 2 -m "not installation"
       - save_cache:
-          key: test-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: test-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "environment.yml" }}
           paths:
             - ".eggs"
             - ".pytest_cache"
@@ -53,7 +53,7 @@ jobs:
       - checkout
       - check_changes
       - restore_cache:
-          key: install-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: install-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "environment.yml" }}
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -73,7 +73,7 @@ jobs:
             pytest -n 2
             esmvaltool version
       - save_cache:
-          key: install-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: install-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "environment.yml" }}
           paths:
             - "/opt/conda/pkgs"
             - ".eggs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: test-{{ .Branch }}
+          key: test-{{ .Branch }}-{{ checksum "setup.py" }}
       - run:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
@@ -35,7 +35,7 @@ jobs:
             pip install .[test]
             pytest -n 2 -m "not installation"
       - save_cache:
-          key: test-{{ .Branch }}
+          key: test-{{ .Branch }}-{{ checksum "setup.py" }}
           paths:
             - ".eggs"
             - ".pytest_cache"


### PR DESCRIPTION
## Description

I made this patch earlier today when I was debugging issues with CircleCI (#952). 

It turned out it did not actually solve my problem, but I think it makes caching in CircleCI a little bit safer in case we change the build through `setup.py` (see https://support.circleci.com/hc/en-us/articles/115015426888-Clear-project-dependency-cache). I linked it to `setup.py` since that is what CircleCI uses, but I'm open to other suggestions.

-   Closes #952

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [x] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [x] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
