### PR TITLE
Fix erroneous use of `grid_latitude` and `grid_longitude` and cleaned ocean grid fixes

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/bcc_csm1_1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/bcc_csm1_1.py
@@ -1,68 +1,7 @@
 """Fixes for bcc-csm1-1."""
-import numpy as np
-from scipy.interpolate import InterpolatedUnivariateSpline
-from scipy.ndimage import map_coordinates
-
-from ..common import ClFixHybridPressureCoord
-from ..fix import Fix
-
+from ..common import ClFixHybridPressureCoord, OceanFixGrid
 
 Cl = ClFixHybridPressureCoord
 
 
-class Tos(Fix):
-    """Fixes for tos."""
-
-    def fix_data(self, cube):
-        """Fix data.
-
-        Calculate missing latitude/longitude boundaries using interpolation.
-
-        Parameters
-        ----------
-        cube: iris.cube.Cube
-            Input cube to fix.
-
-        Returns
-        -------
-        iris.cube.Cube
-
-        """
-        rlat = cube.coord('grid_latitude').points
-        rlon = cube.coord('grid_longitude').points
-
-        # Transform grid latitude/longitude to array indices [0, 1, 2, ...]
-        rlat_to_idx = InterpolatedUnivariateSpline(rlat,
-                                                   np.arange(len(rlat)),
-                                                   k=1)
-        rlon_to_idx = InterpolatedUnivariateSpline(rlon,
-                                                   np.arange(len(rlon)),
-                                                   k=1)
-        rlat_idx_bnds = rlat_to_idx(cube.coord('grid_latitude').bounds)
-        rlon_idx_bnds = rlon_to_idx(cube.coord('grid_longitude').bounds)
-
-        # Calculate latitude/longitude vertices by interpolation
-        lat_vertices = []
-        lon_vertices = []
-        for (i, j) in [(0, 0), (0, 1), (1, 1), (1, 0)]:
-            (rlat_v, rlon_v) = np.meshgrid(rlat_idx_bnds[:, i],
-                                           rlon_idx_bnds[:, j],
-                                           indexing='ij')
-            lat_vertices.append(
-                map_coordinates(cube.coord('latitude').points,
-                                [rlat_v, rlon_v],
-                                mode='nearest'))
-            lon_vertices.append(
-                map_coordinates(cube.coord('longitude').points,
-                                [rlat_v, rlon_v],
-                                mode='wrap'))
-        lat_vertices = np.array(lat_vertices)
-        lon_vertices = np.array(lon_vertices)
-        lat_vertices = np.moveaxis(lat_vertices, 0, -1)
-        lon_vertices = np.moveaxis(lon_vertices, 0, -1)
-
-        # Copy vertices to cube
-        cube.coord('latitude').bounds = lat_vertices
-        cube.coord('longitude').bounds = lon_vertices
-
-        return cube
+Tos = OceanFixGrid

--- a/esmvalcore/cmor/_fixes/cmip5/bcc_csm1_1_m.py
+++ b/esmvalcore/cmor/_fixes/cmip5/bcc_csm1_1_m.py
@@ -1,9 +1,7 @@
 """Fixes for bcc-csm1-1-m."""
-from ..common import ClFixHybridPressureCoord
-from .bcc_csm1_1 import Tos as BaseTos
-
+from ..common import ClFixHybridPressureCoord, OceanFixGrid
 
 Cl = ClFixHybridPressureCoord
 
 
-Tos = BaseTos
+Tos = OceanFixGrid

--- a/esmvalcore/cmor/_fixes/cmip6/bcc_csm2_mr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/bcc_csm2_mr.py
@@ -1,7 +1,5 @@
 """Fixes for BCC-CSM2-MR model."""
-from ..cmip5.bcc_csm1_1 import Tos as BaseTos
-from ..common import ClFixHybridPressureCoord
-
+from ..common import ClFixHybridPressureCoord, OceanFixGrid
 
 Cl = ClFixHybridPressureCoord
 
@@ -12,57 +10,7 @@ Cli = ClFixHybridPressureCoord
 Clw = ClFixHybridPressureCoord
 
 
-class Tos(BaseTos):
-    """Fixes for tos."""
-
-    def fix_metadata(self, cubes):
-        """Rename ``var_name`` of 1D-``latitude`` and 1D-``longitude``.
-        Parameters
-        ----------
-        cubes : iris.cube.CubeList
-            Input cubes.
-        Returns
-        -------
-        iris.cube.CubeList
-        """
-        cube = self.get_cube_from_list(cubes)
-        lat_coord = cube.coord('latitude', dimensions=(1, ))
-        lon_coord = cube.coord('longitude', dimensions=(2, ))
-        lat_coord.standard_name = None
-        lat_coord.long_name = 'grid_latitude'
-        lat_coord.var_name = 'i'
-        lat_coord.units = '1'
-        lon_coord.standard_name = None
-        lon_coord.long_name = 'grid_longitude'
-        lon_coord.var_name = 'j'
-        lon_coord.units = '1'
-        lon_coord.circular = False
-        return cubes
+Tos = OceanFixGrid
 
 
-class Siconc(BaseTos):
-    """Fixes for siconc."""
-
-    def fix_metadata(self, cubes):
-        """Rename ``var_name`` of 1D-``latitude`` and 1D-``longitude``.
-        Parameters
-        ----------
-        cubes : iris.cube.CubeList
-            Input cubes.
-        Returns
-        -------
-        iris.cube.CubeList
-        """
-        cube = self.get_cube_from_list(cubes)
-        lat_coord = cube.coord('latitude', dimensions=(1, ))
-        lon_coord = cube.coord('longitude', dimensions=(2, ))
-        lat_coord.standard_name = None
-        lat_coord.long_name = 'grid_latitude'
-        lat_coord.var_name = 'i'
-        lat_coord.units = '1'
-        lon_coord.standard_name = None
-        lon_coord.long_name = 'grid_longitude'
-        lon_coord.var_name = 'j'
-        lon_coord.units = '1'
-        lon_coord.circular = False
-        return cubes
+Siconc = OceanFixGrid

