### PR TITLE
Fix tests for multi-processing with spawn method (i.e. macOSX with Python>3.8)

### DIFF
--- a/tests/integration/test_task.py
+++ b/tests/integration/test_task.py
@@ -8,28 +8,9 @@ import esmvalcore
 from esmvalcore._task import BaseTask, TaskSet
 
 
-@pytest.fixture
-def example_tasks():
-    """Example tasks for testing the task runners."""
-    tasks = TaskSet()
-    for i in range(3):
-        task = BaseTask(
-            name=f'task{i}',
-            ancestors=[
-                BaseTask(name=f'task{i}-ancestor{j}') for j in range(3)
-            ],
-        )
-        for task0 in task.flatten():
-            task0.priority = i
-        tasks.add(task)
-
-    return tasks
-
-
-@pytest.mark.parametrize('max_parallel_tasks', [1, 2, 3, 4, 16, None])
-def test_run_tasks(monkeypatch, tmp_path, max_parallel_tasks, example_tasks):
-    """Check that tasks are run correctly."""
+class MockBaseTask(BaseTask):
     def _run(self, input_files):
+        tmp_path = self._tmp_path
         output_file = tmp_path / self.name
 
         msg = ('running {} in thread {}, using input {}, generating {}'.format(
@@ -50,7 +31,29 @@ def test_run_tasks(monkeypatch, tmp_path, max_parallel_tasks, example_tasks):
 
         return [output_file]
 
-    monkeypatch.setattr(BaseTask, '_run', _run)
+
+@pytest.fixture
+def example_tasks(tmp_path):
+    """Example tasks for testing the task runners."""
+    tasks = TaskSet()
+    for i in range(3):
+        task = MockBaseTask(
+            name=f'task{i}',
+            ancestors=[
+                MockBaseTask(name=f'task{i}-ancestor{j}') for j in range(3)
+            ],
+        )
+        for task0 in task.flatten():
+            task0.priority = i
+            task0._tmp_path = tmp_path
+        tasks.add(task)
+
+    return tasks
+
+
+@pytest.mark.parametrize('max_parallel_tasks', [1, 2, 3, 4, 16, None])
+def test_run_tasks(monkeypatch, tmp_path, max_parallel_tasks, example_tasks):
+    """Check that tasks are run correctly."""
 
     example_tasks.run(max_parallel_tasks=max_parallel_tasks)
 
@@ -72,7 +75,7 @@ def test_runner_uses_priority(monkeypatch, runner, example_tasks):
         order.append(self.priority)
         return [f'{self.name}_test.nc']
 
-    monkeypatch.setattr(BaseTask, '_run', _run)
+    monkeypatch.setattr(MockBaseTask, '_run', _run)
     monkeypatch.setattr(esmvalcore._task, 'Pool', ThreadPool)
 
     runner(example_tasks)

--- a/tests/integration/test_task.py
+++ b/tests/integration/test_task.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 from functools import partial
 from multiprocessing.pool import ThreadPool
@@ -51,10 +52,13 @@ def example_tasks(tmp_path):
     return tasks
 
 
+@pytest.mark.parametrize('mpmethod', ["spawn", "fork"])
 @pytest.mark.parametrize('max_parallel_tasks', [1, 2, 3, 4, 16, None])
-def test_run_tasks(monkeypatch, tmp_path, max_parallel_tasks, example_tasks):
+def test_run_tasks(monkeypatch, tmp_path, max_parallel_tasks, example_tasks,
+                   mpmethod):
     """Check that tasks are run correctly."""
-
+    monkeypatch.setattr(esmvalcore._task, 'Pool',
+                        multiprocessing.get_context(mpmethod).Pool)
     example_tasks.run(max_parallel_tasks=max_parallel_tasks)
 
     for task in example_tasks:


### PR DESCRIPTION

## Description
Fixed a test that caused problems with MacOSX when using multiprocessing set to spawn (standard in Python 3.8).

-   Closes #1002
-   Link to documentation:

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
