### PR TITLE
Format cmor related files

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -11,8 +11,7 @@ import numpy as np
 
 from .table import CMOR_TABLES
 
-CheckLevels = IntEnum(
-    'CheckLevels', 'DEBUG STRICT DEFAULT RELAXED IGNORE')
+CheckLevels = IntEnum('CheckLevels', 'DEBUG STRICT DEFAULT RELAXED IGNORE')
 """Level of strictness of the checks.
 
    Attributes
@@ -86,8 +85,7 @@ class CMORCheck():
         self.automatic_fixes = automatic_fixes
 
     def check_metadata(self, logger=None):
-        """
-        Check the cube metadata.
+        """Check the cube metadata.
 
         Perform all the tests that do not require to have the data in memory.
 
@@ -109,7 +107,6 @@ class CMORCheck():
             If errors are found. If fail_on_error attribute is set to True,
             raises as soon as an error is detected. If set to False, it perform
             all checks and then raises.
-
         """
         if logger is not None:
             self._logger = logger
@@ -150,7 +147,6 @@ class CMORCheck():
             If errors are found. If fail_on_error attribute is set to True,
             raises as soon as an error is detected. If set to False, it perform
             all checks and then raises.
-
         """
         if logger is not None:
             self._logger = logger
@@ -173,10 +169,9 @@ class CMORCheck():
         ------
         CMORCheckError
             If any errors were reported before calling this method.
-
         """
         if self.has_errors():
-            msg = 'There were errors in variable {}:\n{}\nin cube:\n{}'
+            msg = 'There were errors in variable {}:\n{}\n in cube:\n{}'
             msg = msg.format(self._cube.var_name, '\n '.join(self._errors),
                              self._cube)
             raise CMORCheckError(msg)
@@ -188,7 +183,6 @@ class CMORCheck():
         ----------
         logger: logging.Logger
             Given logger
-
         """
         if self.has_warnings():
             msg = 'There were warnings in variable {}:\n{}\n'.format(
@@ -202,7 +196,6 @@ class CMORCheck():
         ----------
         logger: logging.Logger
             Given logger.
-
         """
         if self.has_debug_messages():
             msg = 'There were metadata changes in variable {}:\n{}\n'.format(
@@ -225,32 +218,27 @@ class CMORCheck():
                 if self.automatic_fixes:
                     self.report_warning(
                         'Standard name for {} changed from {} to {}',
-                        self._cube.var_name,
-                        self._cube.standard_name,
-                        self._cmor_var.standard_name
-                    )
+                        self._cube.var_name, self._cube.standard_name,
+                        self._cmor_var.standard_name)
                     self._cube.standard_name = self._cmor_var.standard_name
                 else:
-                    self.report_error(
-                        self._attr_msg, self._cube.var_name, 'standard_name',
-                        self._cmor_var.standard_name, self._cube.standard_name
-                    )
+                    self.report_error(self._attr_msg, self._cube.var_name,
+                                      'standard_name',
+                                      self._cmor_var.standard_name,
+                                      self._cube.standard_name)
         # Check long_name
         if self._cmor_var.long_name:
             if self._cube.long_name != self._cmor_var.long_name:
                 if self.automatic_fixes:
                     self.report_warning(
                         'Long name for {} changed from {} to {}',
-                        self._cube.var_name,
-                        self._cube.long_name,
-                        self._cmor_var.long_name
-                    )
+                        self._cube.var_name, self._cube.long_name,
+                        self._cmor_var.long_name)
                     self._cube.long_name = self._cmor_var.long_name
                 else:
