### PR TITLE
Fix bugs with large values in multimodel regression tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ REQUIREMENTS = {
         'pytest-metadata>=1.5.1',
         'pytest-mock',
         'pytest-xdist',
-        'ESMValTool_sample_data==0.0.3',
+        'ESMValTool_sample_data==0.0.5',
     ],
     # Development dependencies
     # Use pip install -e .[develop] to install in development mode

--- a/tests/sample_data/multimodel_statistics/test_multimodel.py
+++ b/tests/sample_data/multimodel_statistics/test_multimodel.py
@@ -49,10 +49,17 @@ def preprocess_data(cubes, time_slice: dict = None):
     # regrid to first cube
     regrid_kwargs = {
         'grid': first_cube,
-        'scheme': iris.analysis.Linear(),
+        'scheme': iris.analysis.Nearest(),
     }
 
     cubes = [cube.regrid(**regrid_kwargs) for cube in cubes]
+
+    for cube in cubes:
+        # Make sure cubes have sensible values
+        # https://github.com/ESMValGroup/ESMValCore/issues/1014
+        # https://github.com/ESMValGroup/ESMValTool_sample_data/issues/24
+        assert cube.data.min() > -2e16
+        assert cube.data.max() < 2e16
 
     return cubes
 
@@ -61,7 +68,8 @@ def get_cache_key(value):
     """Get a cache key that is hopefully unique enough for unpickling.
 
     If this doesn't avoid problems with unpickling the cached data,
-    manually clean the pytest cache with the command `pytest --cache-clear`.
+    manually clean the pytest cache with the command `pytest --cache-
+    clear`.
     """
     return ' '.join([
         str(value),


### PR DESCRIPTION
## Description

This PR changes the regridder to a `Nearest` scheme to avoid interpolation errors on masked arrays. For more details see #1014 . I also added a check for large values, which revealed another dataset with a large unmasked value: https://github.com/ESMValGroup/ESMValTool_sample_data/issues/24 that I would like to include in this PR as well.

-   Closes #1014
-   Link to documentation:

## Todo:

- [ ] https://github.com/ESMValGroup/ESMValTool_sample_data/issues/24 merged
- [ ] New release of `ESMValTool_sample_data` (`v0.0.5`)
- [ ] Update regression data

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [x] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [x] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
