### PR TITLE
Fix bounds after reversing coordinate values

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -603,10 +603,14 @@ class CMORCheck():
         if coord.ndim == 1:
             self._cube = iris.util.reverse(self._cube,
                                            self._cube.coord_dims(coord))
-            if coord.has_bounds():
-                if coord.bounds[..., 0].all() > coord.bounds[..., 1].all():
-                    coord.bounds = np.fliplr(coord.bounds)
-                    self._cube.coord(coord.var_name).bounds = coord.bounds
+            reversed_coord = self._cube.coord(var_name=coord.var_name)
+            if reversed_coord.has_bounds():
+                bounds = reversed_coord.bounds
+                right_bounds = bounds[:-2, 1]
+                left_bounds = bounds[1:-1, 0]
+                if np.all(right_bounds != left_bounds):
+                    reversed_coord.bounds = np.fliplr(bounds)
+                    coord = reversed_coord
             self.report_debug_message(f'Coordinate {coord.var_name} values'
                                       'have been reversed.')
 

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -603,6 +603,12 @@ class CMORCheck():
         if coord.ndim == 1:
             self._cube = iris.util.reverse(self._cube,
                                            self._cube.coord_dims(coord))
+            if coord.has_bounds():
+                if coord.bounds[..., 0].all() > coord.bounds[..., 1].all():
+                    coord.bounds = np.fliplr(coord.bounds)
+                    self._cube.coord(coord.var_name).bounds = coord.bounds
+            self.report_debug_message(f'Coordinate {coord.var_name} values'
+                                      'have been reversed.')
 
     def _check_coord_points(self, coord_info, coord, var_name):
         """Check coordinate points: values, bounds and monotonicity."""

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -619,6 +619,23 @@ class TestCMORCheck(unittest.TestCase):
         self._update_coordinate_values(self.cube, coord, values)
         self._check_fails_in_metadata()
 
+    def test_non_increasing_fix(self):
+        """Check automatic fix for direction."""
+        coord = self.cube.coord('latitude')
+        values = np.linspace(
+            coord.points[-1],
+            coord.points[0],
+            len(coord.points)
+        )
+        self._update_coordinate_values(self.cube, coord, values)
+        self._check_cube(automatic_fixes=True)
+        self._check_cube()
+        # test bounds are contiguous
+        bounds = self.cube.coord('latitude').bounds
+        right_bounds = bounds[:-2, 1]
+        left_bounds = bounds[1:-1, 0]
+        self.assertTrue(np.all(left_bounds == right_bounds))
+
     def test_non_decreasing(self):
         """Fail in metadata if decreasing coordinate is increasing."""
         self.var_info.coordinates['lat'].stored_direction = 'decreasing'
@@ -641,10 +658,9 @@ class TestCMORCheck(unittest.TestCase):
                 iris.util.approx_equal(cube_points[index], reference[index]))
         # test bounds are contiguous
         bounds = self.cube.coord('latitude').bounds
-        len_bounds = bounds.shape[0]
-        left_bounds = bounds[0:len_bounds-1, 0]
-        right_bounds = bounds[1:len_bounds, 1]
-        self.assertTrue(left_bounds.all() == right_bounds.all())
+        right_bounds = bounds[:-2, 1]
+        left_bounds = bounds[1:-1, 0]
+        self.assertTrue(np.all(left_bounds == right_bounds))
 
     def test_not_bounds(self):
         """Warning if bounds are not available."""

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -639,6 +639,12 @@ class TestCMORCheck(unittest.TestCase):
         for index in range(20):
             self.assertTrue(
                 iris.util.approx_equal(cube_points[index], reference[index]))
+        # test bounds are contiguous
+        bounds = self.cube.coord('latitude').bounds
+        len_bounds = bounds.shape[0]
+        left_bounds = bounds[0:len_bounds-1, 0]
+        right_bounds = bounds[1:len_bounds, 1]
+        self.assertTrue(left_bounds.all() == right_bounds.all())
 
     def test_not_bounds(self):
         """Warning if bounds are not available."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!
-->

## Description
This pull request flips back the coordinate bounds if they have been reversed when checking the coordinate direction

<!--
    Please describe your changes here, especially focusing on why this PR makes
    ESMValCore better and what problem it solves.

    Before you start, please read our [contribution guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html).

    Please fill in the GitHub issue that is closed by this pull request, e.g. Closes #1903
-->

-   Closes #1060 
-   Link to documentation:

***

## Before you get started

-   [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## Checklist

-   [x] PR has a descriptive title for the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Labels are assigned so they can be used in the [changelog](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] Code follows the [style guide](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#code-style)
-   [ ] [Documentation](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#documentation) is available for new functionality
-   [ ] YAML files pass [`pre-commit`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#pre-commit) or [`yamllint`](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/community/introduction.html#yaml) checks
-   [x] [Circle/CI tests pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [ ] [Codacy code quality checks pass](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review)
-   [x] [Documentation builds successfully](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/contributing.html#branches-pull-requests-and-code-review) on readthedocs
-   [x] [Unit tests](https://docs.esmvaltool.org/projects/esmvalcore/projects/esmvalcore/en/latest/contributing.html#contributing-to-the-esmvalcore-package) are available

If you make backwards incompatible changes to the recipe format:

-   [ ] Update [ESMValTool](https://github.com/esmvalgroup/esmvaltool) and link the pull request(s) in the description

***

To help with the number pull requests:

-   🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValTool/pulls) in this repository
