### PR TITLE
Fix bug when fixing bounds after fixing longitude values

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -527,9 +527,7 @@ class CMORCheck():
                 if not fixed:
                     self.report_critical(self._attr_msg, var_name, 'units',
                                          cmor.units, coord.units)
-        self._check_coord_values(cmor, coord, var_name)
-        self._check_coord_bounds(cmor, coord, var_name)
-        self._check_coord_monotonicity_and_direction(cmor, coord, var_name)
+        self._check_coord_points(cmor, coord, var_name)
 
     def _check_coord_bounds(self, cmor, coord, var_name):
         if cmor.must_have_bounds == 'yes' and not coord.has_bounds():
@@ -606,8 +604,8 @@ class CMORCheck():
             self._cube = iris.util.reverse(self._cube,
                                            self._cube.coord_dims(coord))
 
-    def _check_coord_values(self, coord_info, coord, var_name):
-        """Check coordinate values."""
+    def _check_coord_points(self, coord_info, coord, var_name):
+        """Check coordinate points: values, bounds and monotonicity."""
         # Check requested coordinate values exist in coord.points
         self._check_requested_values(coord, coord_info, var_name)
 
@@ -655,6 +653,10 @@ class CMORCheck():
                 dims = self._cube.coord_dims(coord)
                 self._cube.remove_coord(coord)
                 self._cube.add_aux_coord(new_coord, dims)
+            coord = self._cube.coord(var_name=var_name)
+        self._check_coord_bounds(coord_info, coord, var_name)
+        self._check_coord_monotonicity_and_direction(coord_info, coord,
+                                                     var_name)
 
     def _check_longitude_max(self, coord, var_name):
         if np.any(coord.points > 720):

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -639,13 +639,13 @@ class TestCMORCheck(unittest.TestCase):
         for index in range(20):
             self.assertTrue(
                 iris.util.approx_equal(cube_points[index], reference[index]))
-   
+
     def test_not_bounds(self):
         """Warning if bounds are not available."""
         self.cube.coord('longitude').bounds = None
         self._check_warnings_on_metadata(automatic_fixes=False)
         self.assertFalse(self.cube.coord('longitude').has_bounds())
-    
+
     def test_guess_bounds_with_fixes(self):
         """Warning if bounds added with automatic fixes."""
         self.cube.coord('longitude').bounds = None

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -639,13 +639,13 @@ class TestCMORCheck(unittest.TestCase):
         for index in range(20):
             self.assertTrue(
                 iris.util.approx_equal(cube_points[index], reference[index]))
-
+   
     def test_not_bounds(self):
         """Warning if bounds are not available."""
         self.cube.coord('longitude').bounds = None
         self._check_warnings_on_metadata(automatic_fixes=False)
         self.assertFalse(self.cube.coord('longitude').has_bounds())
-
+    
     def test_guess_bounds_with_fixes(self):
         """Warning if bounds added with automatic fixes."""
         self.cube.coord('longitude').bounds = None
@@ -668,6 +668,15 @@ class TestCMORCheck(unittest.TestCase):
         """Test automatic fixes for bad longitudes."""
         self.cube = self.cube.intersection(longitude=(-180., 180.))
         self._check_cube(automatic_fixes=True)
+
+    def test_lons_automatic_fix_with_bounds(self):
+        """Test automatic fixes for bad longitudes with added bounds."""
+        self.cube.coord('longitude').bounds = None
+        self.cube = self.cube.intersection(longitude=(-180., 180.))
+        self._check_cube(automatic_fixes=True)
+        self.assertTrue(self.cube.coord('longitude').points.min() >= 0.)
+        self.assertTrue(self.cube.coord('longitude').points.max() <= 360.)
+        self.assertTrue(self.cube.coord('longitude').has_bounds())
 
     def test_high_lons_automatic_fix(self):
         """Test automatic fixes for high longitudes."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!
-->

## Description
This pull request adds missing bounds properly if the longitude values have been recomputed.
<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValCore better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

-   Closes #1056 
-   Link to documentation:

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
