### PR TITLE
Fix 'positive' attribute for rsns/rlns variables

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_rlns.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_rlns.dat
@@ -6,7 +6,7 @@ modeling_realm:    atmos
 !----------------------------------
 ! Variable attributes:
 !----------------------------------
-standard_name:     
+standard_name:
 units:             W m-2
 cell_methods:      time: mean
 cell_measures:     area: areacella
@@ -17,6 +17,6 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
+positive:          down
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_rsns.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_rsns.dat
@@ -6,7 +6,7 @@ modeling_realm:    atmos
 !----------------------------------
 ! Variable attributes:
 !----------------------------------
-standard_name:     
+standard_name:
 units:             W m-2
 cell_methods:      time: mean
 cell_measures:     area: areacella
@@ -17,6 +17,6 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
+positive:          down
 !----------------------------------
 !


### PR DESCRIPTION
## Description

As per the discussion in #1050 the custom CMOR file for the variables rsns and rlns (Surface Net **downward** Shortwave/Longwave Radiation) contain a wrong value in the field `positive: up`. This pull request corrects them to `down.` 

-   Closes  #1050
-   Link to documentation:

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

***