--- a/esmvalcore/cmor/_fixes/cmip6/bcc_esm1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/bcc_esm1.py
@@ -1,7 +1,5 @@
 """Fixes for BCC-ESM1 model."""
-from ..common import ClFixHybridPressureCoord
-from .bcc_csm2_mr import Tos as BaseTos
-
+from ..common import ClFixHybridPressureCoord, OceanFixGrid
 
 Cl = ClFixHybridPressureCoord
 
@@ -12,4 +10,4 @@ Cli = ClFixHybridPressureCoord
 Clw = ClFixHybridPressureCoord
 
 
-Tos = BaseTos
+Tos = OceanFixGrid

--- a/esmvalcore/cmor/_fixes/cmip6/fgoals_g3.py
+++ b/esmvalcore/cmor/_fixes/cmip6/fgoals_g3.py
@@ -2,7 +2,6 @@
 from ..cmip5.fgoals_g2 import Cl as BaseCl
 from ..common import OceanFixGrid
 
-
 Cl = BaseCl
 
 
@@ -12,7 +11,31 @@ Cli = BaseCl
 Clw = BaseCl
 
 
-Tos = OceanFixGrid
+class Tos(OceanFixGrid):
+    """Fixes for tos."""
+
+    def fix_metadata(self, cubes):
+        """Fix metadata.
+
+        FGOALS-g3 data contain latitude and longitude data set to >1e30 in some
+        places.
+
+        Parameters
+        ----------
+        cubes : iris.cube.CubeList
+            Input cubes.
+
+        Returns
+        -------
+        iris.cube.CubeList
+
+        """
+        cube = self.get_cube_from_list(cubes)
+        cube.coord('latitude').points[
+            cube.coord('latitude').points > 1000.0] = 0.0
+        cube.coord('longitude').points[
+            cube.coord('longitude').points > 1000.0] = 0.0
+        return super().fix_metadata(cubes)
 
 
-Siconc = OceanFixGrid
+Siconc = Tos

--- a/esmvalcore/cmor/_fixes/common.py
+++ b/esmvalcore/cmor/_fixes/common.py
@@ -124,10 +124,14 @@ class OceanFixGrid(Fix):
         cube = self.get_cube_from_list(cubes)
 
         # Get dimensional coordinates. Note:
-        # - First dimension i -> X-direction (longitude; = dimension 2 in data)
-        # - Second dimension j -> Y-direction (latitude; = dimension 1 in data)
-        i_coord = cube.coord(dim_coords=True, dimensions=2)
-        j_coord = cube.coord(dim_coords=True, dimensions=1)
+        # - First dimension i -> X-direction (= longitude)
+        # - Second dimension j -> Y-direction (= latitude)
+        (j_dim, i_dim) = sorted(set(
+            cube.coord_dims(cube.coord('latitude', dim_coords=False)) +
+            cube.coord_dims(cube.coord('longitude', dim_coords=False))
+        ))
+        i_coord = cube.coord(dim_coords=True, dimensions=i_dim)
+        j_coord = cube.coord(dim_coords=True, dimensions=j_dim)
 
         # Fix metadata of coordinate i
         i_coord.var_name = 'i'

--- a/esmvalcore/cmor/_fixes/common.py
+++ b/esmvalcore/cmor/_fixes/common.py
@@ -161,10 +161,12 @@ class OceanFixGrid(Fix):
             idx_coord.bounds = None
             idx_coord.guess_bounds()
 
-        # Calculate latitude/longitude vertices by interpolation. More details
-        # on boundaries for 2D coordinates and corresponding conventions are
-        # given here:
-        # cfconventions.org/cf-conventions/cf-conventions.html#cell-boundaries
+        # Calculate latitude/longitude vertices by interpolation.
+        # Following the CF conventions (see
+        # cfconventions.org/cf-conventions/cf-conventions.html#cell-boundaries)
+        # we go counter-clockwise around the cells and construct a grid of
+        # index values which are in turn used to interpolate longitudes and
+        # latitudes in the midpoints between the cell centers.
         lat_vertices = []
         lon_vertices = []
         for (j, i) in [(0, 0), (0, 1), (1, 1), (1, 0)]:

--- a/esmvalcore/cmor/_fixes/common.py
+++ b/esmvalcore/cmor/_fixes/common.py
@@ -1,10 +1,14 @@
 """Common fixes used for multiple datasets."""
+import logging
+
 import iris
 import numpy as np
 from scipy.ndimage import map_coordinates
 
 from .fix import Fix
 from .shared import add_plev_from_altitude, fix_bounds
+
+logger = logging.getLogger(__name__)
 
 
 class ClFixHybridHeightCoord(Fix):
