### PR TITLE
Avoid stale cache for multimodel statistics regression tests

### DIFF
--- a/tests/sample_data/multimodel_statistics/test_multimodel.py
+++ b/tests/sample_data/multimodel_statistics/test_multimodel.py
@@ -14,6 +14,9 @@ from esmvalcore.preprocessor._multimodel import multi_model_statistics
 
 esmvaltool_sample_data = pytest.importorskip("esmvaltool_sample_data")
 
+# Increase this number anytime you change the cached input data to the tests.
+TEST_REVISION = 1
+
 CALENDAR_PARAMS = (
     pytest.param(
         '360_day',
@@ -41,6 +44,7 @@ def assert_array_almost_equal(this, other):
 
 def preprocess_data(cubes, time_slice: dict = None):
     """Regrid the data to the first cube and optional time-slicing."""
+    # Increase TEST_REVISION anytime you make changes to this function.
     if time_slice:
         cubes = [extract_time(cube, **time_slice) for cube in cubes]
 
@@ -61,14 +65,14 @@ def get_cache_key(value):
     """Get a cache key that is hopefully unique enough for unpickling.
 
     If this doesn't avoid problems with unpickling the cached data,
-    manually clean the pytest cache with the command `pytest --cache-
-    clear`.
+    manually clean the pytest cache with the command `pytest --cache-clear`.
     """
     return ' '.join([
         str(value),
         iris.__version__,
         np.__version__,
         sys.version,
+        f"rev-{TEST_REVISION}",
     ])
 
 
@@ -82,6 +86,7 @@ def timeseries_cubes_month(request):
     if data:
         cubes = pickle.loads(data.encode('latin1'))
     else:
+        # Increase TEST_REVISION anytime you make changes here.
         time_slice = {
             'start_year': 1985,
             'end_year': 1987,
@@ -111,6 +116,7 @@ def timeseries_cubes_day(request):
         cubes = pickle.loads(data.encode('latin1'))
 
     else:
+        # Increase TEST_REVISION anytime you make changes here.
         time_slice = {
             'start_year': 2001,
             'end_year': 2002,


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!
-->

## Description

<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValCore better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

-   Closes #1028

To show that this actually solves the problem, I

1.  created a branch called `fix-regression-multimodel-tests` off `master` before #1021 was merged and pushed it, to run the tests and create the pytest cache. 
2. pulled the current master into `fix-regression-multimodel-tests` and pushed that, to show that the tests fail because of the stale cache. 
3. changed the cache key, committed and pushed to run the tests again and to show that this solves the problem.

You can view the results of the test runs here:
https://app.circleci.com/pipelines/github/ESMValGroup/ESMValCore?branch=fix-regression-multimodel-tests

I added some comments with instructions to change the cache key every time the cached input data is changed, to hopefully avoid this problem in the future.

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available


***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