-                    self.report_error(
-                        self._attr_msg, self._cube.var_name, 'long_name',
-                        self._cmor_var.long_name, self._cube.long_name
-                    )
+                    self.report_error(self._attr_msg, self._cube.var_name,
+                                      'long_name', self._cmor_var.long_name,
+                                      self._cube.long_name)
 
         # Check units
         if (self.automatic_fixes and self._cube.attributes.get(
@@ -262,10 +250,9 @@ class CMORCheck():
             units = self._get_effective_units()
             if self._cube.units != units:
                 if not self._cube.units.is_convertible(units):
-                    self.report_error(
-                        f'Variable {self._cube.var_name} units '
-                        f'{self._cube.units} can not be '
-                        f'converted to {self._cmor_var.units}')
+                    self.report_error(f'Variable {self._cube.var_name} units '
+                                      f'{self._cube.units} can not be '
+                                      f'converted to {self._cmor_var.units}')
                 else:
                     self.report_warning(
                         f'Variable {self._cube.var_name} units '
@@ -281,10 +268,9 @@ class CMORCheck():
                     self.report_warning('{}: attribute {} not present',
                                         self._cube.var_name, attr)
                 elif self._cube.attributes[attr] != attr_value:
-                    self.report_error(
-                        self._attr_msg, self._cube.var_name,
-                        attr, attr_value,
-                        self._cube.attributes[attr])
+                    self.report_error(self._attr_msg, self._cube.var_name,
+                                      attr, attr_value,
+                                      self._cube.attributes[attr])
 
     def _get_effective_units(self):
         """Get effective units."""
@@ -320,13 +306,13 @@ class CMORCheck():
         for coord in self._cube.coords():
             if coord.standard_name:
                 if coord.standard_name in standard_names:
-                    coords = [c.var_name for c in self._cube.coords(
-                        standard_name=coord.standard_name)
+                    coords = [
+                        c.var_name for c in self._cube.coords(
+                            standard_name=coord.standard_name)
                     ]
                     self.report_error(
                         'There are multiple coordinates with '
-                        f'standard_name "{coord.standard_name}": {coords}'
-                    )
+                        f'standard_name "{coord.standard_name}": {coords}')
                 else:
                     standard_names.add(coord.standard_name)
 
@@ -339,8 +325,8 @@ class CMORCheck():
             else:
                 try:
                     cube_coord = self._cube.coord(var_name=coordinate.out_name)
-                    if (cube_coord.standard_name is None and
-                            coordinate.standard_name == ''):
+                    if (cube_coord.standard_name is None
+                            and coordinate.standard_name == ''):
                         pass
                     elif cube_coord.standard_name != coordinate.standard_name:
                         self.report_critical(
@@ -378,11 +364,11 @@ class CMORCheck():
                         if coordinate.standard_name in ['time', 'latitude',
                                                         'longitude'] or \
                            coordinate.requested:
-                            self.report_critical(
-                                self._does_msg, coordinate.name, 'exist')
+                            self.report_critical(self._does_msg,
+                                                 coordinate.name, 'exist')
                         else:
-                            self.report_error(
-                                self._does_msg, coordinate.name, 'exist')
+                            self.report_error(self._does_msg, coordinate.name,
+                                              'exist')
 
     def _check_generic_level_dim_names(self, key, coordinate):
         standard_name = None
@@ -391,9 +377,7 @@ class CMORCheck():
         if coordinate.generic_lev_coords:
             for coord in coordinate.generic_lev_coords.values():
                 try:
-                    cube_coord = self._cube.coord(
-                        var_name=coord.out_name
-                    )
+                    cube_coord = self._cube.coord(var_name=coord.out_name)
                     out_name = coord.out_name
                     if cube_coord.standard_name == coord.standard_name:
                         standard_name = coord.standard_name
@@ -401,8 +385,7 @@ class CMORCheck():
                 except iris.exceptions.CoordinateNotFoundError:
                     try:
                         cube_coord = self._cube.coord(
-                            var_name=coord.standard_name
-                        )
+                            var_name=coord.standard_name)
                         standard_name = coord.standard_name
                         name = coord.name
                     except iris.exceptions.CoordinateNotFoundError:
@@ -411,29 +394,23 @@ class CMORCheck():
                 if not out_name:
                     self.report_error(
                         f'Generic level coordinate {key} '
-                        'has wrong var_name.',
-                    )
+                        'has wrong var_name.', )
                 level = coordinate.generic_lev_coords[name]
                 level.generic_level = True
                 level.generic_lev_coords = self._cmor_var.coordinates[
                     key].generic_lev_coords
                 self._cmor_var.coordinates[key] = level
-                self.report_debug_message(
-                    f'Generic level coordinate {key} '
-                    'will be checked against '
-                    f'{name} coordinate information'
-                )
+                self.report_debug_message(f'Generic level coordinate {key} '
+                                          'will be checked against '
+                                          f'{name} coordinate information')
             else:
                 if out_name:
                     self.report_critical(
                         f'Generic level coordinate {key} '
                         'has wrong standard_name '
-                        'or is not set.',
-                    )
+                        'or is not set.', )
                 else:
-                    self.report_critical(
-                        self._does_msg, key, 'exist'
-                    )
+                    self.report_critical(self._does_msg, key, 'exist')
 
     def _check_coords(self):
         """Check coordinates."""
@@ -503,18 +480,15 @@ class CMORCheck():
                 except ValueError as ex:
                     self.report_warning(
                         'Can not guess bounds for coordinate {0} '
-                        'from var {1}: {2}', coord.var_name, var_name, ex
-                    )
+                        'from var {1}: {2}', coord.var_name, var_name, ex)
                 else:
                     self.report_warning(
                         'Added guessed bounds to coordinate {0} from var {1}',
-                        coord.var_name, var_name
-                    )
+                        coord.var_name, var_name)
             else:
                 self.report_warning(
                     'Coordinate {0} from var {1} does not have bounds',
-                    coord.var_name, var_name
-                )
+                    coord.var_name, var_name)
 
     def _check_coord_monotonicity_and_direction(self, cmor, coord, var_name):
         """Check monotonicity and direction of coordinate."""
