### PR TITLE
Raise in extract_season and extract_month if result is None

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -148,6 +148,11 @@ def extract_season(cube, season):
     -------
     iris.cube.Cube
         data cube for specified season.
+
+    Raises
+    ------
+    ValueError
+        if requested season is not present in the cube
     """
     season = season.upper()
 
@@ -177,6 +182,8 @@ def extract_season(cube, season):
     result = cube.extract(iris.Constraint(clim_season=season))
     for coord in coords_to_remove:
         cube.remove_coord(coord)
+    if result is None:
+        raise ValueError(f'Season {season} not present in cube {cube}')
     return result
 
 
@@ -194,6 +201,11 @@ def extract_month(cube, month):
     -------
     iris.cube.Cube
         data cube for specified month.
+
+    Raises
+    ------
+    ValueError
+        if requested month is not present in the cube
     """
     if month not in range(1, 13):
         raise ValueError('Please provide a month number between 1 and 12.')
@@ -201,7 +213,10 @@ def extract_month(cube, month):
         iris.coord_categorisation.add_month_number(cube,
                                                    'time',
                                                    name='month_number')
-    return cube.extract(iris.Constraint(month_number=month))
+    result = cube.extract(iris.Constraint(month_number=month))
+    if result is None:
+        raise ValueError(f'Month {month} not present in cube {cube}')
+    return result
 
 
 def get_time_weights(cube):

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -183,7 +183,7 @@ def extract_season(cube, season):
     for coord in coords_to_remove:
         cube.remove_coord(coord)
     if result is None:
-        raise ValueError(f'Season {season} not present in cube {cube}')
+        raise ValueError(f'Season {season!r} not present in cube {cube}')
     return result
 
 
@@ -215,7 +215,7 @@ def extract_month(cube, month):
                                                    name='month_number')
     result = cube.extract(iris.Constraint(month_number=month))
     if result is None:
-        raise ValueError(f'Month {month} not present in cube {cube}')
+        raise ValueError(f'Month {month!r} not present in cube {cube}')
     return result
 
 

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -1,6 +1,7 @@
 """Unit tests for the :func:`esmvalcore.preprocessor._time` module."""
 
 import copy
+import datetime
 import unittest
 
 import iris
@@ -9,7 +10,6 @@ import iris.coords
 import iris.exceptions
 import numpy as np
 import pytest
-import datetime
 from cf_units import Unit
 from iris.cube import Cube
 from numpy.testing import (
@@ -72,6 +72,12 @@ class TestExtractMonth(tests.Test):
         assert_array_equal(np.array([1, 1]),
                            sliced.coord('month_number').points)
 
+    def test_raises_if_extracted_cube_is_none(self):
+        """Test function for winter."""
+        sliced = extract_month(self.cube, 1)
+        with assert_raises(ValueError):
+            extract_month(sliced, 2)
+
     def test_get_january_with_existing_coord(self):
         """Test january extraction."""
         iris.coord_categorisation.add_month_number(self.cube, 'time')
@@ -92,6 +98,11 @@ class TestTimeSlice(tests.Test):
     def setUp(self):
         """Prepare tests."""
         self.cube = _create_sample_cube()
+
+    def test_raises_if_extracted_cube_is_none(self):
+        """Test extract_time."""
+        with assert_raises(ValueError):
+            extract_time(self.cube, 2000, 1, 1, 2000, 12, 31)
 
     def test_extract_time(self):
         """Test extract_time."""
@@ -212,6 +223,12 @@ class TestExtractSeason(tests.Test):
             self.cube.coord('clim_season')
         with assert_raises(iris.exceptions.CoordinateNotFoundError):
             self.cube.coord('season_year')
+
+    def test_raises_if_extracted_cube_is_none(self):
+        """Test function for winter."""
+        sliced = extract_season(self.cube, 'DJF')
+        with assert_raises(ValueError):
+            extract_season(sliced, 'MAM')
 
     def test_get_djf_caps(self):
         """Test function works when season specified in caps."""
@@ -806,7 +823,7 @@ class TestRegridTimeYearly(tests.Test):
             expected_minbound = timeunit_1.date2num(
                 datetime.datetime(year_1, 1, 1))
             expected_maxbound = timeunit_1.date2num(
-                datetime.datetime(year_1+1, 1, 1))
+                datetime.datetime(year_1 + 1, 1, 1))
             assert_array_equal(
                 newcube_1.coord('time').bounds[i],
                 np.array([expected_minbound, expected_maxbound]))
