### PR TITLE
Fix links to Iris documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The ESMValCore package provides various functions for:
 -   Reading CMIP/CMOR tables and using those to check model and observational data.
 
 -   ESMValTool preprocessor functions based on
-    [iris](https://scitools.org.uk/iris/docs/latest/) for e.g. regridding,
+    [iris](https://scitools-iris.readthedocs.io) for e.g. regridding,
     vertical interpolation, statistics, correcting (meta)data errors, extracting
     a time range, etcetera.
 

--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -263,7 +263,7 @@ Data loading
 
 Data loading is done using the data load functionality of `iris`; we will not go into too much detail
 about this since we can point the user to the specific functionality
-`here <https://scitools.org.uk/iris/docs/latest/userguide/loading_iris_cubes.html>`_ but we will underline
+`here <https://scitools-iris.readthedocs.io/en/latest/userguide/loading_iris_cubes.html>`_ but we will underline
 that the initial loading is done by adhering to the CF Conventions that `iris` operates by as well (see
 `CF Conventions Document <http://cfconventions.org/cf-conventions/cf-conventions.html>`_ and the search
 page for CF `standard names <http://cfconventions.org/standard-names.html>`_).
@@ -274,7 +274,7 @@ Data concatenation from multiple sources
 Oftentimes data retrieving results in assembling a continuous data stream from
 multiple files or even, multiple experiments. The internal mechanism through which
 the assembly is done is via cube concatenation. One peculiarity of iris concatenation
-(see `iris cube concatenation <https://scitools.org.uk/iris/docs/latest/userguide/merge_and_concat.html>`_)
+(see `iris cube concatenation <https://scitools-iris.readthedocs.io/en/latest/userguide/merge_and_concat.html>`_)
 is that it doesn't allow for concatenating time-overlapping cubes; this case is rather
 frequent with data from models overlapping in time, and is accounted for by a function that performs a
 flexible concatenation between two cubes, depending on the particular setup:

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -64,7 +64,7 @@ reducing the data processing load on the diagnostics side.  For an overview of
 the preprocessor structure see the :ref:`Preprocessors`.
 
 Each of the preprocessor operations is written in a dedicated python module and
-all of them receive and return an Iris cube
+all of them receive and return an instance of
 :obj:`iris.cube.Cube`, working
 sequentially on the data with no interactions between them. The order in which
 the preprocessor operations is applied is set by default to minimize
@@ -537,7 +537,7 @@ engine uses interpolation and extrapolation, with various schemes). The primary
 difference is that interpolation is based on sample data points, while
 regridding is based on the horizontal grid of another cube (the reference grid).
 
-The underlying regridding mechanism in ESMValTool uses the cube.regrid()
+The underlying regridding mechanism in ESMValTool uses
 :obj:`iris.cube.Cube.regrid`
 from Iris.
 
@@ -606,11 +606,11 @@ The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
 implementations in Iris:
 
-* ``linear``: Linear(extrapolation_mode='mask'), see :obj:`iris.analysis.Linear`.
-* ``linear_extrapolate``: Linear(extrapolation_mode='extrapolate'), see :obj:`iris.analysis.Linear`.
-* ``nearest``: Nearest(extrapolation_mode='mask'), see :obj:`iris.analysis.Nearest`.
-* ``area_weighted``: AreaWeighted() :obj:`iris.analysis.AreaWeighted`.
-* ``unstructured_nearest``: UnstructuredNearest(), see :obj:`iris.analysis.UnstructuredNearest`.
+* ``linear``: ``Linear(extrapolation_mode='mask')``, see :obj:`iris.analysis.Linear`.
+* ``linear_extrapolate``: ``Linear(extrapolation_mode='extrapolate')``, see :obj:`iris.analysis.Linear`.
+* ``nearest``: ``Nearest(extrapolation_mode='mask')``, see :obj:`iris.analysis.Nearest`.
+* ``area_weighted``: ``AreaWeighted()``, see :obj:`iris.analysis.AreaWeighted`.
+* ``unstructured_nearest``: ``UnstructuredNearest()``, see :obj:`iris.analysis.UnstructuredNearest`.
 
 See also :func:`esmvalcore.preprocessor.regrid`
 
@@ -1098,8 +1098,7 @@ See also :func:`esmvalcore.preprocessor.regrid_time`.
 This function allows the user to apply a filter to the timeseries data. This filter may be
 of the user's choice (currently only the ``low-pass`` Lanczos filter is implemented); the
 implementation is inspired by this `iris example
-<https://scitools-iris.readthedocs.io/en/latest/generated/gallery/general/plot_SOI_filtering.html>`_ and uses aggregation via a
-rolling window obj:`iris.cube.Cube.rolling_window`.
+<https://scitools-iris.readthedocs.io/en/latest/generated/gallery/general/plot_SOI_filtering.html>`_ and uses aggregation via :obj:`iris.cube.Cube.rolling_window`.
 
 Parameters:
     * window: the length of the filter window (in units of cube time coordinate).
@@ -1412,7 +1411,7 @@ value) of a field aggregated over specified coordinates. Its only argument is
 ``coords``, which can either be a single coordinate (given as :obj:`str`) or
 multiple coordinates (given as :obj:`list` of :obj:`str`). Usually, these
 coordinates refer to temporal categorised coordinates