@@ -530,15 +504,15 @@ class CMORCheck():
             if cmor.stored_direction == 'increasing':
                 if coord.points[0] > coord.points[1]:
                     if not self.automatic_fixes or coord.ndim > 1:
-                        self.report_critical(
-                            self._is_msg, var_name, 'increasing')
+                        self.report_critical(self._is_msg, var_name,
+                                             'increasing')
                     else:
                         self._reverse_coord(coord)
             elif cmor.stored_direction == 'decreasing':
                 if coord.points[0] < coord.points[1]:
                     if not self.automatic_fixes or coord.ndim > 1:
-                        self.report_critical(
-                            self._is_msg, var_name, 'decreasing')
+                        self.report_critical(self._is_msg, var_name,
+                                             'decreasing')
                     else:
                         self._reverse_coord(coord)
 
@@ -564,9 +538,9 @@ class CMORCheck():
                     l_fix_coord_value = self._check_longitude_min(
                         coord, var_name)
                 else:
-                    self.report_critical(
-                        self._vals_msg, var_name,
-                        '< {} ='.format('valid_min'), valid_min)
+                    self.report_critical(self._vals_msg, var_name,
+                                         '< {} ='.format('valid_min'),
+                                         valid_min)
 
         if coord_info.valid_max:
             valid_max = float(coord_info.valid_max)
@@ -576,14 +550,14 @@ class CMORCheck():
                     l_fix_coord_value = self._check_longitude_max(
                         coord, var_name)
                 else:
-                    self.report_critical(
-                        self._vals_msg, var_name,
-                        '> {} ='.format('valid_max'), valid_max)
+                    self.report_critical(self._vals_msg, var_name,
+                                         '> {} ='.format('valid_max'),
+                                         valid_max)
 
         if l_fix_coord_value:
             if coord.ndim == 1:
-                lon_extent = iris.coords.CoordExtent(
-                    coord, 0.0, 360., True, False)
+                lon_extent = iris.coords.CoordExtent(coord, 0.0, 360., True,
+                                                     False)
                 self._cube = self._cube.intersection(lon_extent)
             else:
                 new_lons = coord.points.copy()
@@ -601,16 +575,14 @@ class CMORCheck():
     def _check_longitude_max(self, coord, var_name):
         if np.any(coord.points > 720):
             self.report_critical(
-                f'{var_name} longitude coordinate has values > 720 degrees'
-            )
+                f'{var_name} longitude coordinate has values > 720 degrees')
             return False
         return True
 
     def _check_longitude_min(self, coord, var_name):
         if np.any(coord.points < -360):
             self.report_critical(
-                f'{var_name} longitude coordinate has values < -360 degrees'
-            )
+                f'{var_name} longitude coordinate has values < -360 degrees')
             return False
         return True
 
@@ -646,9 +618,8 @@ class CMORCheck():
 
         var_name = coord.var_name
         if not coord.is_monotonic():
-            self.report_error(
-                'Time coordinate for var {} is not monotonic', var_name
-            )
+            self.report_error('Time coordinate for var {} is not monotonic',
+                              var_name)
 
         if not coord.units.is_time_reference():
             self.report_critical(self._does_msg, var_name,
@@ -656,9 +627,8 @@ class CMORCheck():
         else:
             old_units = coord.units
             coord.convert_units(
-                cf_units.Unit(
-                    'days since 1850-1-1 00:00:00',
-                    calendar=coord.units.calendar))
+                cf_units.Unit('days since 1850-1-1 00:00:00',
+                              calendar=coord.units.calendar))
             simplified_cal = self._simplify_calendar(coord.units.calendar)
             coord.units = cf_units.Unit(coord.units.origin, simplified_cal)
 
