### PR TITLE
Report coverage for tests that run on any pull request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
           path: test-reports/
       - store_artifacts:
           path: test-reports/
+      - coverage-reporter/send_report:
+          coverage-reports: 'test-reports/coverage.xml'
+          project-token: $CODACY_PROJECT_TOKEN
 
   install:
     # Test installation
@@ -84,9 +87,6 @@ jobs:
           path: test-reports/
       - store_test_results:
           path: test-reports/
-      - coverage-reporter/send_report:
-          coverage-reports: 'test-reports/coverage.xml'
-          project-token: $CODACY_PROJECT_TOKEN
 
   documentation:
     # Test building documentation


### PR DESCRIPTION
At the moment, coverage reports are only uploaded to Codacy if there are changes to files listed in .circleci/install_triggers. For most pull request that means that there is no coverage information available on Codacy. This pull request fixes that problem by uploading the coverage report from the tests that always run.