-obj:`iris.coord_categorisation`
+:obj:`iris.coord_categorisation`
 like `year`, `month`, `day of year`, etc. For example, to extract the amplitude
 of the annual cycle for every single year in the data, use ``coords: year``; to
 extract the amplitude of the diurnal cycle for every single day in the data,

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -65,7 +65,7 @@ the preprocessor structure see the :ref:`Preprocessors`.
 
 Each of the preprocessor operations is written in a dedicated python module and
 all of them receive and return an Iris `cube
-<https://scitools.org.uk/iris/docs/v2.0/iris/iris/cube.html>`_ , working
+<https://scitools-iris.readthedocs.io/en/v2.0/iris/iris/cube.html>`_ , working
 sequentially on the data with no interactions between them. The order in which
 the preprocessor operations is applied is set by default to minimize
 the loss of information due to, for example, temporal and spatial subsetting or
@@ -538,7 +538,7 @@ difference is that interpolation is based on sample data points, while
 regridding is based on the horizontal grid of another cube (the reference grid).
 
 The underlying regridding mechanism in ESMValTool uses the `cube.regrid()
-<https://scitools.org.uk/iris/docs/latest/iris/iris/cube.html#iris.cube.Cube.regrid>`_
+<https://scitools-iris.readthedocs.io/en/latest/iris/iris/cube.html#iris.cube.Cube.regrid>`_
 from Iris.
 
 The use of the horizontal regridding functionality is flexible depending on
@@ -606,11 +606,11 @@ The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
 implementations in Iris:
 
-* ``linear``: `Linear(extrapolation_mode='mask') <https://scitools.org.uk/iris/docs/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
-* ``linear_extrapolate``: `Linear(extrapolation_mode='extrapolate') <https://scitools.org.uk/iris/docs/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
-* ``nearest``: `Nearest(extrapolation_mode='mask') <https://scitools.org.uk/iris/docs/latest/iris/iris/analysis.html#iris.analysis.Nearest>`_.
-* ``area_weighted``: `AreaWeighted() <https://scitools.org.uk/iris/docs/latest/iris/iris/analysis.html#iris.analysis.AreaWeighted>`_.
-* ``unstructured_nearest``: `UnstructuredNearest() <https://scitools.org.uk/iris/docs/latest/iris/iris/analysis.html#iris.analysis.UnstructuredNearest>`_.
+* ``linear``: `Linear(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
+* ``linear_extrapolate``: `Linear(extrapolation_mode='extrapolate') <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
+* ``nearest``: `Nearest(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.Nearest>`_.
+* ``area_weighted``: `AreaWeighted() <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.AreaWeighted>`_.
+* ``unstructured_nearest``: `UnstructuredNearest() <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.UnstructuredNearest>`_.
 
 See also :func:`esmvalcore.preprocessor.regrid`
 
@@ -1098,9 +1098,9 @@ See also :func:`esmvalcore.preprocessor.regrid_time`.
 This function allows the user to apply a filter to the timeseries data. This filter may be
 of the user's choice (currently only the ``low-pass`` Lanczos filter is implemented); the
 implementation is inspired by this `iris example
-<https://scitools.org.uk/iris/docs/latest/examples/General/
+<https://scitools-iris.readthedocs.io/en/latest/examples/General/
 SOI_filtering.html?highlight=running%20mean>`_ and uses aggregation via a
