### PR TITLE
Extending LWP fix for CMIP6 models

### DIFF
--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -47,6 +47,10 @@ class DerivedVariable(DerivedVariableBase):
         project = clwvi_cube.attributes.get('project_id')
         if project:
             dataset = clwvi_cube.attributes.get('model_id')
+            # some CMIP6 models define both, project_id and source_id but
+            # no model_id --> also try source_id to find model name
+            if not dataset:
+                dataset = clwvi_cube.attributes.get('source_id')
         else:
             project = clwvi_cube.attributes.get('mip_era')
             dataset = clwvi_cube.attributes.get('source_id')
@@ -55,28 +59,38 @@ class DerivedVariable(DerivedVariableBase):
         # cubes?
 
         bad_datasets = [
+            'CCSM4',           # CMIP5 models
             'CESM1-CAM5-1-FV2',
             'CESM1-CAM5',
             'CMCC-CESM',
             'CMCC-CM',
             'CMCC-CMS',
+            'CSIRO-Mk3-6-0',
+            'GISS-E2-1-G',
+            'GISS-E2-1-H',
             'IPSL-CM5A-MR',
             'IPSL-CM5A-LR',
             'IPSL-CM5B-LR',
-            'CCSM4',
             'IPSL-CM5A-MR',
             'MIROC-ESM',
             'MIROC-ESM-CHEM',
             'MIROC-ESM',
-            'CSIRO-Mk3-6-0',
-            'MPI-ESM-MR',
             'MPI-ESM-LR',
+            'MPI-ESM-MR',
             'MPI-ESM-P',
+            'AWI-ESM-1-1-LR',   # CMIP6 models
             'CAMS-CSM1-0',
-            'GISS-E2-1-G',
-            'GISS-E2-1-H',
+            'FGOALS-f3-L',
+            'IPSL-CM6A-LR',
+            'MPI-ESM-1-2-HAM',
+            'MPI-ESM1-2-HR',
+            'MPI-ESM1-2-LR',
+            'SAM0-UNICON'
         ]
         affected_projects = ["CMIP5", "CMIP5_ETHZ", "CMIP6"]
+        print("===============")
+        print(dataset)
+        print(project)
         if (project in affected_projects and dataset in bad_datasets):
             logger.info(
                 "Assuming that variable clwvi from %s dataset %s "

--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -88,9 +88,6 @@ class DerivedVariable(DerivedVariableBase):
             'SAM0-UNICON'
         ]
         affected_projects = ["CMIP5", "CMIP5_ETHZ", "CMIP6"]
-        print("===============")
-        print(dataset)
-        print(project)
         if (project in affected_projects and dataset in bad_datasets):
             logger.info(
                 "Assuming that variable clwvi from %s dataset %s "


### PR DESCRIPTION
This PR adds new CMIP6 models to the list of models that provide only liquid water instead of total water (liquid + ice) for variable clwvi. Those models have to be treated seperately when calculating liquid water path (lwp).

## Checklist

-   [ ] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description