### PR TITLE
Move fiona to be installed from conda forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - cftime  # iris=3.0.1 needs <=1.2.1; >=1.3.0 - years<999 get a 0 instead of empty space
   - compilers
+  - fiona  # 1.8.18/py39, they seem weary to build manylinux wheels and pypi ver built with older gdal
   - esmpy
   - iris>=3.0.1
   - graphviz

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,6 @@ REQUIREMENTS = {
     'install': [
         'cf-units',
         'dask[array]',
-        # fiona: 1.8.18/py39, they seem weary to build manylinux wheels
-        # so we may have to install from conda-forge in the future
-        'fiona',
         'fire',
         'nc-time-axis',  # needed by iris.plot
         'netCDF4',


### PR DESCRIPTION
`fiona` is again giving us headaches, the reason why I am moving it to be a `conda-forge` dependency instead of PyPi is in this [comment](https://github.com/ESMValGroup/ESMValCore/issues/972#issuecomment-774111132) as a result of @remi-kazeroni noticing fiona trying to read an old csv file from GDAL that has disappeared from GDAL>=3.1 and asking us about it in this [comment](https://github.com/ESMValGroup/ESMValCore/issues/972#issuecomment-773321942), also an issue documented here https://github.com/Toblerity/Fiona/issues/897 (towards the bottom)