### PR TITLE
Bugfix: Fix units for MSWEP data

### DIFF
--- a/esmvalcore/cmor/_fixes/native6/mswep.py
+++ b/esmvalcore/cmor/_fixes/native6/mswep.py
@@ -92,11 +92,11 @@ class Pr(Fix):
         cube.units = Unit(self.vardef.units)
 
         if frequency in ('day', '3hr'):
-            # divide by number of seconds in a month
-            cube.data = cube.core_data() / 60 * 60 * 24 * 30
-        elif frequency == 'mon':
             # divide by number of seconds in a day
-            cube.data = cube.core_data() / 60 * 60 * 24
+            cube.data = cube.core_data() / (60 * 60 * 24)
+        elif frequency == 'mon':
+            # divide by number of seconds in a month
+            cube.data = cube.core_data() / (60 * 60 * 24 * 30)
         else:
             raise ValueError(f'Cannot fix units for frequency: {frequency!r}')
 


### PR DESCRIPTION
## Description

Hi everyone, I made a silly mistake in converting the units in the MSWEP fix (#969). This PR addresses that. The data have been verified to be similar to ERA5/ERA-Interim 👍

-   Closes #issue_number
-   Link to documentation:

***

## Before you get started

-   [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [x] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [x] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