@@ -925,8 +942,8 @@ class TestRegridTimeDaily(tests.Test):
         self.assert_array_equal(diff_cube.data, expected)
         # test bounds are set with a dt = 12/24 days
         for i, time in enumerate(newcube_1.coord('time').points):
-            expected_minbound = time - 12/24
-            expected_maxbound = time + 12/24
+            expected_minbound = time - 12 / 24
+            expected_maxbound = time + 12 / 24
             assert_array_equal(
                 newcube_1.coord('time').bounds[i],
                 np.array([expected_minbound, expected_maxbound]))
@@ -978,8 +995,8 @@ class TestRegridTime6Hourly(tests.Test):
         self.assert_array_equal(diff_cube.data, expected)
         # test bounds are set with a dt = 3/24 days
         for i, time in enumerate(newcube_1.coord('time').points):
-            expected_minbound = time - 3/24
-            expected_maxbound = time + 3/24
+            expected_minbound = time - 3 / 24
+            expected_maxbound = time + 3 / 24
             assert_array_equal(
                 newcube_1.coord('time').bounds[i],
                 np.array([expected_minbound, expected_maxbound]))
@@ -1031,8 +1048,8 @@ class TestRegridTime3Hourly(tests.Test):
         self.assert_array_equal(diff_cube.data, expected)
         # test bounds are set with a dt = 1.5/24 days
         for i, time in enumerate(newcube_1.coord('time').points):
-            expected_minbound = time - 1.5/24
-            expected_maxbound = time + 1.5/24
+            expected_minbound = time - 1.5 / 24
+            expected_maxbound = time + 1.5 / 24
             assert_array_equal(
                 newcube_1.coord('time').bounds[i],
                 np.array([expected_minbound, expected_maxbound]))
@@ -1084,8 +1101,8 @@ class TestRegridTime1Hourly(tests.Test):
         self.assert_array_equal(diff_cube.data, expected)
         # test bounds are set with a dt = 0.5/24 days
         for i, time in enumerate(newcube_1.coord('time').points):
-            expected_minbound = time - 0.5/24
-            expected_maxbound = time + 0.5/24
+            expected_minbound = time - 0.5 / 24
+            expected_maxbound = time + 0.5 / 24
             assert_array_equal(
                 newcube_1.coord('time').bounds[i],
                 np.array([expected_minbound, expected_maxbound]))


### PR DESCRIPTION
We found that when a `extract_month` call in a cube that did not have the required month in it ESMValTool fails with an obscure extract trace

```python
  File "/opt/conda/lib/python3.8/site-packages/esmvalcore/_task.py", line 735, in _run_task
    output_files = task.run()
  File "/opt/conda/lib/python3.8/site-packages/esmvalcore/_task.py", line 242, in run
    self.output_files = self._run(input_files)
  File "/opt/conda/lib/python3.8/site-packages/esmvalcore/preprocessor/__init__.py", line 432, in _run
    product.apply(step, self.debug)
  File "/opt/conda/lib/python3.8/site-packages/esmvalcore/preprocessor/__init__.py", line 300, in apply
    self.cubes = preprocess(self.cubes, step, **self.settings[step])
  File "/opt/conda/lib/python3.8/site-packages/esmvalcore/preprocessor/__init__.py", line 253, in preprocess
    items.extend(item)
TypeError: 'NoneType' object is not iterable
```

This is due to the function not failing but returning None instead. This PR fixes this behaviour by raising an exception inside `extract_month` and `extract_season` so we fail with a better message and stack trace



## Before you get started

-   [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [ ] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
