### PR TITLE
Update iris documentation URL for sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -418,7 +418,7 @@ intersphinx_mapping = {
     (f'https://docs.esmvaltool.org/projects/esmvalcore/en/{rtd_version}/',
      None),
     'esmvaltool': (f'https://docs.esmvaltool.org/en/{rtd_version}/', None),
-    'iris': ('https://scitools.org.uk/iris/docs/latest/', None),
+    'iris': ('https://scitools-iris.readthedocs.io/en/latest/', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'python': ('https://docs.python.org/3/', None),


### PR DESCRIPTION
The URL where the iris documentation lives has changed. This pull request updates it, so the documentation builds successfully again.