@@ -122,6 +126,11 @@ class OceanFixGrid(Fix):
 
         """
         cube = self.get_cube_from_list(cubes)
+        if cube.ndim != 3:
+            logger.warning(
+                "OceanFixGrid is designed to work on any data with an "
+                "irregular ocean grid, but it was only tested on 3D (time, "
+                "latitude, longitude) data so far; got %dD data", cube.ndim)
 
         # Get dimensional coordinates. Note:
         # - First dimension i -> X-direction (= longitude)
@@ -152,7 +161,10 @@ class OceanFixGrid(Fix):
             idx_coord.bounds = None
             idx_coord.guess_bounds()
 
-        # Calculate latitude/longitude vertices by interpolation
+        # Calculate latitude/longitude vertices by interpolation. More details
+        # on boundaries for 2D coordinates and corresponding conventions are
+        # given here:
+        # cfconventions.org/cf-conventions/cf-conventions.html#cell-boundaries
         lat_vertices = []
         lon_vertices = []
         for (j, i) in [(0, 0), (0, 1), (1, 1), (1, 0)]:

--- a/esmvalcore/cmor/_fixes/common.py
+++ b/esmvalcore/cmor/_fixes/common.py
@@ -1,6 +1,7 @@
 """Common fixes used for multiple datasets."""
 import iris
 import numpy as np
+from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.ndimage import map_coordinates
 
 from .fix import Fix
@@ -108,63 +109,8 @@ class ClFixHybridPressureCoord(Fix):
 class OceanFixGrid(Fix):
     """Fixes for tos, siconc in FGOALS-g3."""
 
-    def fix_data(self, cube):
-        """
-        Fix data.
-
-        Calculate missing latitude/longitude boundaries using interpolation.
-        Based on a similar fix for BCC-CSM2-MR.
-
-        Parameters
-        ----------
-        cube: iris.cube.Cube
-            Input cube to fix.
-
-        Returns
-        -------
-        iris.cube.Cube
-        """
-        rlat = cube.coord('grid_latitude').points
-        rlon = cube.coord('grid_longitude').points
-
-        # Guess coordinate bounds in rlat, rlon (following BCC-CSM2-MR-1).
-        rlat_idx_bnds = np.zeros((len(rlat), 2))
-        rlat_idx_bnds[:, 0] = np.arange(len(rlat)) - 0.5
-        rlat_idx_bnds[:, 1] = np.arange(len(rlat)) + 0.5
-        rlat_idx_bnds[0, 0] = 0.
-        rlat_idx_bnds[len(rlat) - 1, 1] = len(rlat)
-        rlon_idx_bnds = np.zeros((len(rlon), 2))
-        rlon_idx_bnds[:, 0] = np.arange(len(rlon)) - 0.5
-        rlon_idx_bnds[:, 1] = np.arange(len(rlon)) + 0.5
-
-        # Calculate latitude/longitude vertices by interpolation
-        lat_vertices = []
-        lon_vertices = []
-        for (i, j) in [(0, 0), (0, 1), (1, 1), (1, 0)]:
-            (rlat_v, rlon_v) = np.meshgrid(rlat_idx_bnds[:, i],
-                                           rlon_idx_bnds[:, j],
-                                           indexing='ij')
-            lat_vertices.append(
-                map_coordinates(cube.coord('latitude').points,
-                                [rlat_v, rlon_v],
-                                mode='nearest'))
-            lon_vertices.append(
-                map_coordinates(cube.coord('longitude').points,
-                                [rlat_v, rlon_v],
-                                mode='wrap'))
-        lat_vertices = np.array(lat_vertices)
-        lon_vertices = np.array(lon_vertices)
-        lat_vertices = np.moveaxis(lat_vertices, 0, -1)
-        lon_vertices = np.moveaxis(lon_vertices, 0, -1)
-
-        # Copy vertices to cube
-        cube.coord('latitude').bounds = lat_vertices
-        cube.coord('longitude').bounds = lon_vertices
-        return cube
-
     def fix_metadata(self, cubes):
-        """
-        Rename ``var_name`` of 1D-``latitude`` and 1D-``longitude``.
+        """Fix ``latitude`` and ``longitude`` (metadata and bounds).
 
         Parameters
         ----------
@@ -174,25 +120,67 @@ class OceanFixGrid(Fix):
         Returns
         -------
         iris.cube.CubeList
+
         """
         cube = self.get_cube_from_list(cubes)
-        lat_coord = cube.coord('cell index along second dimension',
-                               dimensions=(1, ))
-        lon_coord = cube.coord('cell index along first dimension',
-                               dimensions=(2, ))
-        lat_coord.standard_name = None
-        lat_coord.long_name = 'grid_latitude'
-        lat_coord.var_name = 'i'
-        lat_coord.units = '1'
-        lon_coord.standard_name = None
-        lon_coord.long_name = 'grid_longitude'
-        lon_coord.var_name = 'j'
-        lon_coord.units = '1'
-        lon_coord.circular = False
-        # FGOALS-g3 data contain latitude and longitude data set to
-        # >1e30 in some places. Set to 0. to avoid problem in check.py.
-        cube.coord('latitude').points[cube.coord('latitude').points > 1000.]\
-            = 0.
-        cube.coord('longitude').points[cube.coord('longitude').points > 1000.]\
-            = 0.
-        return cubes
+
+        # Get dimensional coordinates. Note:
+        # - First dimension i -> X-direction (longitude; = dimension 2 in data)
+        # - Second dimension j -> Y-direction (latitude; = dimension 1 in data)
+        i_coord = cube.coord(dim_coords=True, dimensions=2)
+        j_coord = cube.coord(dim_coords=True, dimensions=1)
+
+        # Fix metadata of coordinate i
+        i_coord.var_name = 'i'
+        i_coord.standard_name = None
+        i_coord.long_name = 'cell index along first dimension'
+        i_coord.units = '1'
+        i_coord.circular = False
+
+        # Fix metadata of coordinate j
+        j_coord.var_name = 'j'
+        j_coord.standard_name = None
+        j_coord.long_name = 'cell index along second dimension'
+        j_coord.units = '1'
+
+        # Guess bounds of coordinates i and j if necessary
+        if not i_coord.has_bounds():
+            i_coord.guess_bounds()
+        if not j_coord.has_bounds():
+            j_coord.guess_bounds()
+
+        # Transform i and j bounds into array indices [0, 1, 2, ...]
+        i_to_idx = InterpolatedUnivariateSpline(i_coord.points,
+                                                np.arange(len(i_coord.points)),
+                                                k=1)
+        j_to_idx = InterpolatedUnivariateSpline(j_coord.points,
+                                                np.arange(len(j_coord.points)),
+                                                k=1)
+        i_idx_bnds = i_to_idx(i_coord.bounds)
+        j_idx_bnds = j_to_idx(j_coord.bounds)
+
+        # Calculate latitude/longitude vertices by interpolation
+        lat_vertices = []
+        lon_vertices = []
+        for (j, i) in [(0, 0), (0, 1), (1, 1), (1, 0)]:
+            (j_v, i_v) = np.meshgrid(j_idx_bnds[:, j],
+                                     i_idx_bnds[:, i],
+                                     indexing='ij')
+            lat_vertices.append(
+                map_coordinates(cube.coord('latitude').points,
+                                [j_v, i_v],
+                                mode='nearest'))
+            lon_vertices.append(
+                map_coordinates(cube.coord('longitude').points,
+                                [j_v, i_v],
+                                mode='wrap'))
+        lat_vertices = np.array(lat_vertices)
+        lon_vertices = np.array(lon_vertices)
+        lat_vertices = np.moveaxis(lat_vertices, 0, -1)
+        lon_vertices = np.moveaxis(lon_vertices, 0, -1)
+
+        # Copy vertices to cube
+        cube.coord('latitude').bounds = lat_vertices
+        cube.coord('longitude').bounds = lon_vertices
+
+        return iris.cube.CubeList([cube])

