### PR TITLE
Switch to running the Github Action test workflow every 3 hours in single thread mode to observe if Sementation Faults occur

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -22,15 +22,14 @@ on:
   push:
     branches:
     - master
-    - run_test_hourly
   # run the test only if the PR is to master
   # turn it on if required
   #pull_request:
   #  branches:
   #  - master
   schedule:
-    # - cron: '0 0 * * *'
-    - cron: '0 * * * *'
+    # - cron: '0 0 * * *'  # nightly
+    - cron: '0 */3 * * *'  # every 3 hours
 
 jobs:
   linux:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -22,14 +22,15 @@ on:
   push:
     branches:
     - master
-    - github-actions2
+    - run_test_hourly
   # run the test only if the PR is to master
   # turn it on if required
   #pull_request:
   #  branches:
   #  - master
   schedule:
-    - cron: '0 0 * * *'
+    # - cron: '0 0 * * *'
+    - cron: '0 1-23 * * *'
 
 jobs:
   linux:
@@ -57,7 +58,7 @@ jobs:
       - shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - shell: bash -l {0}
-        run: pytest -n 2 -m "not installation" 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
+        run: pytest -n 1 -m "not installation" 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail
         uses: actions/upload-artifact@v2
@@ -90,7 +91,7 @@ jobs:
       - shell: bash -l {0}
         run: pip install -e .[develop] --use-feature=2020-resolver 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/install.txt
       - shell: bash -l {0}
-        run: pytest -n 2 -m "not installation" 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/test_report.txt
+        run: pytest -n 1 -m "not installation" 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail
         uses: actions/upload-artifact@v2

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -30,7 +30,7 @@ on:
   #  - master
   schedule:
     # - cron: '0 0 * * *'
-    - cron: '0 1-23 * * *'
+    - cron: '0 * * * *'
 
 jobs:
   linux:


### PR DESCRIPTION
I am trying to gather enough statistic to prove that if we run the test in single thread mode we will not see the Segmentation Faults we've been seeing for nearly a year now. So to do that I want to have the GA run the test only workflow every three hours; unfortunately it's not possible to have this done on a branch, it has to be the main branch, but we can let this go for a few days, gather enough statistic then revert to the nightly run as we had it so far. If this is true then we can do what @stefsmeets suggests in this [comment](https://github.com/ESMValGroup/ESMValCore/issues/1020#issuecomment-785809295) and hopefully rid ourselves of those pesty SegFaults for good. Please see logic behind this PR in https://github.com/ESMValGroup/ESMValCore/issues/1020