### PR TITLE
Revert to original Github Actions test workflow removing the 3-hourly test run with -n 1

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -28,8 +28,7 @@ on:
   #  branches:
   #  - master
   schedule:
-    # - cron: '0 0 * * *'  # nightly
-    - cron: '0 */3 * * *'  # every 3 hours
+    - cron: '0 0 * * *'  # nightly
 
 jobs:
   linux:
@@ -57,7 +56,7 @@ jobs:
       - shell: bash -l {0}
         run: pip install -e .[develop] 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/install.txt
       - shell: bash -l {0}
-        run: pytest -n 1 -m "not installation" 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
+        run: pytest -n 2 -m "not installation" 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail
         uses: actions/upload-artifact@v2
@@ -90,7 +89,7 @@ jobs:
       - shell: bash -l {0}
         run: pip install -e .[develop] --use-feature=2020-resolver 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/install.txt
       - shell: bash -l {0}
-        run: pytest -n 1 -m "not installation" 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/test_report.txt
+        run: pytest -n 2 -m "not installation" 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/test_report.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
reverts changes that supported the (now false supposition) tests pass w/o SegFaults if run in single thread mode from #1020 