### PR TITLE
Supported `mip`-level fixes

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2.py
@@ -266,7 +266,7 @@ class Omon(Fix):
             if cube.coords(axis='Z'):
                 z_coord = cube.coord(axis='Z')
 
-                # Only points need be fixed, not bounds
+                # Only points need to be fixed, not bounds
                 if z_coord.units == 'cm':
                     z_coord.points = z_coord.core_points() / 100.0
                     z_coord.units = 'm'

--- a/esmvalcore/cmor/_fixes/fix.py
+++ b/esmvalcore/cmor/_fixes/fix.py
@@ -162,7 +162,7 @@ class Fix:
 
             classes = inspect.getmembers(fixes_module, inspect.isclass)
             classes = dict((name.lower(), value) for name, value in classes)
-            for fix_name in (short_name, 'allvars'):
+            for fix_name in (short_name, mip.lower(), 'allvars'):
                 try:
                     fixes.append(classes[fix_name](vardef))
                 except KeyError:

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -519,11 +519,18 @@ def round_coordinates(cubes, decimals=5, coord_names=None):
     return cubes
 
 
-def set_ocean_depth_coord(cube):
-    """Fix attributes of ocean vertical level coordinate. """
-    cube.coord(axis='Z').standard_name = 'depth'
-    cube.coord('depth').var_name = 'lev'
-    cube.coord('depth').units = Unit('m')
-    cube.coord('depth').long_name = 'ocean depth coordinate'
-    cube.coord('depth').attributes = {'positive': 'down'}
-    return cube
+def fix_ocean_depth_coord(cube):
+    """Fix attributes of ocean vertical level coordinate.
+
+    Parameters
+    ----------
+    cube : iris.cube.Cube
+        Input cube.
+
+    """
+    depth_coord = cube.coord(axis='Z')
+    depth_coord.standard_name = 'depth'
+    depth_coord.var_name = 'lev'
+    depth_coord.units = 'm'
+    depth_coord.long_name = 'ocean depth coordinate'
+    depth_coord.attributes = {'positive': 'down'}

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -517,3 +517,13 @@ def round_coordinates(cubes, decimals=5, coord_names=None):
                 coord.bounds = da.round(da.asarray(coord.core_bounds()),
                                         decimals)
     return cubes
+
+
+def set_ocean_depth_coord(cube):
+    """Fix attributes of ocean vertical level coordinate. """
+    cube.coord(axis='Z').standard_name = 'depth'
+    cube.coord('depth').var_name = 'lev'
+    cube.coord('depth').units = Unit('m')
+    cube.coord('depth').long_name = 'ocean depth coordinate'
+    cube.coord('depth').attributes = {'positive': 'down'}
+    return cube

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from cf_units import Unit
 
-from esmvalcore.cmor._fixes.cmip6.cesm2 import Cl, Cli, Clw, Tas, Tos
+from esmvalcore.cmor._fixes.cmip6.cesm2 import Cl, Cli, Clw, Omon, Tas, Tos
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
@@ -225,6 +225,34 @@ def tos_cubes():
     return iris.cube.CubeList([tos_cube])
 
 
+@pytest.fixture
+def thetao_cubes():
+    """Cubes to test fixes for ``thetao``."""
+    time_coord = iris.coords.DimCoord(
+        [0.0004, 1.09776], var_name='time', standard_name='time',
+        units='days since 1850-01-01 00:00:00')
+    lat_coord = iris.coords.DimCoord(
+        [0.0, 1.0], var_name='lat', standard_name='latitude', units='degrees')
+    lon_coord = iris.coords.DimCoord(
+        [0.0, 1.0], var_name='lon', standard_name='longitude', units='degrees')
+    lev_coord = iris.coords.DimCoord(
+        [500.0, 1000.0], bounds=[[2.5, 7.5], [7.5, 12.5]],
+        var_name='lev', standard_name=None, units='cm',
+        attributes={'positive': 'up'})
+    coord_specs = [
+        (time_coord, 0),
+        (lev_coord, 1),
+        (lat_coord, 2),
+        (lon_coord, 3),
+    ]
+    thetao_cube = iris.cube.Cube(
+        np.ones((2, 2, 2, 2)),
+        var_name='thetao',
+        dim_coords_and_dims=coord_specs,
+    )
+    return iris.cube.CubeList([thetao_cube])
+
+
 def test_get_tas_fix():
     """Test getting of fix."""
     fix = Fix.get_fixes('CMIP6', 'CESM2', 'Amon', 'tas')
@@ -233,8 +261,14 @@ def test_get_tas_fix():
 
 def test_get_tos_fix():
     """Test getting of fix."""
-    fix = Fix.get_fixes('CMIP6', 'CESM2', 'Amon', 'tos')
-    assert fix == [Tos(None)]
+    fix = Fix.get_fixes('CMIP6', 'CESM2', 'Omon', 'tos')
+    assert fix == [Tos(None), Omon(None)]
+
+
+def test_get_thetao_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2', 'Omon', 'thetao')
+    assert fix == [Omon(None)]
 
 
 def test_tas_fix_metadata(tas_cubes):
@@ -271,3 +305,25 @@ def test_tos_fix_metadata(tos_cubes):
     assert out_cubes is tos_cubes
     for cube in out_cubes:
         np.testing.assert_equal(cube.coord("time").points, [0., 1.1])
