### PR TITLE
Support per dataset DRS in native6 project

### DIFF
--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -166,7 +166,7 @@ def _resolve_latestversion(dirname_template):
     return dirname_template
 
 
-def _select_drs(input_type, drs, project):
+def _select_drs(input_type, drs, project, dataset):
     """Select the directory structure of input path."""
     cfg = get_project_config(project)
     input_path = cfg[input_type]
@@ -174,6 +174,10 @@ def _select_drs(input_type, drs, project):
         return input_path
 
     structure = drs.get(project, 'default')
+
+    if project == 'native6' and dataset in input_path:
+        return input_path[dataset]
+
     if structure in input_path:
         return input_path[structure]
 
@@ -194,9 +198,10 @@ def get_rootpath(rootpath, project):
 def _find_input_dirs(variable, rootpath, drs):
     """Return a the full paths to input directories."""
     project = variable['project']
+    dataset = variable['dataset']
 
     root = get_rootpath(rootpath, project)
-    path_template = _select_drs('input_dir', drs, project)
+    path_template = _select_drs('input_dir', drs, project, dataset)
 
     dirnames = []
     for dirname_template in _replace_tags(path_template, variable):
@@ -217,7 +222,9 @@ def _find_input_dirs(variable, rootpath, drs):
 
 def _get_filenames_glob(variable, drs):
     """Return patterns that can be used to look for input files."""
-    path_template = _select_drs('input_file', drs, variable['project'])
+    project = variable['project']
+    dataset = variable['dataset']
+    path_template = _select_drs('input_file', drs, project, dataset)
     filenames_glob = _replace_tags(path_template, variable)
     return filenames_glob
 


### PR DESCRIPTION
## Description
This extends the data finder for the native6 project. This makes it possible to have e.g.

config-user.yml:
```yml
rootpath:
  native6: ~/data
drs:
  native6: default
```

config-developer.yml:
```yml
native6:
  input_dir:
    default: 'Tier{tier}/{dataset}/{latestversion}/{frequency}/{short_name}'
    MSWEP: '{project}/{dataset}_{version}/{area}_{frequency}_{grid}'
    EMAC: '...'
  input_file:
    default: '*.nc'
    MSWEP: '*.nc'
    EMAC: '*.nc'
```

The data finder will then try to use the dataset name to find the corresponding entry in the config-developer file. 
So, if in a recipe

```
datasets:
  - {project: native6, dataset: MSWEP, version: V220, ...}
  - {project: native6, dataset: ERA5, version: 1, tier: 3, ...}
  - {project: native6, dataset: EMAC, ...}
```

it will find the corresponding data stored in:
MSWEP: `~/data/native6/MSWEP_V220/...`
ERA5:  `~/data/native6/Tier3/ERA5/1/...` (it falls back to default for there is no ERA5 specific entry in cfg-developer)
EMAC: `~/data/native6/EMAC/...`

Before I continue, @bouweandela is this what you had in mind for #494?
@stefsmeets @bsolino relevant for MSWEP and EMAC.

TODO: Currently it only works for the input_dir, not the filename pattern

-   Closes #494 
-   Link to documentation:

***

## Before you get started

-   [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [ ] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