--- a/tests/integration/cmor/_fixes/cmip5/test_bcc_csm1_1.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_bcc_csm1_1.py
@@ -92,6 +92,7 @@ def test_tos_fix_metadata():
     fixed_cubes = fix.fix_metadata(cubes)
     assert len(fixed_cubes) == 1
     fixed_cube = fixed_cubes.extract_cube('sea_surface_temperature')
+    assert fixed_cube is cube
     i_coord = fixed_cube.coord('cell index along first dimension')
     j_coord = fixed_cube.coord('cell index along second dimension')
     assert i_coord.var_name == 'i'
@@ -103,7 +104,11 @@ def test_tos_fix_metadata():
     assert j_coord.standard_name is None
     assert j_coord.long_name == 'cell index along second dimension'
     assert j_coord.units == '1'
-    assert fixed_cube is cube
+    np.testing.assert_allclose(i_coord.points, [0, 1, 2])
+    np.testing.assert_allclose(i_coord.bounds,
+                               [[-0.5, 0.5], [0.5, 1.5], [1.5, 2.5]])
+    np.testing.assert_allclose(j_coord.points, [0, 1])
+    np.testing.assert_allclose(j_coord.bounds, [[-0.5, 0.5], [0.5, 1.5]])
     assert fixed_cube.coord('latitude').bounds is not None
     assert fixed_cube.coord('longitude').bounds is not None
     latitude_bounds = np.array([[[-40, -33.75, -23.75, -30.0],

--- a/tests/integration/cmor/_fixes/cmip5/test_bcc_csm1_1.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_bcc_csm1_1.py
@@ -5,8 +5,12 @@ import iris
 import numpy as np
 
 from esmvalcore.cmor._fixes.cmip5.bcc_csm1_1 import Cl, Tos
-from esmvalcore.cmor._fixes.common import ClFixHybridPressureCoord
+from esmvalcore.cmor._fixes.common import (
+    ClFixHybridPressureCoord,
+    OceanFixGrid,
+)
 from esmvalcore.cmor.fix import Fix
+from esmvalcore.cmor.table import get_var_info
 
 
 def test_get_cl_fix():
@@ -26,11 +30,16 @@ class TestTos(unittest.TestCase):
     def test_get(self):
         """Test fix get."""
         self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'BCC-CSM1-1', 'Amon', 'tos'), [Tos(None)])
+            Fix.get_fixes('CMIP5', 'bcc-csm1-1', 'Amon', 'tos'), [Tos(None)])
 
 
-def test_tos_fix_data():
-    """Test ``fix_data`` for ``tos``."""
+def test_tos_fix():
+    """Test fix for ``tos``."""
+    assert Tos is OceanFixGrid
+
+
+def test_tos_fix_metadata():
+    """Test ``fix_metadata`` for ``tos``."""
     grid_lat = iris.coords.DimCoord(
         [20.0, 40.0],
         bounds=[[10.0, 30.0], [30.0, 50.0]],
@@ -55,21 +64,45 @@ def test_tos_fix_data():
         standard_name='longitude',
         units='degrees_east',
     )
+    time_coord = iris.coords.DimCoord(
+        1.0,
+        bounds=[0.0, 2.0],
+        var_name='time',
+        standard_name='time',
+        long_name='time',
+        units='days since 1950-01-01',
+    )
 
     # Create cube without bounds
     cube = iris.cube.Cube(
-        np.full((2, 3), 300.0),
+        np.full((1, 2, 3), 300.0),
         var_name='tos',
+        standard_name='sea_surface_temperature',
         units='K',
-        dim_coords_and_dims=[(grid_lat, 0), (grid_lon, 1)],
-        aux_coords_and_dims=[(latitude, (0, 1)), (longitude, (0, 1))],
+        dim_coords_and_dims=[(time_coord, 0), (grid_lat, 1), (grid_lon, 2)],
+        aux_coords_and_dims=[(latitude, (1, 2)), (longitude, (1, 2))],
     )
     assert cube.coord('latitude').bounds is None
     assert cube.coord('longitude').bounds is None
 
     # Apply fix
-    fix = Tos(None)
-    fixed_cube = fix.fix_data(cube)
+    vardef = get_var_info('CMIP6', 'Omon', 'tos')
+    fix = Tos(vardef)
+    cubes = iris.cube.CubeList([cube])
+    fixed_cubes = fix.fix_metadata(cubes)
+    assert len(fixed_cubes) == 1
+    fixed_cube = fixed_cubes.extract_cube('sea_surface_temperature')
+    i_coord = fixed_cube.coord('cell index along first dimension')
+    j_coord = fixed_cube.coord('cell index along second dimension')
+    assert i_coord.var_name == 'i'
+    assert i_coord.standard_name is None
+    assert i_coord.long_name == 'cell index along first dimension'
+    assert i_coord.units == '1'
+    assert i_coord.circular is False
+    assert j_coord.var_name == 'j'
+    assert j_coord.standard_name is None
+    assert j_coord.long_name == 'cell index along second dimension'
+    assert j_coord.units == '1'
     assert fixed_cube is cube
     assert fixed_cube.coord('latitude').bounds is not None
     assert fixed_cube.coord('longitude').bounds is not None

--- a/tests/integration/cmor/_fixes/cmip5/test_bcc_csm1_1_m.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_bcc_csm1_1_m.py
@@ -1,9 +1,11 @@
 """Test fixes for bcc-csm1-1-m."""
 import unittest
 
-from esmvalcore.cmor._fixes.cmip5.bcc_csm1_1 import Tos as BaseTos
 from esmvalcore.cmor._fixes.cmip5.bcc_csm1_1_m import Cl, Tos
-from esmvalcore.cmor._fixes.common import ClFixHybridPressureCoord
+from esmvalcore.cmor._fixes.common import (
+    ClFixHybridPressureCoord,
+    OceanFixGrid,
+)
 from esmvalcore.cmor._fixes.fix import Fix
 
 