-`rolling window <https://scitools.org.uk/iris/docs/v2.0/iris/iris/cube.html#iris.cube.Cube.rolling_window>`_.
+`rolling window <https://scitools-iris.readthedocs.io/en/v2.0/iris/iris/cube.html#iris.cube.Cube.rolling_window>`_.
 
 Parameters:
     * window: the length of the filter window (in units of cube time coordinate).
@@ -1413,7 +1413,7 @@ value) of a field aggregated over specified coordinates. Its only argument is
 ``coords``, which can either be a single coordinate (given as :obj:`str`) or
 multiple coordinates (given as :obj:`list` of :obj:`str`). Usually, these
 coordinates refer to temporal `categorised coordinates
-<https://scitools.org.uk/iris/docs/latest/iris/iris/coord_categorisation.html>`_
+<https://scitools-iris.readthedocs.io/en/latest/iris/iris/coord_categorisation.html>`_
 like `year`, `month`, `day of year`, etc. For example, to extract the amplitude
 of the annual cycle for every single year in the data, use ``coords: year``; to
 extract the amplitude of the diurnal cycle for every single day in the data,

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1098,8 +1098,7 @@ See also :func:`esmvalcore.preprocessor.regrid_time`.
 This function allows the user to apply a filter to the timeseries data. This filter may be
 of the user's choice (currently only the ``low-pass`` Lanczos filter is implemented); the
 implementation is inspired by this `iris example
-<https://scitools-iris.readthedocs.io/en/latest/examples/General/
-SOI_filtering.html?highlight=running%20mean>`_ and uses aggregation via a
+<https://scitools-iris.readthedocs.io/en/latest/generated/gallery/general/plot_SOI_filtering.html>`_ and uses aggregation via a
 `rolling window <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/cube.html#iris.cube.Cube.rolling_window>`_.
 
 Parameters:

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -64,8 +64,8 @@ reducing the data processing load on the diagnostics side.  For an overview of
 the preprocessor structure see the :ref:`Preprocessors`.
 
 Each of the preprocessor operations is written in a dedicated python module and
-all of them receive and return an Iris `cube
-<https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/cube.html>`_ , working
+all of them receive and return an Iris cube
+:obj:`iris.cube.Cube`, working
 sequentially on the data with no interactions between them. The order in which
 the preprocessor operations is applied is set by default to minimize
 the loss of information due to, for example, temporal and spatial subsetting or
@@ -537,8 +537,8 @@ engine uses interpolation and extrapolation, with various schemes). The primary
 difference is that interpolation is based on sample data points, while
 regridding is based on the horizontal grid of another cube (the reference grid).
 
-The underlying regridding mechanism in ESMValTool uses the `cube.regrid()
-<https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/cube.html#iris.cube.Cube.regrid>`_
+The underlying regridding mechanism in ESMValTool uses the cube.regrid()
+:obj:`iris.cube.Cube.regrid`
 from Iris.
 
 The use of the horizontal regridding functionality is flexible depending on
@@ -606,11 +606,11 @@ The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
 implementations in Iris:
 
-* ``linear``: `Linear(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.Linear>`_.
-* ``linear_extrapolate``: `Linear(extrapolation_mode='extrapolate') <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.Linear>`_.
-* ``nearest``: `Nearest(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/generated/api/irisanalysis.html#iris.analysis.Nearest>`_.
-* ``area_weighted``: `AreaWeighted() <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.AreaWeighted>`_.
-* ``unstructured_nearest``: `UnstructuredNearest() <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.UnstructuredNearest>`_.
+* ``linear``: Linear(extrapolation_mode='mask') obj:`iris.analysis.Linear`.
+* ``linear_extrapolate``: Linear(extrapolation_mode='extrapolate') obj:`iris.analysis.Linear`.
+* ``nearest``: Nearest(extrapolation_mode='mask') obj:`iris.analysis.Nearest`.
+* ``area_weighted``: AreaWeighted() obj:`iris.analysis.AreaWeighted`.
+* ``unstructured_nearest``: UnstructuredNearest() obj:`iris.analysis.UnstructuredNearest`.
 
 See also :func:`esmvalcore.preprocessor.regrid`
 