@@ -761,7 +731,6 @@ class CMORCheck():
         -------
         bool:
             True if there are pending errors, False otherwise.
-
         """
         return len(self._errors) > 0
 
@@ -772,7 +741,6 @@ class CMORCheck():
         -------
         bool:
             True if there are pending warnings, False otherwise.
-
         """
         return len(self._warnings) > 0
 
@@ -783,12 +751,11 @@ class CMORCheck():
         -------
         bool:
             True if there are pending debug messages, False otherwise.
-
         """
         return len(self._debug_messages) > 0
 
     def report(self, level, message, *args):
-        """Generic method to report a message from the checker
+        """Generic method to report a message from the checker.
 
         Parameters
         ----------
@@ -818,7 +785,8 @@ class CMORCheck():
                 self._warnings.append(msg)
         else:
             if self._failerr:
-                raise CMORCheckError(msg + '\nin cube:\n{}'.format(self._cube))
+                raise CMORCheckError(msg +
+                                     '\n in cube:\n{}'.format(self._cube))
             self._errors.append(msg)
 
     def report_critical(self, message, *args):
@@ -833,7 +801,6 @@ class CMORCheck():
             Message for the error.
         *args:
             arguments to format the message string.
-
         """
         self.report(CheckLevels.RELAXED, message, *args)
 
@@ -846,7 +813,6 @@ class CMORCheck():
             Message for the error.
         *args:
             arguments to format the message string.
-
         """
         self.report(CheckLevels.DEFAULT, message, *args)
 
@@ -859,7 +825,6 @@ class CMORCheck():
             Message for the warning.
         *args:
             arguments to format the message string.
-
         """
         self.report(CheckLevels.STRICT, message, *args)
 
@@ -872,7 +837,6 @@ class CMORCheck():
             Message for the debug logger.
         *args:
             arguments to format the message string
-
         """
         self.report(CheckLevels.DEBUG, message, *args)
 
@@ -897,21 +861,23 @@ def _get_cmor_checker(table,
         var_info = CMOR_TABLES['custom'].get_variable(mip, short_name)
 
     def _checker(cube):
-        return CMORCheck(
-            cube,
-            var_info,
-            frequency=frequency,
-            fail_on_error=fail_on_error,
-            check_level=check_level,
-            automatic_fixes=automatic_fixes)
+        return CMORCheck(cube,
+                         var_info,
+                         frequency=frequency,
+                         fail_on_error=fail_on_error,
+                         check_level=check_level,
+                         automatic_fixes=automatic_fixes)
 
     return _checker
 
 
-def cmor_check_metadata(cube, cmor_table, mip,
-                        short_name, frequency,
+def cmor_check_metadata(cube,
+                        cmor_table,
+                        mip,
+                        short_name,
+                        frequency,
                         check_level=CheckLevels.DEFAULT):
-    """Check if metadata conforms to variable's CMOR definiton.
+    """Check if metadata conforms to variable's CMOR definition.
 
     None of the checks at this step will force the cube to load the data.
 
@@ -929,18 +895,23 @@ def cmor_check_metadata(cube, cmor_table, mip,
         Data frequency.
     check_level: CheckLevels
         Level of strictness of the checks.
-
     """
