### PR TITLE
Move _get_time_bounds from preprocessor._time to cmor.check to avoid circular import with cmor module

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -1,4 +1,5 @@
 """Module for checking iris cubes against their CMOR definitions."""
+import datetime
 import logging
 from enum import IntEnum
 
@@ -22,6 +23,47 @@ CheckLevels = IntEnum('CheckLevels', 'DEBUG STRICT DEFAULT RELAXED IGNORE')
    - RELAXED: Fail if cubes present severe discrepancies with CMOR standards.
    - IGNORE: Do not fail for any discrepancy with CMOR standards.
 """
+
+
+def _get_next_month(month, year):
+    if month != 12:
+        return month + 1, year
+    return 1, year + 1
+
+
+def _get_time_bounds(time, freq):
+    bounds = []
+    for step, point in enumerate(time.points):
+        month = time.cell(step).point.month
+        year = time.cell(step).point.year
+        if freq in ['mon', 'mo']:
+            next_month, next_year = _get_next_month(month, year)
+            min_bound = time.units.date2num(
+                datetime.datetime(year, month, 1, 0, 0))
+            max_bound = time.units.date2num(
+                datetime.datetime(next_year, next_month, 1, 0, 0))
+        elif freq == 'yr':
+            min_bound = time.units.date2num(
+                datetime.datetime(year, 1, 1, 0, 0))
+            max_bound = time.units.date2num(
+                datetime.datetime(year + 1, 1, 1, 0, 0))
+        elif freq == 'dec':
+            min_bound = time.units.date2num(
+                datetime.datetime(year, 1, 1, 0, 0))
+            max_bound = time.units.date2num(
+                datetime.datetime(year + 10, 1, 1, 0, 0))
+        else:
+            delta = {
+                'day': 12 / 24,
+                '6hr': 3 / 24,
+                '3hr': 1.5 / 24,
+                '1hr': 0.5 / 24,
+            }
+            min_bound = point - delta[freq]
+            max_bound = point + delta[freq]
+        bounds.append([min_bound, max_bound])
+
+    return np.array(bounds)
 
 
 class CMORCheckError(Exception):
@@ -508,7 +550,6 @@ class CMORCheck():
                     coord.var_name, var_name)
 
     def _check_time_bounds(self, freq, time):
-        from esmvalcore.preprocessor._time import _get_time_bounds
         times = {'time', 'time1', 'time2', 'time3'}
         key = times.intersection(self._cmor_var.coordinates)
         cmor = self._cmor_var.coordinates[" ".join(key)]

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -9,7 +9,6 @@ import iris.exceptions
 import iris.util
 import numpy as np
 
-from esmvalcore.preprocessor._time import _get_time_bounds
 from .table import CMOR_TABLES
 
 CheckLevels = IntEnum('CheckLevels', 'DEBUG STRICT DEFAULT RELAXED IGNORE')
@@ -509,6 +508,7 @@ class CMORCheck():
                     coord.var_name, var_name)
 
     def _check_time_bounds(self, freq, time):
+        from esmvalcore.preprocessor._time import _get_time_bounds
         times = {'time', 'time1', 'time2', 'time3'}
         key = times.intersection(self._cmor_var.coordinates)
         cmor = self._cmor_var.coordinates[" ".join(key)]

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -17,6 +17,8 @@ import iris.util
 import numpy as np
 from iris.time import PartialDateTime
 
+from esmvalcore.cmor.check import _get_time_bounds
+
 from ._shared import get_iris_analysis_operation, operator_accept_weights
 
 logger = logging.getLogger(__name__)
@@ -742,46 +744,6 @@ def regrid_time(cube, frequency):
                                               name='day_of_year')
 
     return cube
-
-
-def _get_time_bounds(time, freq):
-    bounds = []
-    for step, point in enumerate(time.points):
-        month = time.cell(step).point.month
-        year = time.cell(step).point.year
-        if freq in ['mon', 'mo']:
-            next_month, next_year = _get_next_month(month, year)
-            min_bound = time.units.date2num(
-                datetime.datetime(year, month, 1, 0, 0))
-            max_bound = time.units.date2num(
-                datetime.datetime(next_year, next_month, 1, 0, 0))
-        elif freq == 'yr':
-            min_bound = time.units.date2num(
-                datetime.datetime(year, 1, 1, 0, 0))
-            max_bound = time.units.date2num(
-                datetime.datetime(year + 1, 1, 1, 0, 0))
-        elif freq == 'dec':
-            min_bound = time.units.date2num(
-                datetime.datetime(year, 1, 1, 0, 0))
-            max_bound = time.units.date2num(
-                datetime.datetime(year + 10, 1, 1, 0, 0))
-        else:
-            delta = {
-                'day': 12 / 24,
-                '6hr': 3 / 24,
-                '3hr': 1.5 / 24,
-                '1hr': 0.5 / 24,
-            }
-            min_bound = point - delta[freq]
-            max_bound = point + delta[freq]
-        bounds.append([min_bound, max_bound])
-    return np.array(bounds)
-
-
-def _get_next_month(month, year):
-    if month != 12:
-        return month + 1, year
-    return 1, year + 1
 
 
 def low_pass_weights(window, cutoff):

--- a/tests/unit/test_cmor_api.py
+++ b/tests/unit/test_cmor_api.py
@@ -1,0 +1,13 @@
+# flake8: noqa
+import esmvalcore.cmor.check
+import esmvalcore.cmor.fix
+import esmvalcore.cmor.fixes
+import esmvalcore.cmor.table
+from esmvalcore.cmor.check import (
+    CheckLevels,
+    CMORCheck,
+    CMORCheckError,
+    cmor_check,
+    cmor_check_data,
+    cmor_check_metadata,
+)


### PR DESCRIPTION
Closes #1036 

as a thumb rule, we should really not use variable names like `time` as well as we should make a proper `__init__.py` file for the `cmor` module - this fix here is not elegant at all but until we de-convolute `cmor` module from `preprocessor` modue via a good `__init__` file I can't see another solution