@@ -1099,7 +1099,7 @@ This function allows the user to apply a filter to the timeseries data. This fil
 of the user's choice (currently only the ``low-pass`` Lanczos filter is implemented); the
 implementation is inspired by this `iris example
 <https://scitools-iris.readthedocs.io/en/latest/generated/gallery/general/plot_SOI_filtering.html>`_ and uses aggregation via a
-`rolling window <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/cube.html#iris.cube.Cube.rolling_window>`_.
+rolling window obj:`iris.cube.Cube.rolling_window`.
 
 Parameters:
     * window: the length of the filter window (in units of cube time coordinate).
@@ -1411,8 +1411,8 @@ This function extracts the peak-to-peak amplitude (maximum value minus minimum
 value) of a field aggregated over specified coordinates. Its only argument is
 ``coords``, which can either be a single coordinate (given as :obj:`str`) or
 multiple coordinates (given as :obj:`list` of :obj:`str`). Usually, these
-coordinates refer to temporal `categorised coordinates
-<https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/coord_categorisation.html>`_
+coordinates refer to temporal categorised coordinates
+obj:`iris.coord_categorisation`
 like `year`, `month`, `day of year`, etc. For example, to extract the amplitude
 of the annual cycle for every single year in the data, use ``coords: year``; to
 extract the amplitude of the diurnal cycle for every single day in the data,

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -606,11 +606,11 @@ The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
 implementations in Iris:
 
-* ``linear``: <Linear(extrapolation_mode='mask') :obj:`iris.analysis.Linear`>.
-* ``linear_extrapolate``: <Linear(extrapolation_mode='extrapolate') :obj:`iris.analysis.Linear`>.
-* ``nearest``: <Nearest(extrapolation_mode='mask') :obj:`iris.analysis.Nearest`>.
-* ``area_weighted``: <AreaWeighted() :obj:`iris.analysis.AreaWeighted`>.
-* ``unstructured_nearest``: <UnstructuredNearest() :obj:`iris.analysis.UnstructuredNearest`>.
+* ``linear``: Linear(extrapolation_mode='mask'), see :obj:`iris.analysis.Linear`.
+* ``linear_extrapolate``: Linear(extrapolation_mode='extrapolate'), see :obj:`iris.analysis.Linear`.
+* ``nearest``: Nearest(extrapolation_mode='mask'), see :obj:`iris.analysis.Nearest`.
+* ``area_weighted``: AreaWeighted() :obj:`iris.analysis.AreaWeighted`.
+* ``unstructured_nearest``: UnstructuredNearest(), see :obj:`iris.analysis.UnstructuredNearest`.
 
 See also :func:`esmvalcore.preprocessor.regrid`
 

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -606,11 +606,11 @@ The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
 implementations in Iris:
 
-* ``linear``: Linear(extrapolation_mode='mask') obj:`iris.analysis.Linear`.
-* ``linear_extrapolate``: Linear(extrapolation_mode='extrapolate') obj:`iris.analysis.Linear`.
-* ``nearest``: Nearest(extrapolation_mode='mask') obj:`iris.analysis.Nearest`.
-* ``area_weighted``: AreaWeighted() obj:`iris.analysis.AreaWeighted`.
-* ``unstructured_nearest``: UnstructuredNearest() obj:`iris.analysis.UnstructuredNearest`.
+* ``linear``: <Linear(extrapolation_mode='mask') obj:`iris.analysis.Linear`>.
+* ``linear_extrapolate``: <Linear(extrapolation_mode='extrapolate') obj:`iris.analysis.Linear`>.
+* ``nearest``: <Nearest(extrapolation_mode='mask') obj:`iris.analysis.Nearest`>.
+* ``area_weighted``: <AreaWeighted() obj:`iris.analysis.AreaWeighted`>.
+* ``unstructured_nearest``: <UnstructuredNearest() obj:`iris.analysis.UnstructuredNearest`>.
 
 See also :func:`esmvalcore.preprocessor.regrid`
 

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -606,11 +606,11 @@ The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
 implementations in Iris:
 
