### PR TITLE
Fix: Flip big endian arrays before concatenation

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -171,12 +171,22 @@ def _get_concatenation_error(cubes):
     raise ValueError(f'Can not concatenate cubes: {msg}')
 
 
+def _fix_cube_endianess(cubes):
+    """Transform cubes in big endian to little"""
+    for cube in cubes:
+        if cube.dtype.byteorder == ">":
+            logger.warning("Changing cube endianess to little. This may be "
+                           "memory intensive.")
+            cube.data = cube.data.byteswap().newbyteorder()
+
+
 def concatenate(cubes):
     """Concatenate all cubes after fixing metadata."""
     if len(cubes) == 1:
         return cubes[0]
 
     _fix_cube_attributes(cubes)
+    _fix_cube_endianess(cubes)
 
     if len(cubes) > 1:
         # order cubes by first time point


### PR DESCRIPTION
## Description

This fix is needed to support the CCLM CORDEX model data as it is available in ESGF and in the CDS. Endianness between files is not consistent, and this raises an error when concatenating. The best way to solve this we saw is to look for the ">" that flags big endian datatypes and, if found,  call numpy methods byteswap and newbyteorder to reverse the endianness of the underlying arrays.


Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***