@@ -29,4 +31,4 @@ class TestTos(unittest.TestCase):
 
 def test_tos_fix():
     """Test fix for ``tos``."""
-    assert Tos is BaseTos
+    assert Tos is OceanFixGrid

--- a/tests/integration/cmor/_fixes/cmip6/test_bcc_csm2_mr.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_bcc_csm2_mr.py
@@ -1,13 +1,10 @@
 """Test fixes for BCC-CSM2-MR."""
-import unittest.mock
-
-import iris
-
-from esmvalcore.cmor._fixes.cmip6.bcc_csm2_mr import (Cl, Cli,
-                                                      Clw, Tos, Siconc)
-from esmvalcore.cmor._fixes.common import ClFixHybridPressureCoord
+from esmvalcore.cmor._fixes.cmip6.bcc_csm2_mr import Cl, Cli, Clw, Siconc, Tos
+from esmvalcore.cmor._fixes.common import (
+    ClFixHybridPressureCoord,
+    OceanFixGrid,
+)
 from esmvalcore.cmor._fixes.fix import Fix
-from esmvalcore.cmor.table import get_var_info
 
 
 def test_get_cl_fix():
@@ -49,146 +46,17 @@ def test_get_tos_fix():
     assert fix == [Tos(None)]
 
 
+def test_tos_fix():
+    """Test fix for ``tos``."""
+    assert Tos is OceanFixGrid
+
+
 def test_get_siconc_fix():
     """Test getting of fix."""
-    fix = Fix.get_fixes('CMIP6', 'BCC-CSM2-MR', 'Omon', 'siconc')
+    fix = Fix.get_fixes('CMIP6', 'BCC-CSM2-MR', 'SImon', 'siconc')
     assert fix == [Siconc(None)]
 
 
-@unittest.mock.patch(
-    'esmvalcore.cmor._fixes.cmip6.bcc_csm2_mr.BaseTos.fix_data',
-    autospec=True)
-def test_tos_fix_data(mock_base_fix_data):
-    """Test ``fix_data`` for ``tos``."""
-    fix = Tos(None)
-    fix.fix_data('cubes')
-    mock_base_fix_data.assert_called_once_with(fix, 'cubes')
-
-
-@unittest.mock.patch(
-    'esmvalcore.cmor._fixes.cmip6.bcc_csm2_mr.BaseTos.fix_data',
-    autospec=True)
-def test_siconc_fix_data(mock_base_fix_data):
-    """Test ``fix_data`` for ``siconc``."""
-    fix = Siconc(None)
-    fix.fix_data('cubes')
-    mock_base_fix_data.assert_called_once_with(fix, 'cubes')
-
-
-def test_tos_fix_metadata():
-    """Test ``fix_metadata`` for ``tos``."""
-    grid_lat = iris.coords.DimCoord([1.0],
-                                    var_name='lat',
-                                    standard_name='latitude',
-                                    long_name='latitude',
-                                    units='degrees_north',
-                                    attributes={'1D': '1'})
-    grid_lon = iris.coords.DimCoord([1.0],
-                                    var_name='lon',
-                                    standard_name='longitude',
-                                    long_name='longitude',
-                                    units='degrees_east',
-                                    circular=True,
-                                    attributes={'1D': '1'})
-    latitude = iris.coords.AuxCoord([[0.0]],
-                                    var_name='lat',
-                                    standard_name='latitude',
-                                    long_name='latitude',
-                                    units='degrees_north')
-    longitude = iris.coords.AuxCoord([[0]],
-                                     var_name='lon',
-                                     standard_name='longitude',
-                                     long_name='longitude',
-                                     units='degrees_east')
-    cube = iris.cube.Cube(
-        [[[0.0]]],
-        var_name='tos',
-        long_name='sea_surface_temperature',
-        dim_coords_and_dims=[(grid_lat.copy(), 1), (grid_lon.copy(), 2)],
-        aux_coords_and_dims=[(latitude.copy(), (1, 2)),
-                             (longitude.copy(), (1, 2))],
-    )
-    cubes = iris.cube.CubeList([cube, iris.cube.Cube(0.0)])
-    vardef = get_var_info('CMIP6', 'Omon', 'tos')
-    fix = Tos(vardef)
-    fixed_cubes = fix.fix_metadata(cubes)
-    tos_cube = fixed_cubes.extract_cube('sea_surface_temperature')
-
-    # No duplicates anymore
-    assert len(tos_cube.coords('latitude')) == 1
-    assert len(tos_cube.coords('longitude')) == 1
-
-    # Latitude
-    grid_lat = tos_cube.coord('grid_latitude')
-    assert grid_lat.var_name == 'i'
-    assert grid_lat.long_name == 'grid_latitude'
-    assert grid_lat.standard_name is None
-    assert grid_lat.units == '1'
-
-    # Longitude
-    grid_lon = tos_cube.coord('grid_longitude')
-    assert grid_lon.var_name == 'j'
-    assert grid_lon.long_name == 'grid_longitude'
-    assert grid_lon.standard_name is None
-    assert grid_lon.units == '1'
-    assert not grid_lon.circular
-
-
-def test_siconc_fix_metadata():
-    """Test ``fix_metadata`` for ``tos``."""
-    grid_lat = iris.coords.DimCoord([1.0],
-                                    var_name='lat',
-                                    standard_name='latitude',
-                                    long_name='latitude',
-                                    units='degrees_north',
-                                    attributes={'1D': '1'})
-    grid_lon = iris.coords.DimCoord([1.0],
-                                    var_name='lon',
-                                    standard_name='longitude',
-                                    long_name='longitude',
-                                    units='degrees_east',
-                                    circular=True,
-                                    attributes={'1D': '1'})
-    latitude = iris.coords.AuxCoord([[0.0]],
-                                    var_name='lat',
-                                    standard_name='latitude',
-                                    long_name='latitude',
-                                    units='degrees_north')
-    longitude = iris.coords.AuxCoord([[0]],
-                                     var_name='lon',
-                                     standard_name='longitude',
-                                     long_name='longitude',
-                                     units='degrees_east')
-
-    cube = iris.cube.Cube(
-        [[[0.0]]],
-        var_name='siconc',
-        long_name='sea_ice_area_fraction',
-        dim_coords_and_dims=[(grid_lat.copy(), 1), (grid_lon.copy(), 2)],
-        aux_coords_and_dims=[(latitude.copy(), (1, 2)),
-                             (longitude.copy(), (1, 2))],
-    )
-    cubes = iris.cube.CubeList([cube, iris.cube.Cube(0.0)])
-    vardef = get_var_info('CMIP6', 'SImon', 'siconc')
-    fix = Siconc(vardef)
-    fixed_cubes = fix.fix_metadata(cubes)
-    siconc_cube = fixed_cubes.extract_cube('sea_ice_area_fraction')
-
-    # No duplicates anymore
-    assert len(siconc_cube.coords('latitude')) == 1
-    assert len(siconc_cube.coords('longitude')) == 1
-
-    # Latitude
-    grid_lat = siconc_cube.coord('grid_latitude')
-    assert grid_lat.var_name == 'i'
-    assert grid_lat.long_name == 'grid_latitude'
-    assert grid_lat.standard_name is None
-    assert grid_lat.units == '1'
-
-    # Longitude
-    grid_lon = siconc_cube.coord('grid_longitude')
-    assert grid_lon.var_name == 'j'
-    assert grid_lon.long_name == 'grid_longitude'
-    assert grid_lon.standard_name is None
-    assert grid_lon.units == '1'
-    assert not grid_lon.circular
+def test_siconc_fix():
+    """Test fix for ``siconc``."""
+    assert Siconc is OceanFixGrid

