### PR TITLE
Fix duplication in preprocessors DEFAULT_ORDER 

### DIFF
--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -89,12 +89,6 @@ __all__ = [
     'cmor_check_metadata',
     # Extract years given by dataset keys (start_year and end_year)
     'clip_start_end_year',
-    # Time extraction
-    'extract_time',
-    'extract_season',
-    'extract_month',
-    'resample_hours',
-    'resample_time',
     # Data reformatting/CMORization
     'fix_data',
     'cmor_check_data',
@@ -102,6 +96,8 @@ __all__ = [
     'extract_time',
     'extract_season',
     'extract_month',
+    'resample_hours',
+    'resample_time',
     # Level extraction
     'extract_levels',
     # Weighting

--- a/tests/unit/preprocessor/test_configuration.py
+++ b/tests/unit/preprocessor/test_configuration.py
@@ -1,0 +1,27 @@
+"""Tests for the basic configuration of the preprocessor module."""
+from esmvalcore.preprocessor import (
+    DEFAULT_ORDER,
+    FINAL_STEPS,
+    INITIAL_STEPS,
+    MULTI_MODEL_FUNCTIONS,
+    TIME_PREPROCESSORS,
+)
+
+
+def test_non_repeated_keys():
+    """Check that there are not repeated keys in the lists."""
+    assert len(DEFAULT_ORDER) == len(set(DEFAULT_ORDER))
+    assert len(TIME_PREPROCESSORS) == len(set(TIME_PREPROCESSORS))
+    assert len(INITIAL_STEPS) == len(set(INITIAL_STEPS))
+    assert len(FINAL_STEPS) == len(set(FINAL_STEPS))
+    assert len(MULTI_MODEL_FUNCTIONS) == len(set(MULTI_MODEL_FUNCTIONS))
+
+
+def test_time_preprocessores_default_order_added():
+    assert all(
+        (time_preproc in DEFAULT_ORDER for time_preproc in TIME_PREPROCESSORS))
+
+
+def test_multimodel_functions_in_default_order():
+    assert all((time_preproc in DEFAULT_ORDER
+                for time_preproc in MULTI_MODEL_FUNCTIONS))


### PR DESCRIPTION
Fix duplicated keys in DEFAULT_ORDER and add some tests to avoid it happening again

-   Closes #971 


-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [x] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