-    checker = _get_cmor_checker(cmor_table, mip,
-                                short_name, frequency,
+    checker = _get_cmor_checker(cmor_table,
+                                mip,
+                                short_name,
+                                frequency,
                                 check_level=check_level)
     checker(cube).check_metadata()
     return cube
 
 
-def cmor_check_data(cube, cmor_table, mip, short_name, frequency,
+def cmor_check_data(cube,
+                    cmor_table,
+                    mip,
+                    short_name,
+                    frequency,
                     check_level=CheckLevels.DEFAULT):
-    """Check if data conforms to variable's CMOR definiton.
+    """Check if data conforms to variable's CMOR definition.
 
     The checks performed at this step require the data in memory.
 
@@ -958,16 +929,18 @@ def cmor_check_data(cube, cmor_table, mip, short_name, frequency,
         Data frequency
     check_level: CheckLevels
         Level of strictness of the checks.
-
     """
-    checker = _get_cmor_checker(cmor_table, mip, short_name, frequency,
+    checker = _get_cmor_checker(cmor_table,
+                                mip,
+                                short_name,
+                                frequency,
                                 check_level=check_level)
     checker(cube).check_data()
     return cube
 
 
 def cmor_check(cube, cmor_table, mip, short_name, frequency, check_level):
-    """Check if cube conforms to variable's CMOR definiton.
+    """Check if cube conforms to variable's CMOR definition.
 
     Equivalent to calling cmor_check_metadata and cmor_check_data
     consecutively.
@@ -986,10 +959,17 @@ def cmor_check(cube, cmor_table, mip, short_name, frequency, check_level):
         Data frequency.
     check_level: enum.IntEnum
         Level of strictness of the checks.
-
     """
-    cmor_check_metadata(cube, cmor_table, mip, short_name, frequency,
+    cmor_check_metadata(cube,
+                        cmor_table,
+                        mip,
+                        short_name,
+                        frequency,
                         check_level=check_level)
-    cmor_check_data(cube, cmor_table, mip, short_name, frequency,
+    cmor_check_data(cube,
+                    cmor_table,
+                    mip,
+                    short_name,
+                    frequency,
                     check_level=check_level)
     return cube

--- a/esmvalcore/cmor/fix.py
+++ b/esmvalcore/cmor/fix.py
@@ -1,11 +1,8 @@
-"""
-Apply automatic fixes for known errors in cmorized data
+"""Apply automatic fixes for known errors in cmorized data.
 
 All functions in this module will work even if no fixes are available
 for the given dataset. Therefore is recommended to apply them to all
-variables to be sure that all known errors are
-fixed.
-
+variables to be sure that all known errors are fixed.
 """
 import logging
 from collections import defaultdict
@@ -13,14 +10,13 @@ from collections import defaultdict
 from iris.cube import CubeList
 
 from ._fixes.fix import Fix
-from .check import _get_cmor_checker, CheckLevels
+from .check import CheckLevels, _get_cmor_checker
 
 logger = logging.getLogger(__name__)
 
 
 def fix_file(file, short_name, project, dataset, mip, output_dir):
-    """
-    Fix files before ESMValTool can load them.
+    """Fix files before ESMValTool can load them.
 
     This fixes are only for issues that prevent iris from loading the cube or
     that cannot be fixed after the cube is loaded.
@@ -42,10 +38,11 @@ def fix_file(file, short_name, project, dataset, mip, output_dir):
     -------
     str:
         Path to the fixed file
-
     """
-    for fix in Fix.get_fixes(
-            project=project, dataset=dataset, mip=mip, short_name=short_name):
+    for fix in Fix.get_fixes(project=project,
+                             dataset=dataset,
+                             mip=mip,
+                             short_name=short_name):
         file = fix.fix_file(file, output_dir)
     return file
 
@@ -57,8 +54,7 @@ def fix_metadata(cubes,
                  mip,
                  frequency=None,
                  check_level=CheckLevels.DEFAULT):
-    """
-    Fix cube metadata if fixes are required and check it anyway.
+    """Fix cube metadata if fixes are required and check it anyway.
 
     This method collects all the relevant fixes for a given variable, applies
     them and checks the resulting cube (or the original if no fixes were
@@ -92,10 +88,11 @@ def fix_metadata(cubes,
     ------
     CMORCheckError
         If the checker detects errors in the metadata that it can not fix.
-
     """
-    fixes = Fix.get_fixes(
-        project=project, dataset=dataset, mip=mip, short_name=short_name)
+    fixes = Fix.get_fixes(project=project,
+                          dataset=dataset,
+                          mip=mip,
+                          short_name=short_name)
     fixed_cubes = []
     by_file = defaultdict(list)
     for cube in cubes:
@@ -107,14 +104,13 @@ def fix_metadata(cubes,
             cube_list = fix.fix_metadata(cube_list)
 
         cube = _get_single_cube(cube_list, short_name, project, dataset)
-        checker = _get_cmor_checker(
-            frequency=frequency,
-            table=project,
-            mip=mip,
-            short_name=short_name,
-            check_level=check_level,
-            fail_on_error=False,
-            automatic_fixes=True)
+        checker = _get_cmor_checker(frequency=frequency,
+                                    table=project,
+                                    mip=mip,
+                                    short_name=short_name,
+                                    check_level=check_level,
+                                    fail_on_error=False,
+                                    automatic_fixes=True)
         cube = checker(cube).check_metadata()
         cube.attributes.pop('source_file', None)
         fixed_cubes.append(cube)
@@ -134,19 +130,14 @@ def _get_single_cube(cube_list, short_name, project, dataset):
             'More than one cube found for variable %s in %s:%s but '
             'none of their var_names match the expected. \n'
             'Full list of cubes encountered: %s' %
-            (short_name, project, dataset, cube_list)
-        )
+            (short_name, project, dataset, cube_list))
     logger.warning(
         'Found variable %s in %s:%s, but there were other present in '
         'the file. Those extra variables are usually metadata '
         '(cell area, latitude descriptions) that was not saved '
         'according to CF-conventions. It is possible that errors appear '
         'further on because of this. \nFull list of cubes encountered: %s',
-        short_name,
-        project,
-        dataset,
-        cube_list
-    )
+        short_name, project, dataset, cube_list)
     return cube
 
 
@@ -157,8 +148,7 @@ def fix_data(cube,
              mip,
              frequency=None,
              check_level=CheckLevels.DEFAULT):
-    """
-    Fix cube data if fixes add present and check it anyway.
+    """Fix cube data if fixes add present and check it anyway.
 
     This method assumes that metadata is already fixed and checked.
 
@@ -191,18 +181,18 @@ def fix_data(cube,
     ------
     CMORCheckError
         If the checker detects errors in the data that it can not fix.
-
     """
-    for fix in Fix.get_fixes(
-            project=project, dataset=dataset, mip=mip, short_name=short_name):
+    for fix in Fix.get_fixes(project=project,
+                             dataset=dataset,
+                             mip=mip,
+                             short_name=short_name):
         cube = fix.fix_data(cube)
-    checker = _get_cmor_checker(
-        frequency=frequency,
-        table=project,
-        mip=mip,
-        short_name=short_name,
-        fail_on_error=False,
-        automatic_fixes=True,
-        check_level=check_level)
+    checker = _get_cmor_checker(frequency=frequency,
+                                table=project,
+                                mip=mip,
+                                short_name=short_name,
+                                fail_on_error=False,
+                                automatic_fixes=True,
+                                check_level=check_level)
     cube = checker(cube).check_data()
     return cube

--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -1,8 +1,7 @@
-"""
-CMOR information reader for ESMValTool.
+"""CMOR information reader for ESMValTool.
 
-Read variable information from CMOR 2 and CMOR 3 tables and make it easily
-available for the other components of ESMValTool
+Read variable information from CMOR 2 and CMOR 3 tables and make it
+easily available for the other components of ESMValTool
 """
 import copy
 import errno
@@ -10,8 +9,8 @@ import glob
 import json
 import logging
 import os
-from functools import total_ordering
 from collections import Counter
+from functools import total_ordering
 from pathlib import Path
 
 import yaml
@@ -44,7 +43,6 @@ def read_cmor_tables(cfg_developer=None):
     ----------
     cfg_developer : dict of str
         Parsed config-developer file
-
     """
     if cfg_developer is None:
         cfg_file = Path(__file__).parent.parent / 'config-developer.yml'
@@ -61,8 +59,8 @@ def read_cmor_tables(cfg_developer=None):
     CMOR_TABLES['custom'] = custom
     install_dir = os.path.dirname(os.path.realpath(__file__))
     for table in cfg_developer:
-        CMOR_TABLES[table] = _read_table(
-            cfg_developer, table, install_dir, custom, alt_names)
+        CMOR_TABLES[table] = _read_table(cfg_developer, table, install_dir,
+                                         custom, alt_names)
 
 
 def _read_table(cfg_developer, table, install_dir, custom, alt_names):
@@ -83,12 +81,10 @@ def _read_table(cfg_developer, table, install_dir, custom, alt_names):
         )
 
     if cmor_type == 'CMIP5':
-        return CMIP5Info(
-            table_path,
-            default=custom,
-            strict=cmor_strict,
-            alt_names=alt_names
-        )
+        return CMIP5Info(table_path,
+                         default=custom,
+                         strict=cmor_strict,
+                         alt_names=alt_names)
 
     if cmor_type == 'CMIP6':
         return CMIP6Info(
@@ -102,8 +98,7 @@ def _read_table(cfg_developer, table, install_dir, custom, alt_names):
 
 
 class InfoBase():
-    """
-    Base class for all table info classes.
+    """Base class for all table info classes.
 
     This uses CMOR 3 json format
 
@@ -118,9 +113,7 @@ class InfoBase():
     strict: bool
         If False, will look for a variable in other tables if it can not be
         found in the requested one
-
     """
-
     def __init__(self, default, alt_names, strict):
         if alt_names is None:
             alt_names = ""
@@ -130,8 +123,7 @@ class InfoBase():
         self.tables = {}
 
     def get_table(self, table):
-        """
-        Search and return the table info.
+        """Search and return the table info.
 
         Parameters
         ----------
@@ -143,13 +135,11 @@ class InfoBase():
         TableInfo
             Return the TableInfo object for the requested table if
             found, returns None if not
-
         """
         return self.tables.get(table)
 
     def get_variable(self, table_name, short_name, derived=False):
-        """
-        Search and return the variable info.
+        """Search and return the variable info.
 
         Parameters
         ----------
@@ -167,7 +157,6 @@ class InfoBase():
         VariableInfo
             Return the VariableInfo object for the requested variable if
             found, returns None if not
-
         """
         alt_names_list = self._get_alt_names_list(short_name)
 
@@ -181,8 +170,8 @@ class InfoBase():
 
         var_info = self._look_in_all_tables(alt_names_list)
         if not var_info:
-            var_info = self._look_in_default(
-                derived, alt_names_list, table_name)
+            var_info = self._look_in_default(derived, alt_names_list,
+                                             table_name)
         if var_info:
             var_info = var_info.copy()
             var_info = self._update_frequency_from_mip(table_name, var_info)
@@ -211,9 +200,10 @@ class InfoBase():
         alt_names_list = [short_name]
         for alt_names in self.alt_names:
             if short_name in alt_names:
-                alt_names_list.extend(
-                    [alt_name for alt_name in alt_names
-                     if alt_name not in alt_names_list])
+                alt_names_list.extend([
+                    alt_name for alt_name in alt_names
+                    if alt_name not in alt_names_list
+                ])
         return alt_names_list
 
     def _update_frequency_from_mip(self, table_name, var_info):
@@ -230,8 +220,7 @@ class InfoBase():
 
 
 class CMIP6Info(InfoBase):
-    """
-    Class to read CMIP6-like data request.
+    """Class to read CMIP6-like data request.
 
     This uses CMOR 3 json format
 
@@ -246,9 +235,7 @@ class CMIP6Info(InfoBase):
     strict: bool
         If False, will look for a variable in other tables if it can not be
         found in the requested one
-
     """
-
     def __init__(self,
                  cmor_tables_path,
                  default=None,
@@ -375,8 +362,7 @@ class CMIP6Info(InfoBase):
                     pass
 
     def get_table(self, table):
-        """
-        Search and return the table info.
+        """Search and return the table info.
 
         Parameters
         ----------
@@ -388,7 +374,6 @@ class CMIP6Info(InfoBase):
         TableInfo
             Return the TableInfo object for the requested table if
             found, returns None if not
-
         """
         try:
             return self.tables[table]
@@ -407,7 +392,6 @@ class CMIP6Info(InfoBase):
 @total_ordering
 class TableInfo(dict):
     """Container class for storing a CMOR table."""
-
     def __init__(self, *args, **kwargs):
         """Create a new TableInfo object for storing VariableInfo objects."""
         super(TableInfo, self).__init__(*args, **kwargs)
@@ -429,18 +413,15 @@ class TableInfo(dict):
 
 
 class JsonInfo(object):
-    """
-    Base class for the info classes.
+    """Base class for the info classes.
 
     Provides common utility methods to read json variables
     """
-
     def __init__(self):
         self._json_data = {}
 
     def _read_json_variable(self, parameter, default=''):
-        """
-        Read a json parameter in json_data.
+        """Read a json parameter in json_data.
 
         Parameters
         ----------
@@ -451,15 +432,13 @@ class JsonInfo(object):
         -------
         str
             Option's value or empty string if parameter is not present
-
         """
         if parameter not in self._json_data:
             return default
         return str(self._json_data[parameter])
 
     def _read_json_list_variable(self, parameter):
-        """
-        Read a json list parameter in json_data.
+        """Read a json list parameter in json_data.
 
         Parameters
         ----------
@@ -470,7 +449,6 @@ class JsonInfo(object):
         -------
         str
             Option's value or empty list if parameter is not present
-
         """
         if parameter not in self._json_data:
             return []
@@ -479,16 +457,13 @@ class JsonInfo(object):
 
 class VariableInfo(JsonInfo):
     """Class to read and store variable information."""
-
     def __init__(self, table_type, short_name):
-        """
-        Class to read and store variable information.
+        """Class to read and store variable information.
 
         Parameters
         ----------
         short_name: str
             variable's short name
-
         """
         super(VariableInfo, self).__init__()
         self.table_type = table_type
@@ -523,8 +498,7 @@ class VariableInfo(JsonInfo):
         self._json_data = None
 
     def copy(self):
-        """
-        Return a shallow copy of VariableInfo.
+        """Return a shallow copy of VariableInfo.
 
         Returns
         -------
@@ -534,8 +508,7 @@ class VariableInfo(JsonInfo):
         return copy.copy(self)
 
     def read_json(self, json_data, default_freq):
-        """
-        Read variable information from json.
+        """Read variable information from json.
 
         Non-present options will be set to empty
 
@@ -547,7 +520,6 @@ class VariableInfo(JsonInfo):
 
         default_freq: str
             Default frequency to use if it is not defined at variable level
-
         """
         self._json_data = json_data
 
@@ -566,16 +538,13 @@ class VariableInfo(JsonInfo):
 
 class CoordinateInfo(JsonInfo):
     """Class to read and store coordinate information."""
-
     def __init__(self, name):
-        """
-        Class to read and store coordinate information.
+        """Class to read and store coordinate information.
 
         Parameters
         ----------
         name: str
             coordinate's name
-
         """
         super(CoordinateInfo, self).__init__()
         self.name = name
@@ -614,8 +583,7 @@ class CoordinateInfo(JsonInfo):
         """Generic level name"""
 
     def read_json(self, json_data):
-        """
-        Read coordinate information from json.
+        """Read coordinate information from json.
 
         Non-present options will be set to empty
 
@@ -624,7 +592,6 @@ class CoordinateInfo(JsonInfo):
         json_data: dict
             dictionary created by the json reader containing
             coordinate information
-
         """
         self._json_data = json_data
 
@@ -644,8 +611,7 @@ class CoordinateInfo(JsonInfo):
 
 
 class CMIP5Info(InfoBase):
-    """
-    Class to read CMIP5-like data request.
+    """Class to read CMIP5-like data request.
 
     Parameters
     ----------
@@ -658,10 +624,11 @@ class CMIP5Info(InfoBase):
     strict: bool
         If False, will look for a variable in other tables if it can not be
         found in the requested one
-
     """
-
-    def __init__(self, cmor_tables_path, default=None, alt_names=None,
+    def __init__(self,
+                 cmor_tables_path,
+                 default=None,
+                 alt_names=None,
                  strict=True):
         super().__init__(default, alt_names, strict)
         cmor_tables_path = self._get_cmor_path(cmor_tables_path)
@@ -785,8 +752,7 @@ class CMIP5Info(InfoBase):
         return var
 
     def get_table(self, table):
-        """
-        Search and return the table info.
+        """Search and return the table info.
 
         Parameters
         ----------
@@ -798,14 +764,12 @@ class CMIP5Info(InfoBase):
         TableInfo
             Return the TableInfo object for the requested table if
             found, returns None if not
-
         """
         return self.tables.get(table)
 
 
 class CMIP3Info(CMIP5Info):
-    """
-    Class to read CMIP3-like data request.
+    """Class to read CMIP3-like data request.
 
     Parameters
     ----------
@@ -818,9 +782,7 @@ class CMIP3Info(CMIP5Info):
     strict: bool
         If False, will look for a variable in other tables if it can not be
         found in the requested one
-
     """
-
     def _read_table_file(self, table_file, table=None):
         for dim in ('zlevel', ):
             coord = CoordinateInfo(dim)
@@ -844,17 +806,14 @@ class CMIP3Info(CMIP5Info):
 
 
 class CustomInfo(CMIP5Info):
-    """
-    Class to read custom var info for ESMVal.
+    """Class to read custom var info for ESMVal.
 
     Parameters
     ----------
     cmor_tables_path: basestring or None
         Full path to the table or name for the table if it is present in
         ESMValTool repository
-
     """
-
     def __init__(self, cmor_tables_path=None):
         cwd = os.path.dirname(os.path.realpath(__file__))
         self._cmor_folder = os.path.join(cwd, 'tables', 'custom')
@@ -884,8 +843,7 @@ class CustomInfo(CMIP5Info):
                 raise
 
     def get_variable(self, table, short_name, derived=False):
-        """
-        Search and return the variable info.
+        """Search and return the variable info.
 
         Parameters
         ----------
@@ -903,7 +861,6 @@ class CustomInfo(CMIP5Info):
         VariableInfo
             Return the VariableInfo object for the requested variable if
             found, returns None if not
-
         """
         return self.tables['custom'].get(short_name, None)
 


### PR DESCRIPTION
Just to avoid messing with the pre-commit hooks, as usually is just @sloosvel and me modifying these files

***

## Before you get started

-   [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [ ] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description