--- a/tests/integration/cmor/_fixes/cmip6/test_bcc_esm1.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_bcc_esm1.py
@@ -1,7 +1,9 @@
 """Test fixes for BCC-ESM1."""
-from esmvalcore.cmor._fixes.cmip6.bcc_csm2_mr import Tos as BaseTos
 from esmvalcore.cmor._fixes.cmip6.bcc_esm1 import Cl, Cli, Clw, Tos
-from esmvalcore.cmor._fixes.common import ClFixHybridPressureCoord
+from esmvalcore.cmor._fixes.common import (
+    ClFixHybridPressureCoord,
+    OceanFixGrid,
+)
 from esmvalcore.cmor._fixes.fix import Fix
 
 
@@ -46,4 +48,4 @@ def test_get_tos_fix():
 
 def test_tos_fix():
     """Test fix for ``tos``."""
-    assert Tos is BaseTos
+    assert Tos is OceanFixGrid

--- a/tests/integration/cmor/_fixes/cmip6/test_fgoals_g3.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fgoals_g3.py
@@ -1,7 +1,14 @@
 """Tests for the fixes of FGOALS-g3."""
+from unittest import mock
+
+import iris
+import numpy as np
+
 from esmvalcore.cmor._fixes.cmip5.fgoals_g2 import Cl as BaseCl
-from esmvalcore.cmor._fixes.cmip6.fgoals_g3 import Cl, Cli, Clw
+from esmvalcore.cmor._fixes.cmip6.fgoals_g3 import Cl, Cli, Clw, Siconc, Tos
+from esmvalcore.cmor._fixes.common import OceanFixGrid
 from esmvalcore.cmor.fix import Fix
+from esmvalcore.cmor.table import get_var_info
 
 
 def test_get_cl_fix():
@@ -35,3 +42,56 @@ def test_get_clw_fix():
 def test_clw_fix():
     """Test fix for ``clw``."""
     assert Clw is BaseCl
+
+
+def test_get_tos_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'BCC-CSM2-MR', 'Omon', 'tos')
+    assert fix == [Tos(None)]
+
+
+def test_tos_fix():
+    """Test fix for ``tos``."""
+    assert issubclass(Tos, OceanFixGrid)
+
+
+@mock.patch('esmvalcore.cmor._fixes.cmip6.fgoals_g3.OceanFixGrid.fix_metadata',
+            autospec=True)
+def test_tos_fix_metadata(mock_base_fix_metadata):
+    """Test ``fix_metadata`` for ``tos``."""
+    mock_base_fix_metadata.side_effect = lambda x, y: y
+
+    # Create test cube
+    lat_coord = iris.coords.AuxCoord([3.14, 1200.0, 6.28],
+                                     var_name='lat',
+                                     standard_name='latitude')
+    lon_coord = iris.coords.AuxCoord([1.0, 2.0, 1e30],
+                                     var_name='lon',
+                                     standard_name='longitude')
+    cube = iris.cube.Cube([1.0, 2.0, 3.0], var_name='tos',
+                          standard_name='sea_surface_temperature',
+                          aux_coords_and_dims=[(lat_coord, 0), (lon_coord, 0)])
+    cubes = iris.cube.CubeList([cube])
+
+    # Apply fix
+    vardef = get_var_info('CMIP6', 'Omon', 'tos')
+    fix = Tos(vardef)
+    fixed_cubes = fix.fix_metadata(cubes)
+    assert len(fixed_cubes) == 1
+    fixed_cube = fixed_cubes[0]
+    np.testing.assert_allclose(fixed_cube.coord('latitude').points,
+                               [3.14, 0.0, 6.28])
+    np.testing.assert_allclose(fixed_cube.coord('longitude').points,
+                               [1.0, 2.0, 0.0])
+    mock_base_fix_metadata.assert_called_once_with(fix, cubes)
+
+
+def test_get_siconc_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'BCC-CSM2-MR', 'SImon', 'siconc')
+    assert fix == [Siconc(None)]
+
+
+def test_siconc_fix():
+    """Test fix for ``siconc``."""
+    assert Siconc is Tos

--- a/tests/integration/cmor/_fixes/test_common.py
+++ b/tests/integration/cmor/_fixes/test_common.py
@@ -272,6 +272,13 @@ def test_ocean_fix_grid_wrong_ij_names(tos_cubes_wrong_ij_names):
     assert j_coord.long_name == 'cell index along second dimension'
     assert j_coord.units == '1'
 
