### PR TITLE
Added new Extract surface preprocessor

### DIFF
--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -68,6 +68,7 @@ from ._volume import (
     extract_trajectory,
     extract_transect,
     extract_volume,
+    extract_surface,
     volume_statistics,
 )
 from ._weighting import weighting_landsea_fraction
@@ -99,6 +100,7 @@ __all__ = [
     'resample_hours',
     'resample_time',
     # Level extraction
+    'extract_surface',
     'extract_levels',
     # Weighting
     'weighting_landsea_fraction',

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -295,6 +295,37 @@ def volume_statistics(
     return _create_cube_time(src_cube, result, times)
 
 
+def extract_surface(cube):
+    """
+    Extact the surface layer from a 3D cube.
+    """
+    zcoord = cube.coord(axis='Z')
+    positive = zcoord.attributes['positive']
+
+    if zcoord.points.ndim == 1:
+        # ie downwards is positive
+        surf = np.abs(zcoord.points).argmin()
+
+    else:
+        assert 0
+        if positive == 'up':
+            # ie downwards is positive
+            surf = 0
+        if positive == 'down': # Not sure about this part!
+            # ie downwards is negative
+            surf = -1
+
+    zcoord_dim  = cube.coord_dims(zcoord)
+    if zcoord_dim in [0, (0,)]:
+       return  cube[surf]
+
+    if zcoord_dim in [1, (1,)]:
+       return  cube[:, surf] 
+
+    logger.error('Condition not recognised: postive: %s , zcoord_dim: %s, surface level: %s', positive, zcoord_dim, surf)
+    assert 0
+    
+
 def depth_integration(cube):
     """
     Determine the total sum over the vertical component.


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!
-->

## Description

This PR adds the `extract_surface` preprocessor, this is necessary because of the issues described in #1039.

Basically, when we're looking at a 3D dataset, but only want to keep the surface layer. Extract_layer can be used to do this, but it actually regrids the entire dataset along the z axis, so this is incredibly slow and memory intensive. 

-   Closes #1039
-   Link to documentation:

***

## Before you get started

-   [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [ ] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
