### PR TITLE
Added fixes for various CMIP5 datasets, variable cl (3-dim cloud fraction)

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/bnu_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/bnu_esm.py
@@ -6,7 +6,27 @@ from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 
 
-Cl = ClFixHybridPressureCoord
+class Cl(ClFixHybridPressureCoord):
+    def fix_data(self, cube):
+        """
+        Fix data.
+
+        Fixes discrepancy between declared units and real units
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube to fix.
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        metadata = cube.metadata
+        cube *= 100
+        cube.metadata = metadata
+        return cube
 
 
 class FgCo2(Fix):

--- a/esmvalcore/cmor/_fixes/cmip5/bnu_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/bnu_esm.py
@@ -7,6 +7,8 @@ from ..fix import Fix
 
 
 class Cl(ClFixHybridPressureCoord):
+    """Fixes for cl."""
+
     def fix_data(self, cube):
         """
         Fix data.

--- a/esmvalcore/cmor/_fixes/cmip5/ccsm4.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ccsm4.py
@@ -2,34 +2,12 @@
 
 import dask.array as da
 
-from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 from ..shared import round_coordinates
+from .bnu_esm import Cl as BaseCl
 
 
-class Cl(ClFixHybridPressureCoord):
-    """Fixes for cl."""
-
-    def fix_data(self, cube):
-        """
-        Fix data.
-
-        Fixes discrepancy between declared units and real units
-
-        Parameters
-        ----------
-        cube: iris.cube.Cube
-            Input cube to fix.
-
-        Returns
-        -------
-        iris.cube.Cube
-
-        """
-        metadata = cube.metadata
-        cube *= 100
-        cube.metadata = metadata
-        return cube
+Cl = BaseCl
 
 
 class Csoil(Fix):

--- a/esmvalcore/cmor/_fixes/cmip5/ccsm4.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ccsm4.py
@@ -7,7 +7,27 @@ from ..fix import Fix
 from ..shared import round_coordinates
 
 
-Cl = ClFixHybridPressureCoord
+class Cl(ClFixHybridPressureCoord):
+    def fix_data(self, cube):
+        """
+        Fix data.
+
+        Fixes discrepancy between declared units and real units
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube to fix.
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        metadata = cube.metadata
+        cube *= 100
+        cube.metadata = metadata
+        return cube
 
 
 class Csoil(Fix):

--- a/esmvalcore/cmor/_fixes/cmip5/ccsm4.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ccsm4.py
@@ -8,6 +8,8 @@ from ..shared import round_coordinates
 
 
 class Cl(ClFixHybridPressureCoord):
+    """Fixes for cl."""
+
     def fix_data(self, cube):
         """
         Fix data.

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
@@ -6,6 +6,8 @@ from ..fix import Fix
 
 
 class Cl(Fix):