+    # Check ij points and bounds
+    np.testing.assert_allclose(i_coord.points, [0, 1, 2])
+    np.testing.assert_allclose(i_coord.bounds,
+                               [[-0.5, 0.5], [0.5, 1.5], [1.5, 2.5]])
+    np.testing.assert_allclose(j_coord.points, [0, 1])
+    np.testing.assert_allclose(j_coord.bounds, [[-0.5, 0.5], [0.5, 1.5]])
+
     # Check bounds of latitude and longitude
     assert len(fixed_cube.coords('latitude')) == 1
     assert len(fixed_cube.coords('longitude')) == 1
@@ -334,11 +341,12 @@ def test_ocean_fix_grid_no_ij_bounds(tos_cubes_no_ij_bounds):
     assert j_coord.long_name == 'cell index along second dimension'
     assert j_coord.units == '1'
 
-    # Check bounds of i and j
+    # Check ij points and bounds
+    np.testing.assert_allclose(i_coord.points, [0, 1, 2])
     np.testing.assert_allclose(i_coord.bounds,
-                               [[5.0, 15.0], [15.0, 25.0], [25.0, 35.0]])
-    np.testing.assert_allclose(j_coord.bounds,
-                               [[10.0, 30.0], [30.0, 50.0]])
+                               [[-0.5, 0.5], [0.5, 1.5], [1.5, 2.5]])
+    np.testing.assert_allclose(j_coord.points, [0, 1])
+    np.testing.assert_allclose(j_coord.bounds, [[-0.5, 0.5], [0.5, 1.5]])
 
     # Check bounds of latitude and longitude
     assert len(fixed_cube.coords('latitude')) == 1

--- a/tests/integration/cmor/_fixes/test_common.py
+++ b/tests/integration/cmor/_fixes/test_common.py
@@ -6,6 +6,7 @@ import pytest
 from esmvalcore.cmor._fixes.common import (
     ClFixHybridHeightCoord,
     ClFixHybridPressureCoord,
+    OceanFixGrid,
 )
 from esmvalcore.cmor.table import get_var_info
 from esmvalcore.iris_helpers import var_name_constraint
@@ -166,3 +167,197 @@ def test_cl_hybrid_height_coord_fix_metadata(test_data_path):
     nc_path = test_data_path / 'common_cl_hybrid_height.nc'
     hybrid_height_coord_fix_metadata(nc_path, 'cl',
                                      ClFixHybridHeightCoord(vardef))
