### PR TITLE
Add derived variable rsus

### DIFF
--- a/esmvalcore/preprocessor/_derive/rsus.py
+++ b/esmvalcore/preprocessor/_derive/rsus.py
@@ -1,0 +1,38 @@
+"""Derivation of variable `rsus`.
+
+authors:
+    - lukas_brunner
+
+"""
+from iris import Constraint
+
+from ._baseclass import DerivedVariableBase
+
+
+class DerivedVariable(DerivedVariableBase):
+    """Derivation of variable `rsus`."""
+
+    @staticmethod
+    def required(project):
+        """Declare the variables needed for derivation."""
+        required = [
+            {
+                'short_name': 'rsds'
+            },
+            {
+                'short_name': 'rsns'
+            },
+        ]
+        return required
+
+    @staticmethod
+    def calculate(cubes):
+        """Compute upwelling shortwave flux from downwelling and net."""
+        rsds_cube = cubes.extract(
+            Constraint(name='surface_downwelling_shortwave_flux_in_air'))
+        rsns_cube = cubes.extract(
+            Constraint(name='surface_net_downward_shortwave_flux'))
+
+        rsus_cube = rsds_cube - rsns_cube
+
+        return rsus_cube


### PR DESCRIPTION
## Description

Add the option to derive the variable rsus (long_name: Surface Upwelling Shortwave Radiation) for ERA5 where it is not present as discussed in #1050. This is exactly equivalent to existing derivations for, e.g., rsns. 

-   Closes #1050
-   Link to documentation:

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [ ] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available
***