-* ``linear``: <Linear(extrapolation_mode='mask') obj:`iris.analysis.Linear`>.
-* ``linear_extrapolate``: <Linear(extrapolation_mode='extrapolate') obj:`iris.analysis.Linear`>.
-* ``nearest``: <Nearest(extrapolation_mode='mask') obj:`iris.analysis.Nearest`>.
-* ``area_weighted``: <AreaWeighted() obj:`iris.analysis.AreaWeighted`>.
-* ``unstructured_nearest``: <UnstructuredNearest() obj:`iris.analysis.UnstructuredNearest`>.
+* ``linear``: <Linear(extrapolation_mode='mask') :obj:`iris.analysis.Linear`>.
+* ``linear_extrapolate``: <Linear(extrapolation_mode='extrapolate') :obj:`iris.analysis.Linear`>.
+* ``nearest``: <Nearest(extrapolation_mode='mask') :obj:`iris.analysis.Nearest`>.
+* ``area_weighted``: <AreaWeighted() :obj:`iris.analysis.AreaWeighted`>.
+* ``unstructured_nearest``: <UnstructuredNearest() :obj:`iris.analysis.UnstructuredNearest`>.
 
 See also :func:`esmvalcore.preprocessor.regrid`
 

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -607,7 +607,7 @@ the horizontal regridding functionality directly map to their corresponding
 implementations in Iris:
 
 * ``linear``: `Linear(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.Linear>`_.