+
+
+def test_thetao_fix_metadata(thetao_cubes):
+    """Test ``fix_metadata`` for ``thetao``."""
+    vardef = get_var_info('CMIP6', 'Omon', 'thetao')
+    fix = Omon(vardef)
+    out_cubes = fix.fix_metadata(thetao_cubes)
+    assert out_cubes is thetao_cubes
+    assert len(out_cubes) == 1
+    out_cube = out_cubes[0]
+
+    # Check metadata of depth coordinate
+    depth_coord = out_cube.coord('depth')
+    assert depth_coord.standard_name == 'depth'
+    assert depth_coord.var_name == 'lev'
+    assert depth_coord.long_name == 'ocean depth coordinate'
+    assert depth_coord.units == 'm'
+    assert depth_coord.attributes == {'positive': 'down'}
+
+    # Check values of depth coordinate
+    np.testing.assert_allclose(depth_coord.points, [5.0, 10.0])
+    np.testing.assert_allclose(depth_coord.bounds, [[2.5, 7.5], [7.5, 12.5]])

--- a/tests/integration/cmor/_fixes/test_fix.py
+++ b/tests/integration/cmor/_fixes/test_fix.py
@@ -1,3 +1,5 @@
+"""Integration tests for fixes."""
+
 import os
 import shutil
 import tempfile
@@ -6,35 +8,35 @@ import unittest
 import pytest
 from iris.cube import Cube
 
+from esmvalcore.cmor._fixes.cmip5.bnu_esm import Ch4
+from esmvalcore.cmor._fixes.cmip5.canesm2 import FgCo2
+from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Gpp
+from esmvalcore.cmor._fixes.cmip6.cesm2 import Omon, Tos
 from esmvalcore.cmor.fix import Fix
 
 
 class TestFix(unittest.TestCase):
     def setUp(self):
-        """Set up temp folder"""
+        """Set up temp folder."""
         self.temp_folder = tempfile.mkdtemp()
 
     def tearDown(self):
-        """Remove temp folder"""
+        """Remove temp folder."""
         shutil.rmtree(self.temp_folder)
 
     def test_get_fix(self):
-        from esmvalcore.cmor._fixes.cmip5.canesm2 import FgCo2
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'CanESM2', 'Amon', 'fgco2'), [FgCo2(None)])
 
     def test_get_fix_case_insensitive(self):
-        from esmvalcore.cmor._fixes.cmip5.canesm2 import FgCo2
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'CanESM2', 'Amon', 'fgCo2'), [FgCo2(None)])
 
     def test_get_fixes_with_replace(self):
-        from esmvalcore.cmor._fixes.cmip5.bnu_esm import Ch4
         self.assertListEqual(Fix.get_fixes('CMIP5', 'BNU-ESM', 'Amon', 'ch4'),
                              [Ch4(None)])
 
     def test_get_fixes_with_generic(self):
-        from esmvalcore.cmor._fixes.cmip5.cesm1_bgc import Gpp
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'CESM1-BGC', 'Amon', 'gpp'), [Gpp(None)])
 
@@ -49,6 +51,19 @@ class TestFix(unittest.TestCase):
     def test_get_fix_no_var(self):
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'BNU-ESM', 'Amon', 'BAD_VAR'), [])
+
+    def test_get_fix_only_mip(self):
+        self.assertListEqual(
+            Fix.get_fixes('CMIP6', 'CESM2', 'Omon', 'thetao'), [Omon(None)])
+
+    def test_get_fix_only_mip_case_insensitive(self):
+        self.assertListEqual(
+            Fix.get_fixes('CMIP6', 'CESM2', 'omOn', 'thetao'), [Omon(None)])
+
+    def test_get_fix_mip_and_var(self):
+        self.assertListEqual(
+            Fix.get_fixes('CMIP6', 'CESM2', 'Omon', 'tos'),
+            [Tos(None), Omon(None)])
 
     def test_fix_metadata(self):
         cube = Cube([0])

--- a/tests/integration/cmor/_fixes/test_shared.py
+++ b/tests/integration/cmor/_fixes/test_shared.py
@@ -15,6 +15,7 @@ from esmvalcore.cmor._fixes.shared import (
     add_sigma_factory,
     cube_to_aux_coord,
     fix_bounds,
+    fix_ocean_depth_coord,
     get_altitude_to_pressure_func,
     get_bounds_cube,
     get_pressure_to_altitude_func,
@@ -500,3 +501,18 @@ def test_round_coordinates_single_coord():
     assert cubes[0].coord('longitude') is out[0].coord('longitude')
     np.testing.assert_allclose(out[0].coord('latitude').points, [10])
     np.testing.assert_allclose(out[0].coord('latitude').bounds, [[9, 11]])
+
+
+def test_fix_ocean_depth_coord():
+    """Test `fix_ocean_depth_coord`."""
+    z_coord = iris.coords.DimCoord(0.0, var_name='alt',
+                                   attributes={'positive': 'up'})
+    cube = iris.cube.Cube([0.0], var_name='x',
+                          dim_coords_and_dims=[(z_coord, 0)])
+    fix_ocean_depth_coord(cube)
+    depth_coord = cube.coord('depth')
+    assert depth_coord.standard_name == 'depth'
+    assert depth_coord.var_name == 'lev'
+    assert depth_coord.units == 'm'
+    assert depth_coord.long_name == 'ocean depth coordinate'
+    assert depth_coord.attributes == {'positive': 'down'}


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

This PR adds the support for `mip`-level fixes, i.e. a fix for all variables of a MIP table for a single dataset. As test case, a fix for CESM2 is included, which supersedes #888.

@tomaslovato Can you briefly do a test if this works for CESM's `thetao` for the scientific review?
@jvegasbsc  Could you please do a brief technical review?

Thanks!!

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1094.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
