### PR TITLE
Avoid side effects in extract_season

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -156,19 +156,26 @@ def extract_season(cube, season):
     sstart = allmonths.index(season)
     res_season = allmonths[sstart + len(season):sstart + 12]
     seasons = [season, res_season]
+    coords_to_remove = []
 
     if not cube.coords('clim_season'):
         iris.coord_categorisation.add_season(cube,
                                              'time',
                                              name='clim_season',
                                              seasons=seasons)
+        coords_to_remove.append('clim_season')
+
     if not cube.coords('season_year'):
         iris.coord_categorisation.add_season_year(cube,
                                                   'time',
                                                   name='season_year',
                                                   seasons=seasons)
+        coords_to_remove.append('season_year')
 
-    return cube.extract(iris.Constraint(clim_season=season))
+    result = cube.extract(iris.Constraint(clim_season=season))
+    for coord in coords_to_remove:
+        cube.remove_coord(coord)
+    return result
 
 
 def extract_month(cube, month):

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -241,6 +241,15 @@ class TestExtractSeason(tests.Test):
         assert_array_equal(np.array([6, 7, 8, 6, 7, 8]),
                            sliced.coord('month_number').points)
 
+    def test_get_multiple_seasons(self):
+        """Test function for two seasons."""
+        sliced = [extract_season(self.cube, seas) for seas in ["JJA", "SON"]]
+        clim_coords = [sin_sli.coord("clim_season") for sin_sli in sliced]
+        assert_array_equal(clim_coords[0].points,
+                           ['JJA', 'JJA', 'JJA', 'JJA', 'JJA', 'JJA'])
+        assert_array_equal(clim_coords[1].points,
+                           ['SON', 'SON', 'SON', 'SON', 'SON', 'SON'])
+
     def test_get_son(self):
         """Test function for summer."""
         sliced = extract_season(self.cube, 'SON')

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -6,11 +6,16 @@ import unittest
 import iris
 import iris.coord_categorisation
 import iris.coords
+import iris.exceptions
 import numpy as np
 import pytest
 from cf_units import Unit
 from iris.cube import Cube
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import (
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_raises,
+)
 
 import tests
 from esmvalcore.preprocessor._time import (
@@ -202,6 +207,10 @@ class TestExtractSeason(tests.Test):
         iris.coord_categorisation.add_month_number(sliced, 'time')
         assert_array_equal(np.array([1, 2, 12, 1, 2, 12]),
                            sliced.coord('month_number').points)
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('clim_season')
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('season_year')
 
     def test_get_djf_caps(self):
         """Test function works when season specified in caps."""
@@ -209,6 +218,10 @@ class TestExtractSeason(tests.Test):
         iris.coord_categorisation.add_month_number(sliced, 'time')
         assert_array_equal(np.array([1, 2, 12, 1, 2, 12]),
                            sliced.coord('month_number').points)
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('clim_season')
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('season_year')
 
     def test_get_mam(self):
         """Test function for spring."""
@@ -216,6 +229,10 @@ class TestExtractSeason(tests.Test):
         iris.coord_categorisation.add_month_number(sliced, 'time')
         assert_array_equal(np.array([3, 4, 5, 3, 4, 5]),
                            sliced.coord('month_number').points)
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('clim_season')
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('season_year')
 
     def test_get_jja(self):
         """Test function for summer."""
@@ -230,6 +247,10 @@ class TestExtractSeason(tests.Test):
         iris.coord_categorisation.add_month_number(sliced, 'time')
         assert_array_equal(np.array([9, 10, 11, 9, 10, 11]),
                            sliced.coord('month_number').points)
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('clim_season')
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('season_year')
 
     def test_get_jf(self):
         """Test function for custom seasons."""
@@ -237,6 +258,10 @@ class TestExtractSeason(tests.Test):
         iris.coord_categorisation.add_month_number(sliced, 'time')
         assert_array_equal(np.array([1, 2, 1, 2]),
                            sliced.coord('month_number').points)
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('clim_season')
+        with assert_raises(iris.exceptions.CoordinateNotFoundError):
+            self.cube.coord('season_year')
 
 
 class TestClimatology(tests.Test):


### PR DESCRIPTION
Extract season was having side efefcts in the form of extra aux coords left in the original cube. This PR fixes it

-   Closes #1013

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [ ] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
