### PR TITLE
Support multiple paths in input_dir

### DIFF
--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -220,7 +220,7 @@ Input file paths
 ----------------
 
 When looking for input files, the ``esmvaltool`` command provided by
-ESMValCore replaces the placeholders ``[item]`` in
+ESMValCore replaces the placeholders ``{item}`` in
 ``input_dir`` and ``input_file`` with the values supplied in the recipe.
 ESMValCore will try to automatically fill in the values for institute, frequency,
 and modeling_realm based on the information provided in the CMOR tables
@@ -239,6 +239,21 @@ The resulting directory path would look something like this:
 .. code-block:: bash
 
     CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/Omon/tos/gn/latest
+
+Please, bear in mind that ``input_dirs`` can also be a list for those  cases in
+which may be needed:
+
+.. code-block:: yaml
+
+  - '{exp}/{ensemble}/original/{mip}/{short_name}/{grid}/{latestversion}'
+  - '{exp}/{ensemble}/computed/{mip}/{short_name}/{grid}/{latestversion}'
+
+In that case, the resultant directories will be:
+
+.. code-block:: bash
+
+  historical/r1i1p1f3/original/Omon/tos/gn/latest
+  historical/r1i1p1f3/computed/Omon/tos/gn/latest
 
 For a more in-depth description of how to configure ESMValCore so it can find
 your data please see :ref:`CMOR-DRS`.

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -89,11 +89,18 @@ def select_files(filenames, start_year, end_year):
     return selection
 
 
-def _replace_tags(path, variable):
+def _replace_tags(paths, variable):
     """Replace tags in the config-developer's file with actual values."""
-    path = path.strip('/')
-    tlist = re.findall(r'{([^}]*)}', path)
-    paths = [path]
+    if isinstance(paths, str):
+        paths = (paths, )
+    new_paths = []
+    tlist = set()
+    for path in paths:
+        path = path.strip('/')
+        tlist = tlist.union(re.findall(r'{([^}]*)}', path))
+        new_paths.append(path)
+    logger.debug(tlist)
+
     for tag in tlist:
         original_tag = tag
         tag, _, _ = _get_caps_options(tag)

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -92,13 +92,13 @@ def select_files(filenames, start_year, end_year):
 def _replace_tags(paths, variable):
     """Replace tags in the config-developer's file with actual values."""
     if isinstance(paths, str):
-        paths = (paths, )
-    new_paths = []
+        paths = (paths.strip('/'), )
+    else:
+        paths = [path.strip('/') for path in paths]
     tlist = set()
+
     for path in paths:
-        path = path.strip('/')
         tlist = tlist.union(re.findall(r'{([^}]*)}', path))
-        new_paths.append(path)
     logger.debug(tlist)
 
     for tag in tlist:

--- a/tests/unit/data_finder/test_replace_tags.py
+++ b/tests/unit/data_finder/test_replace_tags.py
@@ -1,0 +1,22 @@
+"""Tests for _replace_tags in _data_finder.py."""
+
+from esmvalcore._data_finder import _replace_tags
+
+VARIABLE = {
+    'short_name': 'tas',
+}
+
+
+def test_replace_tags_str():
+    assert _replace_tags('folder/subfolder/{short_name}',
+                         VARIABLE) == ['folder/subfolder/tas']
+
+
+def test_replace_tags_list_of_str():
+    assert _replace_tags(('folder/subfolder/{short_name}',
+                          'folder2/{short_name}', 'subfolder/{short_name}'),
+                         VARIABLE) == [
+                             'folder/subfolder/tas',
+                             'folder2/tas',
+                             'subfolder/tas',
+                         ]


### PR DESCRIPTION
At BSC, we have different paths for variables generated directly from the model and those computed afterwards. In order to be able to read both, we need to pass multiple input_dirs because we need some replacements in the first part of the path.

An example:

```yaml

EC-EARTH:
  input_dir:
    default:
      - '{expid}/cmorfiles/{activity}/{institute}/{dataset}/{exp}/{ensemble}/{mip}/{short_name}/{grid}/{latestversion}'
      - '{expid}/diags/{activity}/{institute}/{dataset}/{exp}/{ensemble}/{mip}/{short_name}/{grid}/{latestversion}'
```


## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [x] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [x] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [x] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description
