### PR TITLE
Add fixes for the net & up radiation variables from ERA5

### DIFF
--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -181,6 +181,30 @@ class Rlds(Fix):
         return cubes
 
 
+class Rlns(Fix):
+    """Fixes for Rlns."""
+    def fix_metadata(self, cubes):
+        """Fix metadata."""
+        for cube in cubes:
+            fix_hourly_time_coordinate(cube)
+            fix_accumulated_units(cube)
+            cube.attributes['positive'] = 'down'
+
+        return cubes
+
+
+class Rlus(Fix):
+    """Fixes for Rlds."""
+    def fix_metadata(self, cubes):
+        """Fix metadata."""
+        for cube in cubes:
+            fix_hourly_time_coordinate(cube)
+            fix_accumulated_units(cube)
+            cube.attributes['positive'] = 'up'
+
+        return cubes
+
+
 class Rls(Fix):
     """Fixes for Rls."""
     def fix_metadata(self, cubes):
@@ -200,6 +224,30 @@ class Rsds(Fix):
             fix_hourly_time_coordinate(cube)
             fix_accumulated_units(cube)
             cube.attributes['positive'] = 'down'
+
+        return cubes
+
+
+class Rsns(Fix):
+    """Fixes for Rsns."""
+    def fix_metadata(self, cubes):
+        """Fix metadata."""
+        for cube in cubes:
+            fix_hourly_time_coordinate(cube)
+            fix_accumulated_units(cube)
+            cube.attributes['positive'] = 'down'
+
+        return cubes
+
+
+class Rsus(Fix):
+    """Fixes for Rsus."""
+    def fix_metadata(self, cubes):
+        """Fix metadata."""
+        for cube in cubes:
+            fix_hourly_time_coordinate(cube)
+            fix_accumulated_units(cube)
+            cube.attributes['positive'] = 'up'
 
         return cubes
 

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -194,7 +194,7 @@ class Rlns(Fix):
 
 
 class Rlus(Fix):
-    """Fixes for Rlds."""
+    """Fixes for Rlus."""
     def fix_metadata(self, cubes):
         """Fix metadata."""
         for cube in cubes:

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -183,6 +183,7 @@ class Rlds(Fix):
 
 class Rlns(Fix):
     """Fixes for Rlns."""
+
     def fix_metadata(self, cubes):
         """Fix metadata."""
         for cube in cubes:
@@ -195,6 +196,7 @@ class Rlns(Fix):
 
 class Rlus(Fix):
     """Fixes for Rlus."""
+
     def fix_metadata(self, cubes):
         """Fix metadata."""
         for cube in cubes:
@@ -230,6 +232,7 @@ class Rsds(Fix):
 
 class Rsns(Fix):
     """Fixes for Rsns."""
+
     def fix_metadata(self, cubes):
         """Fix metadata."""
         for cube in cubes:
@@ -242,6 +245,7 @@ class Rsns(Fix):
 
 class Rsus(Fix):
     """Fixes for Rsus."""
+
     def fix_metadata(self, cubes):
         """Fix metadata."""
         for cube in cubes:


### PR DESCRIPTION
## Description

As discussed in #1050 we need some additional radiation data from ERA5 (namely rsus, rlus, rsns, rlns). This pull request adds fixes to these variables equivalent to the existing fixes for rsds and rlds. 

Additional information: radiation upward variables are not available for ERA5. We discussed several ideas but have not really come up with a solution how to fix this on the fly (e.g. https://github.com/ESMValGroup/ESMValCore/issues/1050#issuecomment-800271692). Fixing it in the diagnostic (as I suggested here: https://github.com/ESMValGroup/ESMValCore/issues/1050#issuecomment-800226289) does not work because some of the calculations are not linear (e.g., there is a difference if we do std(rsus) or std(rsds) - std(rsns)). 
Therefore I now calculate the upwards variables offline as a first fix. 

-   Closes #1050  
-   Link to documentation:

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [x] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

***
