### PR TITLE
Run conda build parallel AND sequential tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             . /opt/conda/etc/profile.d/conda.sh
             conda activate esmvaltool
             pip install .[test]
-            pytest -n 2 -m "not installation and not sequential"
+            pytest -n 4 -m "not installation and not sequential"
             pytest -n 0 -m "sequential"
       - save_cache:
           key: test-{{ .Branch }}
@@ -74,7 +74,7 @@ jobs:
             conda env export > /logs/environment.yml
             pip freeze > /logs/requirements.txt
             # Test installation
-            pytest -n 2 -m "not sequential"
+            pytest -n 4 -m "not sequential"
             pytest -n 0 -m "sequential"
             esmvaltool version
       - save_cache:
@@ -142,7 +142,7 @@ jobs:
             pip freeze > /logs/requirements.txt
             # Test installation
             esmvaltool version
-            pytest -n 2 -m "not sequential"
+            pytest -n 4 -m "not sequential"
             pytest -n 0 -m "sequential"
       - store_artifacts:
           path: /logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             . /opt/conda/etc/profile.d/conda.sh
             conda activate esmvaltool
             pip install .[test]
-            pytest -n 4 -m "not installation and not sequential"
+            pytest -n 2 -m "not installation and not sequential"
             pytest -n 0 -m "sequential"
       - save_cache:
           key: test-{{ .Branch }}
@@ -74,7 +74,7 @@ jobs:
             conda env export > /logs/environment.yml
             pip freeze > /logs/requirements.txt
             # Test installation
-            pytest -n 4 -m "not sequential"
+            pytest -n 2 -m "not sequential"
             pytest -n 0 -m "sequential"
             esmvaltool version
       - save_cache:
@@ -142,7 +142,7 @@ jobs:
             pip freeze > /logs/requirements.txt
             # Test installation
             esmvaltool version
-            pytest -n 4 -m "not sequential"
+            pytest -n 2 -m "not sequential"
             pytest -n 0 -m "sequential"
       - store_artifacts:
           path: /logs

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -77,8 +77,8 @@ test:
     - r-yaml
     - ncl
   commands:
-    - pytest -n 2 -m "not sequential"
-    - pytest -n 0 -m "sequential"
+    - pytest -n 2 -m "not sequential" --ignore=run_test.py
+    - pytest -n 0 -m "sequential" --ignore=run_test.py
     - esmvaltool -- --help
     - esmvaltool version
   imports:

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -77,7 +77,8 @@ test:
     - r-yaml
     - ncl
   commands:
-    - pytest -n 2 --ignore=run_test.py
+    - pytest -n 4 -m "not sequential"
+    - pytest -n 0 -m "sequential"
     - esmvaltool -- --help
     - esmvaltool version
   imports:

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -77,7 +77,7 @@ test:
     - r-yaml
     - ncl
   commands:
-    - pytest -n 4 -m "not sequential"
+    - pytest -n 2 -m "not sequential"
     - pytest -n 0 -m "sequential"
     - esmvaltool -- --help
     - esmvaltool version

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2.py
@@ -51,6 +51,7 @@ AIR_PRESSURE_BOUNDS = np.array([[[[[0.0, 1.5],
                                    [7.0, 25.0]]]]])
 
 
+@pytest.mark.sequential
 @pytest.mark.skipif(sys.version_info < (3, 7, 6),
                     reason="requires python3.7.6 or newer")
 @unittest.mock.patch(

--- a/tests/integration/cmor/_fixes/cmip6/test_gfdl_cm4.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_gfdl_cm4.py
@@ -33,6 +33,7 @@ AIR_PRESSURE_BOUNDS = np.array([[[[[0.0, 1.5],
                                    [9.0, 21.0]]]]])
 
 
+@pytest.mark.sequential
 def test_cl_fix_metadata(test_data_path):
     """Test ``fix_metadata`` for ``cl``."""
     nc_path = test_data_path / 'gfdl_cm4_cl.nc'

--- a/tests/integration/cmor/_fixes/cmip6/test_gfdl_cm4.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_gfdl_cm4.py
@@ -1,6 +1,7 @@
 """Tests for the fixes of GFDL-CM4."""
 import iris
 import numpy as np
+import pytest
 
 from esmvalcore.cmor._fixes.cmip6.gfdl_cm4 import Cl, Cli, Clw
 from esmvalcore.cmor.fix import Fix


### PR DESCRIPTION
Continuation from #1064 to include the same test run strategy for conda build tests ~and try bump the number of threads we use for running the parallel tests on Circle.~ Bumping number of threads with `-n 4` definitely leads to memory issues for the conda build tests and might lead to the same issue for the regular CI tests, so let's keep them at 2