+    """Fixes for cl."""
+
     def fix_data(self, cube):
         """
         Fix data.

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
@@ -3,31 +3,10 @@
 from dask import array as da
 
 from ..fix import Fix
+from .cesm1_cam5 import Cl as BaseCl
 
 
-class Cl(Fix):
-    """Fixes for cl."""
-
-    def fix_data(self, cube):
-        """
-        Fix data.
-
-        Fixes discrepancy between declared units and real units
-
-        Parameters
-        ----------
-        cube: iris.cube.Cube
-            Input cube to fix.
-
-        Returns
-        -------
-        iris.cube.Cube
-
-        """
-        metadata = cube.metadata
-        cube *= 100
-        cube.metadata = metadata
-        return cube
+Cl = BaseCl
 
 
 class Gpp(Fix):

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
@@ -5,6 +5,29 @@ from dask import array as da
 from ..fix import Fix
 
 
+class Cl(Fix):
+    def fix_data(self, cube):
+        """
+        Fix data.
+
+        Fixes discrepancy between declared units and real units
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube to fix.
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        metadata = cube.metadata
+        cube *= 100
+        cube.metadata = metadata
+        return cube
+
+
 class Gpp(Fix):
     """Fixes for gpp variable."""
 

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_cam5.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_cam5.py
@@ -1,0 +1,26 @@
+"""Fixes for CESM1-CAM5 model."""
+
+from ..fix import Fix
+
+
+class Cl(Fix):
+    def fix_data(self, cube):
+        """
+        Fix data.
+
+        Fixes discrepancy between declared units and real units
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube to fix.
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        metadata = cube.metadata
+        cube *= 100
+        cube.metadata = metadata
+        return cube

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_cam5.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_cam5.py
@@ -4,6 +4,8 @@ from ..fix import Fix
 
 
 class Cl(Fix):
+    """Fixes for cl."""
+
     def fix_data(self, cube):
         """
         Fix data.

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_fastchem.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_fastchem.py
@@ -1,0 +1,3 @@
+"""Fixes for CESM1-FASTCHEM model."""
+
+from .cesm1_cam5 import Cl

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_fastchem.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_fastchem.py
@@ -1,3 +1,6 @@
 """Fixes for CESM1-FASTCHEM model."""
 
-from .cesm1_cam5 import Cl
+from .cesm1_cam5 import Cl as BaseCl
+
+
+Cl = BaseCl

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_waccm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_waccm.py
@@ -1,0 +1,3 @@
+"""Fixes for CESM1-WACCM model."""
+
+from .cesm1_cam5 import Cl

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_waccm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_waccm.py
@@ -1,6 +1,6 @@
 """Fixes for CESM1-WACCM model."""
 
-from .cesm1_cam5 import BaseCl
+from .cesm1_cam5 import Cl as BaseCl
 
 
 Cl = BaseCl

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_waccm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_waccm.py
@@ -1,3 +1,6 @@
 """Fixes for CESM1-WACCM model."""
 
-from .cesm1_cam5 import Cl
+from .cesm1_cam5 import BaseCl
+
+
+Cl = BaseCl

--- a/esmvalcore/cmor/_fixes/cmip5/fio_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/fio_esm.py
@@ -4,6 +4,8 @@ from ..fix import Fix
 
 
 class Cl(Fix):
+    """Fixes for cl."""
+
     def fix_data(self, cube):
         """
         Fix data.

--- a/esmvalcore/cmor/_fixes/cmip5/fio_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/fio_esm.py
@@ -1,31 +1,10 @@
 
 """Fixes for FIO ESM model."""
 from ..fix import Fix
+from .cesm1_cam5 import Cl as BaseCl
 
 
-class Cl(Fix):
-    """Fixes for cl."""
-
-    def fix_data(self, cube):
-        """
-        Fix data.
-
-        Fixes discrepancy between declared units and real units
-
-        Parameters
-        ----------
-        cube: iris.cube.Cube
-            Input cube to fix.
-
-        Returns
-        -------
-        iris.cube.Cube
-
-        """
-        metadata = cube.metadata
-        cube *= 100
-        cube.metadata = metadata
-        return cube
+Cl = BaseCl
 
 
 class Co2(Fix):

--- a/esmvalcore/cmor/_fixes/cmip5/fio_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/fio_esm.py
@@ -3,6 +3,29 @@
 from ..fix import Fix
 
 
+class Cl(Fix):
+    def fix_data(self, cube):
+        """
+        Fix data.
+
+        Fixes discrepancy between declared units and real units
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube to fix.
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        metadata = cube.metadata
+        cube *= 100
+        cube.metadata = metadata
+        return cube
+
+
 class Co2(Fix):
     """Fixes for co2."""
 

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
@@ -34,6 +34,29 @@ class Areacello(Fix):
         return cubes
 
 
