### PR TITLE
Set remove_preproc_dir to false in default config-user

### DIFF
--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -17,7 +17,7 @@ compress_netcdf: false
 # Save intermediary cubes in the preprocessor true/[false]
 save_intermediary_cubes: false
 # Remove the preproc dir if all fine
-remove_preproc_dir: true
+remove_preproc_dir: false
 # Run at most this many tasks in parallel [null]/1/2/3/4/..
 # Set to null to use the number of available CPUs.
 # If you run out of memory, try setting max_parallel_tasks to 1 and check the


### PR DESCRIPTION
The `remove_preproc_dir` needs to be set to `false` by default because 80% users actually need the preprocessor files and may contribute to confusion amongst uninitiated users