-* ``linear_extrapolate``: `Linear(extrapolation_mode='extrapolate') <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
+* ``linear_extrapolate``: `Linear(extrapolation_mode='extrapolate') <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.Linear>`_.
 * ``nearest``: `Nearest(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/generated/api/irisanalysis.html#iris.analysis.Nearest>`_.
 * ``area_weighted``: `AreaWeighted() <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.AreaWeighted>`_.
 * ``unstructured_nearest``: `UnstructuredNearest() <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.UnstructuredNearest>`_.

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -65,7 +65,7 @@ the preprocessor structure see the :ref:`Preprocessors`.
 
 Each of the preprocessor operations is written in a dedicated python module and
 all of them receive and return an Iris `cube
-<https://scitools-iris.readthedocs.io/en/v2.0/iris/iris/cube.html>`_ , working
+<https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/cube.html>`_ , working
 sequentially on the data with no interactions between them. The order in which
 the preprocessor operations is applied is set by default to minimize
 the loss of information due to, for example, temporal and spatial subsetting or
@@ -538,7 +538,7 @@ difference is that interpolation is based on sample data points, while
 regridding is based on the horizontal grid of another cube (the reference grid).
 
 The underlying regridding mechanism in ESMValTool uses the `cube.regrid()
-<https://scitools-iris.readthedocs.io/en/latest/iris/iris/cube.html#iris.cube.Cube.regrid>`_
+<https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/cube.html#iris.cube.Cube.regrid>`_
 from Iris.
 
 The use of the horizontal regridding functionality is flexible depending on
@@ -606,11 +606,11 @@ The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
 implementations in Iris:
 
-* ``linear``: `Linear(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
+* ``linear``: `Linear(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.Linear>`_.
 * ``linear_extrapolate``: `Linear(extrapolation_mode='extrapolate') <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.Linear>`_.
-* ``nearest``: `Nearest(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.Nearest>`_.
-* ``area_weighted``: `AreaWeighted() <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.AreaWeighted>`_.
-* ``unstructured_nearest``: `UnstructuredNearest() <https://scitools-iris.readthedocs.io/en/latest/iris/iris/analysis.html#iris.analysis.UnstructuredNearest>`_.
+* ``nearest``: `Nearest(extrapolation_mode='mask') <https://scitools-iris.readthedocs.io/en/latest/generated/api/irisanalysis.html#iris.analysis.Nearest>`_.
+* ``area_weighted``: `AreaWeighted() <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.AreaWeighted>`_.
+* ``unstructured_nearest``: `UnstructuredNearest() <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/analysis.html#iris.analysis.UnstructuredNearest>`_.
 
 See also :func:`esmvalcore.preprocessor.regrid`
 
@@ -1100,7 +1100,7 @@ of the user's choice (currently only the ``low-pass`` Lanczos filter is implemen
 implementation is inspired by this `iris example
 <https://scitools-iris.readthedocs.io/en/latest/examples/General/
 SOI_filtering.html?highlight=running%20mean>`_ and uses aggregation via a
-`rolling window <https://scitools-iris.readthedocs.io/en/v2.0/iris/iris/cube.html#iris.cube.Cube.rolling_window>`_.
+`rolling window <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/cube.html#iris.cube.Cube.rolling_window>`_.
 
 Parameters:
     * window: the length of the filter window (in units of cube time coordinate).
@@ -1413,7 +1413,7 @@ value) of a field aggregated over specified coordinates. Its only argument is
 ``coords``, which can either be a single coordinate (given as :obj:`str`) or
 multiple coordinates (given as :obj:`list` of :obj:`str`). Usually, these
 coordinates refer to temporal `categorised coordinates
-<https://scitools-iris.readthedocs.io/en/latest/iris/iris/coord_categorisation.html>`_
+<https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/coord_categorisation.html>`_
 like `year`, `month`, `day of year`, etc. For example, to extract the amplitude
 of the annual cycle for every single year in the data, use ``coords: year``; to
 extract the amplitude of the diurnal cycle for every single day in the data,

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -741,8 +741,7 @@ def low_pass_weights(window, cutoff):
     """Calculate weights for a low pass Lanczos filter.
 
     Method borrowed from `iris example
-    <https://scitools-iris.readthedocs.io/en/latest/examples/General/
-    SOI_filtering.html?highlight=running%20mean>`_
+    <https://scitools-iris.readthedocs.io/en/latest/generated/gallery/general/plot_SOI_filtering.html?highlight=running%20mean>`_
 
     Parameters
     ----------
@@ -778,15 +777,14 @@ def timeseries_filter(cube,
     """Apply a timeseries filter.
 
     Method borrowed from `iris example
-    <https://scitools-iris.readthedocs.io/en/latest/examples/General/
-    SOI_filtering.html?highlight=running%20mean>`_
+    <https://scitools-iris.readthedocs.io/en/latest/generated/gallery/general/plot_SOI_filtering.html?highlight=running%20mean>`_
 
     Apply each filter using the rolling_window method used with the weights
     keyword argument. A weighted sum is required because the magnitude of
     the weights are just as important as their relative sizes.
 
     See also the `iris rolling window
-    <https://scitools-iris.readthedocs.io/en/v2.0/iris/iris/
+    <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/
     cube.html#iris.cube.Cube.rolling_window>`_
 
     Parameters

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -741,7 +741,7 @@ def low_pass_weights(window, cutoff):
     """Calculate weights for a low pass Lanczos filter.
 
     Method borrowed from `iris example
-    <https://scitools.org.uk/iris/docs/latest/examples/General/
+    <https://scitools-iris.readthedocs.io/en/latest/examples/General/
     SOI_filtering.html?highlight=running%20mean>`_
 
     Parameters
@@ -778,7 +778,7 @@ def timeseries_filter(cube,
     """Apply a timeseries filter.
 
     Method borrowed from `iris example
-    <https://scitools.org.uk/iris/docs/latest/examples/General/
+    <https://scitools-iris.readthedocs.io/en/latest/examples/General/
     SOI_filtering.html?highlight=running%20mean>`_
 
     Apply each filter using the rolling_window method used with the weights
@@ -786,7 +786,7 @@ def timeseries_filter(cube,
     the weights are just as important as their relative sizes.
 
     See also the `iris rolling window
-    <https://scitools.org.uk/iris/docs/v2.0/iris/iris/
+    <https://scitools-iris.readthedocs.io/en/v2.0/iris/iris/
     cube.html#iris.cube.Cube.rolling_window>`_
 
     Parameters

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -783,7 +783,7 @@ def timeseries_filter(cube,
     keyword argument. A weighted sum is required because the magnitude of
     the weights are just as important as their relative sizes.
 
-    See also the iris rolling window obj:`iris.cube.Cube.rolling_window`.
+    See also the iris rolling window :obj:`iris.cube.Cube.rolling_window`.
 
     Parameters
     ----------

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -783,9 +783,7 @@ def timeseries_filter(cube,
     keyword argument. A weighted sum is required because the magnitude of
     the weights are just as important as their relative sizes.
 
-    See also the `iris rolling window
-    <https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/
-    cube.html#iris.cube.Cube.rolling_window>`_
+    See also the iris rolling window obj:`iris.cube.Cube.rolling_window`.
 
     Parameters
     ----------


### PR DESCRIPTION
Iris documentation has been moved to ReadTheDocs. This PR updates our links to it

***

## Before you get started

-   [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [x] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