+class Cl(Fix):
+    def fix_data(self, cube):
+        """
+        Fix data.
+
+        Fixes discrepancy between declared units and real units
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube to fix.
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        metadata = cube.metadata
+        cube *= 100
+        cube.metadata = metadata
+        return cube
+
+
 class Sftof(Fix):
     """Fixes for sftof."""
 

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
@@ -5,6 +5,10 @@ import cftime
 
 from ..fix import Fix
 from ..cmip5.gfdl_esm2g import AllVars as BaseAllVars
+from .cesm1_cam5 import Cl as BaseCl
+
+
+Cl = BaseCl
 
 
 class AllVars(BaseAllVars):
@@ -32,31 +36,6 @@ class Areacello(Fix):
         cube = self.get_cube_from_list(cubes)
         cube.units = 'm2'
         return cubes
-
-
-class Cl(Fix):
-    """Fixes for cl."""
-
-    def fix_data(self, cube):
-        """
-        Fix data.
-
-        Fixes discrepancy between declared units and real units
-
-        Parameters
-        ----------
-        cube: iris.cube.Cube
-            Input cube to fix.
-
-        Returns
-        -------
-        iris.cube.Cube
-
-        """
-        metadata = cube.metadata
-        cube *= 100
-        cube.metadata = metadata
-        return cube
 
 
 class Sftof(Fix):

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_cm2p1.py
@@ -35,6 +35,8 @@ class Areacello(Fix):
 
 
 class Cl(Fix):
+    """Fixes for cl."""
+
     def fix_data(self, cube):
         """
         Fix data.

--- a/tests/integration/cmor/_fixes/cmip5/test_bnu_esm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_bnu_esm.py
@@ -12,15 +12,26 @@ from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
 
-def test_get_cl_fix():
-    """Test getting of fix."""
-    fix = Fix.get_fixes('CMIP5', 'bcc-csm1-1', 'Amon', 'cl')
-    assert fix == [Cl(None)]
+class TestCl(unittest.TestCase):
+    """Test cl fix."""
+    def setUp(self):
+        """Prepare tests."""
+        self.cube = Cube([1.0], var_name='cl', units='%')
+        self.fix = Cl(None)
 
+    def test_get(self):
+        """Test fix get"""
+        fix = Fix.get_fixes('CMIP5', 'BNU-ESM', 'Amon', 'cl')
+        assert fix == [Cl(None)]
 
