### PR TITLE
Fixed --skip-nonexistent option

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -173,6 +173,8 @@ def _get_concatenation_error(cubes):
 
 def concatenate(cubes):
     """Concatenate all cubes after fixing metadata."""
+    if not cubes:
+        return cubes
     if len(cubes) == 1:
         return cubes[0]
 
@@ -227,7 +229,15 @@ def save(cubes, filename, optimize_access='', compress=False, alias='',
     str
         filename
 
+    Raises
+    ------
+    ValueError
+        cubes is empty.
+
     """
+    if not cubes:
+        raise ValueError(f"Cannot save empty cubes '{cubes}'")
+
     # Rename some arguments
     kwargs['target'] = filename
     kwargs['zlib'] = compress

--- a/tests/integration/preprocessor/_io/test_concatenate.py
+++ b/tests/integration/preprocessor/_io/test_concatenate.py
@@ -1,7 +1,7 @@
 """Integration tests for :func:`esmvalcore.preprocessor._io.concatenate`."""
 
-import warnings
 import unittest
+import warnings
 from unittest.mock import call
 
 import numpy as np
@@ -242,6 +242,12 @@ class TestConcatenate(unittest.TestCase):
         concatenated = _io.concatenate(self.raw_cubes)
         np.testing.assert_array_equal(
             concatenated.coord('time').points, np.array([1, 2, 3, 4, 5, 6]))
+
+    def test_concatenate_empty_cubes(self):
+        """Test concatenation with empty :class:`iris.cube.CubeList`."""
+        empty_cubes = CubeList([])
+        result = _io.concatenate(empty_cubes)
+        assert result is empty_cubes
 
     def test_concatenate_noop(self):
         """Test concatenation of a single cube."""

--- a/tests/integration/preprocessor/_io/test_save.py
+++ b/tests/integration/preprocessor/_io/test_save.py
@@ -8,7 +8,7 @@ import iris
 import netCDF4
 import numpy as np
 from iris.coords import DimCoord
-from iris.cube import Cube
+from iris.cube import Cube, CubeList
 
 from esmvalcore.preprocessor import save
 
@@ -77,6 +77,13 @@ class TestSave(unittest.TestCase):
         self.assertTrue(sample_filters['shuffle'])
         self.assertEqual(sample_filters['complevel'], 4)
         handler.close()
+
+    def test_fail_empty_cubes(self):
+        """Test save fails if empty cubes is provided."""
+        (_, filename) = self._create_sample_cube()
+        empty_cubes = CubeList([])
+        with self.assertRaises(ValueError):
+            save(empty_cubes, filename)
 
     def test_fail_without_filename(self):
         """Test save fails if filename is not provided."""

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -1,6 +1,6 @@
 import pytest
 
-from esmvalcore._recipe import Recipe
+from esmvalcore._recipe import Recipe, _allow_skipping
 from esmvalcore._recipe_checks import RecipeError
 
 
@@ -40,3 +40,37 @@ class TestRecipe:
 
         with pytest.raises(RecipeError):
             Recipe._expand_ensemble(datasets)
+
+
+VAR_A = {'dataset': 'A'}
+VAR_A_REF_A = {'dataset': 'A', 'reference_dataset': 'A'}
+VAR_A_REF_B = {'dataset': 'A', 'reference_dataset': 'B'}
+
+
+TEST_ALLOW_SKIPPING = [
+    ([], VAR_A, {}, False),
+    ([], VAR_A, {'skip-nonexistent': False}, False),
+    ([], VAR_A, {'skip-nonexistent': True}, True),
+    ([], VAR_A_REF_A, {}, False),
+    ([], VAR_A_REF_A, {'skip-nonexistent': False}, False),
+    ([], VAR_A_REF_A, {'skip-nonexistent': True}, False),
+    ([], VAR_A_REF_B, {}, False),
+    ([], VAR_A_REF_B, {'skip-nonexistent': False}, False),
+    ([], VAR_A_REF_B, {'skip-nonexistent': True}, True),
+    (['A'], VAR_A, {}, False),
+    (['A'], VAR_A, {'skip-nonexistent': False}, False),
+    (['A'], VAR_A, {'skip-nonexistent': True}, False),
+    (['A'], VAR_A_REF_A, {}, False),
+    (['A'], VAR_A_REF_A, {'skip-nonexistent': False}, False),
+    (['A'], VAR_A_REF_A, {'skip-nonexistent': True}, False),
+    (['A'], VAR_A_REF_B, {}, False),
+    (['A'], VAR_A_REF_B, {'skip-nonexistent': False}, False),
+    (['A'], VAR_A_REF_B, {'skip-nonexistent': True}, False),
+]
+
+
+@pytest.mark.parametrize('ancestors,var,cfg,out', TEST_ALLOW_SKIPPING)
+def test_allow_skipping(ancestors, var, cfg, out):
+    """Test ``_allow_skipping``."""
+    result = _allow_skipping(ancestors, var, cfg)
+    assert result is out


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

This PR fixes a bug that was introduced in #917 that prevented the usage of the ``--skip-nonexistent`` option. I also add a tiny test for it.

Note that I also adapted the preprocessors `concatenate` and `save` which gave ugly error messages when an empty cube was passed. This should never happen during a regular ESMValTool run, but could happen when these functions are used as part of the `esmvalcore` API. 

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1040, closes #988.

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