+
+
+def get_tos_cubes(wrong_ij_names=False, ij_bounds=False):
+    """Cubes containing tos variable."""
+    if wrong_ij_names:
+        j_var_name = 'lat'
+        j_long_name = 'latitude'
+        i_var_name = 'lon'
+        i_long_name = 'longitude'
+    else:
+        j_var_name = 'j'
+        j_long_name = 'cell index along second dimension'
+        i_var_name = 'i'
+        i_long_name = 'cell index along first dimension'
+    if ij_bounds:
+        j_bounds = [[10.0, 30.0], [30.0, 50.0]]
+        i_bounds = [[5.0, 15.0], [15.0, 25.0], [25.0, 35.0]]
+    else:
+        j_bounds = None
+        i_bounds = None
+    j_coord = iris.coords.DimCoord(
+        [20.0, 40.0],
+        bounds=j_bounds,
+        var_name=j_var_name,
+        long_name=j_long_name,
+    )
+    i_coord = iris.coords.DimCoord(
+        [10.0, 20.0, 30.0],
+        bounds=i_bounds,
+        var_name=i_var_name,
+        long_name=i_long_name,
+    )
+    lat_coord = iris.coords.AuxCoord(
+        [[-40.0, -20.0, 0.0], [-20.0, 0.0, 20.0]],
+        var_name='lat',
+        standard_name='latitude',
+        units='degrees_north',
+    )
+    lon_coord = iris.coords.AuxCoord(
+        [[100.0, 140.0, 180.0], [80.0, 100.0, 120.0]],
+        var_name='lon',
+        standard_name='longitude',
+        units='degrees_east',
+    )
+    time_coord = iris.coords.DimCoord(
+        1.0,
+        bounds=[0.0, 2.0],
+        var_name='time',
+        standard_name='time',
+        long_name='time',
+        units='days since 1950-01-01',
+    )
+
+    # Create tos variable cube
+    cube = iris.cube.Cube(
+        np.full((1, 2, 3), 300.0),
+        var_name='tos',
+        long_name='sea_surface_temperature',
+        units='K',
+        dim_coords_and_dims=[(time_coord, 0), (j_coord, 1), (i_coord, 2)],
+        aux_coords_and_dims=[(lat_coord, (1, 2)), (lon_coord, (1, 2))],
+    )
+
+    # Create empty (dummy) cube
+    empty_cube = iris.cube.Cube(0.0)
+    return iris.cube.CubeList([cube, empty_cube])
+
+
+@pytest.fixture
+def tos_cubes_wrong_ij_names():
+    """Cubes with wrong ij names."""
+    return get_tos_cubes(wrong_ij_names=True, ij_bounds=True)
+
+
+def test_ocean_fix_grid_wrong_ij_names(tos_cubes_wrong_ij_names):
+    """Test ``fix_metadata`` with cubes with wrong ij names."""
+    cube_in = tos_cubes_wrong_ij_names.extract_cube('sea_surface_temperature')
+    assert len(cube_in.coords('latitude')) == 2
+    assert len(cube_in.coords('longitude')) == 2
+    assert cube_in.coord('latitude', dimensions=1).bounds is not None
+    assert cube_in.coord('longitude', dimensions=2).bounds is not None
+    assert cube_in.coord('latitude', dimensions=(1, 2)).bounds is None
+    assert cube_in.coord('longitude', dimensions=(1, 2)).bounds is None
+
+    # Apply fix
+    vardef = get_var_info('CMIP6', 'Omon', 'tos')
+    fix = OceanFixGrid(vardef)
+    fixed_cubes = fix.fix_metadata(tos_cubes_wrong_ij_names)
+    assert len(fixed_cubes) == 1
+    fixed_cube = fixed_cubes.extract_cube('sea_surface_temperature')
+    assert fixed_cube is cube_in
+
+    # Check ij names
+    i_coord = fixed_cube.coord('cell index along first dimension')
+    j_coord = fixed_cube.coord('cell index along second dimension')
+    assert i_coord.var_name == 'i'
+    assert i_coord.standard_name is None
+    assert i_coord.long_name == 'cell index along first dimension'
+    assert i_coord.units == '1'
+    assert i_coord.circular is False
+    assert j_coord.var_name == 'j'
+    assert j_coord.standard_name is None
+    assert j_coord.long_name == 'cell index along second dimension'
+    assert j_coord.units == '1'
+
+    # Check bounds of latitude and longitude
+    assert len(fixed_cube.coords('latitude')) == 1
+    assert len(fixed_cube.coords('longitude')) == 1
+    assert fixed_cube.coord('latitude').bounds is not None
+    assert fixed_cube.coord('longitude').bounds is not None
+    latitude_bounds = np.array([[[-40, -33.75, -23.75, -30.0],
+                                 [-33.75, -6.25, 3.75, -23.75],
+                                 [-6.25, -1.02418074021670e-14, 10.0, 3.75]],
+                                [[-30.0, -23.75, -13.75, -20.0],
+                                 [-23.75, 3.75, 13.75, -13.75],
+                                 [3.75, 10.0, 20.0, 13.75]]])
+    np.testing.assert_allclose(fixed_cube.coord('latitude').bounds,
+                               latitude_bounds)
+    longitude_bounds = np.array([[[140.625, 99.375, 99.375, 140.625],
+                                  [99.375, 140.625, 140.625, 99.375],
+                                  [140.625, 99.375, 99.375, 140.625]],
+                                 [[140.625, 99.375, 99.375, 140.625],
+                                  [99.375, 140.625, 140.625, 99.375],
+                                  [140.625, 99.375, 99.375, 140.625]]])
+    np.testing.assert_allclose(fixed_cube.coord('longitude').bounds,
+                               longitude_bounds)
+
+
+@pytest.fixture
+def tos_cubes_no_ij_bounds():
+    """Cubes with no ij bounds."""
+    return get_tos_cubes(wrong_ij_names=False, ij_bounds=False)
+
+
+def test_ocean_fix_grid_no_ij_bounds(tos_cubes_no_ij_bounds):
+    """Test ``fix_metadata`` with cubes with no ij bounds."""
+    cube_in = tos_cubes_no_ij_bounds.extract_cube('sea_surface_temperature')
+    assert len(cube_in.coords('latitude')) == 1
+    assert len(cube_in.coords('longitude')) == 1
+    assert cube_in.coord('latitude').bounds is None
+    assert cube_in.coord('longitude').bounds is None
+    assert cube_in.coord('cell index along first dimension').var_name == 'i'
+    assert cube_in.coord('cell index along second dimension').var_name == 'j'
+    assert cube_in.coord('cell index along first dimension').bounds is None
+    assert cube_in.coord('cell index along second dimension').bounds is None
+
+    # Apply fix
+    vardef = get_var_info('CMIP6', 'Omon', 'tos')
+    fix = OceanFixGrid(vardef)
+    fixed_cubes = fix.fix_metadata(tos_cubes_no_ij_bounds)
+    assert len(fixed_cubes) == 1
+    fixed_cube = fixed_cubes.extract_cube('sea_surface_temperature')
+    assert fixed_cube is cube_in
+
+    # Check ij names
+    i_coord = fixed_cube.coord('cell index along first dimension')
+    j_coord = fixed_cube.coord('cell index along second dimension')
+    assert i_coord.var_name == 'i'
+    assert i_coord.standard_name is None
+    assert i_coord.long_name == 'cell index along first dimension'
+    assert i_coord.units == '1'
+    assert i_coord.circular is False
+    assert j_coord.var_name == 'j'
+    assert j_coord.standard_name is None
+    assert j_coord.long_name == 'cell index along second dimension'
+    assert j_coord.units == '1'
+
+    # Check bounds of i and j
+    np.testing.assert_allclose(i_coord.bounds,
+                               [[5.0, 15.0], [15.0, 25.0], [25.0, 35.0]])
+    np.testing.assert_allclose(j_coord.bounds,
+                               [[10.0, 30.0], [30.0, 50.0]])
+
+    # Check bounds of latitude and longitude
+    assert len(fixed_cube.coords('latitude')) == 1
+    assert len(fixed_cube.coords('longitude')) == 1
+    assert fixed_cube.coord('latitude').bounds is not None
+    assert fixed_cube.coord('longitude').bounds is not None
+    latitude_bounds = np.array([[[-40, -33.75, -23.75, -30.0],
+                                 [-33.75, -6.25, 3.75, -23.75],
+                                 [-6.25, -1.02418074021670e-14, 10.0, 3.75]],
+                                [[-30.0, -23.75, -13.75, -20.0],
+                                 [-23.75, 3.75, 13.75, -13.75],
+                                 [3.75, 10.0, 20.0, 13.75]]])
+    np.testing.assert_allclose(fixed_cube.coord('latitude').bounds,
+                               latitude_bounds)
+    longitude_bounds = np.array([[[140.625, 99.375, 99.375, 140.625],
+                                  [99.375, 140.625, 140.625, 99.375],
+                                  [140.625, 99.375, 99.375, 140.625]],
+                                 [[140.625, 99.375, 99.375, 140.625],
+                                  [99.375, 140.625, 140.625, 99.375],
+                                  [140.625, 99.375, 99.375, 140.625]]])
+    np.testing.assert_allclose(fixed_cube.coord('longitude').bounds,
+                               longitude_bounds)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

This PR
- renames `grid_latitude` and `grid_longitude` to `cell index along first/second dimension` (see #1067).
- removes duplicated code from ocean grid fixes and corresponding tests.
- adds missing tests for `tos` and `siconc` of FGOALS-g3.

I checked all affected preprocessed files (raw and regridded to a regular grid) before and after this PR with `cdo diff` and found no differences.

I didn't find any appearance of `grid_latitude` or `grid_longitude` in ESMValTool, so this shouldn't affect any diagnostic.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1067.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