-def test_cl_fix():
-    """Test fix for ``cl``."""
-    assert Cl is ClFixHybridPressureCoord
+    def test_cl_fix(self):
+        """Test fix for ``cl``."""
+        assert issubclass(Cl, ClFixHybridPressureCoord)
+
+    def test_fix_data(self):
+        """Test data fix."""
+        cube = self.fix.fix_data(self.cube)
+        self.assertEqual(cube.data[0], 100)
 
 
 class TestCo2(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/cmip5/test_ccsm4.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_ccsm4.py
@@ -11,15 +11,26 @@ from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
 
-def test_get_cl_fix():
-    """Test getting of fix."""
-    fix = Fix.get_fixes('CMIP5', 'CCSM4', 'Amon', 'cl')
-    assert fix == [Cl(None)]
+class TestCl(unittest.TestCase):
+    """Test cl fix."""
+    def setUp(self):
+        """Prepare tests."""
+        self.cube = Cube([1.0], var_name='cl', units='%')
+        self.fix = Cl(None)
 
+    def test_get(self):
+        """Test fix get"""
+        fix = Fix.get_fixes('CMIP5', 'CCSM4', 'Amon', 'cl')
+        assert fix == [Cl(None)]
 
-def test_cl_fix():
-    """Test fix for ``cl``."""
-    assert Cl is ClFixHybridPressureCoord
+    def test_cl_fix(self):
+        """Test fix for ``cl``."""
+        assert issubclass(Cl, ClFixHybridPressureCoord)
+
+    def test_fix_data(self):
+        """Test data fix."""
+        cube = self.fix.fix_data(self.cube)
+        self.assertEqual(cube.data[0], 100)
 
 
 class TestCsoil(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/cmip5/test_ccsm4.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_ccsm4.py
@@ -6,31 +6,20 @@ from iris.coords import DimCoord
 from iris.cube import Cube
 
 from esmvalcore.cmor._fixes.cmip5.ccsm4 import Cl, Csoil, Rlut, Rlutcs, So
-from esmvalcore.cmor._fixes.common import ClFixHybridPressureCoord
+from esmvalcore.cmor._fixes.cmip5.bnu_esm import Cl as BaseCl
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
 
-class TestCl(unittest.TestCase):
-    """Test cl fix."""
-    def setUp(self):
-        """Prepare tests."""
-        self.cube = Cube([1.0], var_name='cl', units='%')
-        self.fix = Cl(None)
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP5', 'CCSM4', 'Amon', 'cl')
+    assert fix == [Cl(None)]
 
-    def test_get(self):
-        """Test fix get"""
-        fix = Fix.get_fixes('CMIP5', 'CCSM4', 'Amon', 'cl')
-        assert fix == [Cl(None)]
 
-    def test_cl_fix(self):
-        """Test fix for ``cl``."""
-        assert issubclass(Cl, ClFixHybridPressureCoord)
-
-    def test_fix_data(self):
-        """Test data fix."""
-        cube = self.fix.fix_data(self.cube)
-        self.assertEqual(cube.data[0], 100)
+def test_cl_fix():
+    """Test fix for ``cl``."""
+    assert Cl is BaseCl
 
 
 class TestCsoil(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/cmip5/test_cesm1_bgc.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_cesm1_bgc.py
@@ -4,8 +4,26 @@ import unittest
 import numpy as np
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Gpp, Nbp
+from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Cl, Gpp, Nbp
 from esmvalcore.cmor.fix import Fix
+
+
+class TestCl(unittest.TestCase):
+    """Test cl fix."""
+    def setUp(self):
+        """Prepare tests."""
+        self.cube = Cube([1.0], var_name='cl', units='%')
+        self.fix = Cl(None)
+
+    def test_get(self):
+        """Test fix get"""
+        self.assertListEqual(
+            Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'cl'), [Cl(None)])
+
+    def test_fix_data(self):
+        """Test data fix."""
+        cube = self.fix.fix_data(self.cube)
+        self.assertEqual(cube.data[0], 100)
 
 
 class TestGpp(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/cmip5/test_cesm1_bgc.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_cesm1_bgc.py
@@ -5,25 +5,19 @@ import numpy as np
 from iris.cube import Cube
 
 from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Cl, Gpp, Nbp
+from esmvalcore.cmor._fixes.cmip5.cesm1_cam5 import Cl as BaseCl
 from esmvalcore.cmor.fix import Fix
 
 
-class TestCl(unittest.TestCase):
-    """Test cl fix."""
-    def setUp(self):
-        """Prepare tests."""
-        self.cube = Cube([1.0], var_name='cl', units='%')
-        self.fix = Cl(None)
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'cl')
+    assert fix == [Cl(None)]
 
-    def test_get(self):
-        """Test fix get"""
-        self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'cl'), [Cl(None)])
 
-    def test_fix_data(self):
-        """Test data fix."""
-        cube = self.fix.fix_data(self.cube)
-        self.assertEqual(cube.data[0], 100)
+def test_cl_fix():
+    """Test fix for ``cl``."""
+    assert Cl is BaseCl
 
 
 class TestGpp(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/cmip5/test_cesm1_cam5.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_cesm1_cam5.py
@@ -1,0 +1,31 @@
+"""Tests for the fixes of CESM1-CAM5."""
+import iris
+import pytest
+
+from esmvalcore.cmor._fixes.cmip5.cesm1_cam5 import Cl
+from esmvalcore.cmor.fix import Fix
+
+
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP5', 'CESM1-CAM5', 'Amon', 'cl')
+    assert fix == [Cl(None)]
+
+
+@pytest.fixture
+def cl_cube():
+    """``cl`` cube."""
+    cube = iris.cube.Cube(
+        [1.0],
+        var_name='cl',
+        standard_name='cloud_area_fraction_in_atmosphere_layer',
+        units='%',
+    )
+    return cube
+
+
+def test_cl_fix_data(cl_cube):
+    """Test ``fix_data`` for ``cl``."""
+    fix = Cl(None)
+    out_cube = fix.fix_data(cl_cube)
+    assert out_cube.data == [100.0]

--- a/tests/integration/cmor/_fixes/cmip5/test_cesm1_fastchem.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_cesm1_fastchem.py
@@ -1,0 +1,15 @@
+"""Tests for CESM1-FASTCHEM fixes."""
+from esmvalcore.cmor._fixes.cmip5.cesm1_cam5 import Cl as BaseCl
+from esmvalcore.cmor._fixes.cmip5.cesm1_fastchem import Cl
+from esmvalcore.cmor.fix import Fix
+
+
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP5', 'CESM1-FASTCHEM', 'Amon', 'cl')
+    assert fix == [Cl(None)]
+
+
+def test_cl_fix():
+    """Test fix for ``cl``."""
+    assert Cl is BaseCl

--- a/tests/integration/cmor/_fixes/cmip5/test_cesm1_waccm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_cesm1_waccm.py
@@ -1,0 +1,15 @@
+"""Tests for CESM1-WACCM fixes."""
+from esmvalcore.cmor._fixes.cmip5.cesm1_cam5 import Cl as BaseCl
+from esmvalcore.cmor._fixes.cmip5.cesm1_waccm import Cl
+from esmvalcore.cmor.fix import Fix
+
+
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP5', 'CESM1-WACCM', 'Amon', 'cl')
+    assert fix == [Cl(None)]
+
+
+def test_cl_fix():
+    """Test fix for ``cl``."""
+    assert Cl is BaseCl

--- a/tests/integration/cmor/_fixes/cmip5/test_fio_esm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_fio_esm.py
@@ -5,7 +5,7 @@ from cf_units import Unit
 from iris.cube import Cube
 
 from esmvalcore.cmor.fix import Fix
-from esmvalcore.cmor._fixes.cmip5.fio_esm import Ch4, Co2
+from esmvalcore.cmor._fixes.cmip5.fio_esm import Ch4, Cl, Co2
 
 
 class TestCh4(unittest.TestCase):
@@ -25,6 +25,24 @@ class TestCh4(unittest.TestCase):
         cube = self.fix.fix_data(self.cube)
         self.assertEqual(cube.data[0], 29. / 16. * 1.e9)
         self.assertEqual(cube.units, Unit('J'))
+
+
+class TestCl(unittest.TestCase):
+    """Test cl fix."""
+    def setUp(self):
+        """Prepare tests."""
+        self.cube = Cube([1.0], var_name='cl', units='%')
+        self.fix = Cl(None)
+
+    def test_get(self):
+        """Test fix get"""
+        self.assertListEqual(
+            Fix.get_fixes('CMIP5', 'FIO-ESM', 'Amon', 'cl'), [Cl(None)])
+
+    def test_fix_data(self):
+        """Test data fix."""
+        cube = self.fix.fix_data(self.cube)
+        self.assertEqual(cube.data[0], 100)
 
 
 class TestCo2(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/cmip5/test_fio_esm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_fio_esm.py
@@ -6,6 +6,18 @@ from iris.cube import Cube
 
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor._fixes.cmip5.fio_esm import Ch4, Cl, Co2
+from esmvalcore.cmor._fixes.cmip5.cesm1_cam5 import Cl as BaseCl
+
+
+def test_get_cl_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP5', 'FIO-ESM', 'Amon', 'cl')
+    assert fix == [Cl(None)]
+
+
+def test_cl_fix():
+    """Test fix for ``cl``."""
+    assert Cl is BaseCl
 
 
 class TestCh4(unittest.TestCase):
@@ -25,24 +37,6 @@ class TestCh4(unittest.TestCase):
         cube = self.fix.fix_data(self.cube)
         self.assertEqual(cube.data[0], 29. / 16. * 1.e9)
         self.assertEqual(cube.units, Unit('J'))
-
-
-class TestCl(unittest.TestCase):
-    """Test cl fix."""
-    def setUp(self):
-        """Prepare tests."""
-        self.cube = Cube([1.0], var_name='cl', units='%')
-        self.fix = Cl(None)
-
-    def test_get(self):
-        """Test fix get"""
-        self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'FIO-ESM', 'Amon', 'cl'), [Cl(None)])
-
-    def test_fix_data(self):
-        """Test data fix."""
-        cube = self.fix.fix_data(self.cube)
-        self.assertEqual(cube.data[0], 100)
 
 
 class TestCo2(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/cmip5/test_gfdl_cm2p1.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_gfdl_cm2p1.py
@@ -8,27 +8,22 @@ from iris.cube import Cube
 
 from esmvalcore.cmor._fixes.cmip5.gfdl_cm2p1 import (AllVars, Areacello, Cl,
                                                      Sftof, Sit)
+from esmvalcore.cmor._fixes.cmip5.cesm1_cam5 import Cl as BaseCl
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
 
 class TestCl(unittest.TestCase):
     """Test cl fix."""
-    def setUp(self):
-        """Prepare tests."""
-        self.cube = Cube([1.0], var_name='cl', units='%')
-        self.fix = Cl(None)
-
     def test_get(self):
-        """Test fix get"""
+        """Test getting of fix."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-CM2P1', 'Amon', 'cl'),
             [Cl(None), AllVars(None)])
 
-    def test_fix_data(self):
-        """Test data fix."""
-        cube = self.fix.fix_data(self.cube)
-        self.assertEqual(cube.data[0], 100)
+    def test_fix(self):
+        """Test fix for ``cl``."""
+        assert Cl is BaseCl
 
 
 class TestSftof(unittest.TestCase):

--- a/tests/integration/cmor/_fixes/cmip5/test_gfdl_cm2p1.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_gfdl_cm2p1.py
@@ -6,10 +6,29 @@ import iris
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip5.gfdl_cm2p1 import (AllVars, Areacello, Sftof,
-                                                     Sit)
+from esmvalcore.cmor._fixes.cmip5.gfdl_cm2p1 import (AllVars, Areacello, Cl,
+                                                     Sftof, Sit)
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
+
+
+class TestCl(unittest.TestCase):
+    """Test cl fix."""
+    def setUp(self):
+        """Prepare tests."""
+        self.cube = Cube([1.0], var_name='cl', units='%')
+        self.fix = Cl(None)
+
+    def test_get(self):
+        """Test fix get"""
+        self.assertListEqual(
+            Fix.get_fixes('CMIP5', 'GFDL-CM2P1', 'Amon', 'cl'),
+            [Cl(None), AllVars(None)])
+
+    def test_fix_data(self):
+        """Test data fix."""
+        cube = self.fix.fix_data(self.cube)
+        self.assertEqual(cube.data[0], 100)
 
 
 class TestSftof(unittest.TestCase):


### PR DESCRIPTION
This PR provides fixes for the CMIP5 datasets BNU-ESM, CCSM4, CESM1-BGC, CESM1-CAM5, CESM1-FASTCHEM, CESM1-WACCM, FIO-ESM, GFDL-CM2p1. Variable cl (3-dim cloud fraction) is erroneously reported in units percent (%) but units are actually given as fraction (0-1).

-   Closes #1016

## Checklist

-   [ ] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
