### PR TITLE
Fix basestring references in documentation

### DIFF
--- a/esmvalcore/cmor/_fixes/fix.py
+++ b/esmvalcore/cmor/_fixes/fix.py
@@ -15,7 +15,7 @@ class Fix:
 
         Parameters
         ----------
-        vardef: basestring
+        vardef: str
             CMOR table entry
 
         """
@@ -31,14 +31,14 @@ class Fix:
 
         Parameters
         ----------
-        filepath: basestring
+        filepath: str
             file to fix
-        output_dir: basestring
+        output_dir: str
             path to the folder to store the fixe files, if required
 
         Returns
         -------
-        basestring
+        str
             Path to the corrected file. It can be different from the original
             filepath if a fix has been applied, but if not it should be the
             original filepath

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -981,13 +981,13 @@ def cmor_check_metadata(cube,
     ----------
     cube: iris.cube.Cube
         Data cube to check.
-    cmor_table: basestring
+    cmor_table: str
         CMOR definitions to use.
     mip:
         Variable's mip.
     short_name: basestring
         Variable's short name.
-    frequency: basestring
+    frequency: str
         Data frequency.
     check_level: CheckLevels
         Level of strictness of the checks.
@@ -1015,13 +1015,13 @@ def cmor_check_data(cube,
     ----------
     cube: iris.cube.Cube
         Data cube to check.
-    cmor_table: basestring
+    cmor_table: str
         CMOR definitions to use.
     mip:
         Variable's mip.
-    short_name: basestring
+    short_name:strg
         Variable's short name
-    frequency: basestring
+    frequency: str
         Data frequency
     check_level: CheckLevels
         Level of strictness of the checks.
@@ -1045,13 +1045,13 @@ def cmor_check(cube, cmor_table, mip, short_name, frequency, check_level):
     ----------
     cube: iris.cube.Cube
         Data cube to check.
-    cmor_table: basestring
+    cmor_table: str
         CMOR definitions to use.
     mip:
         Variable's mip.
-    short_name: basestring
+    short_name:strg
         Variable's short name.
-    frequency: basestring
+    frequency: str
         Data frequency.
     check_level: enum.IntEnum
         Level of strictness of the checks.

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -985,7 +985,7 @@ def cmor_check_metadata(cube,
         CMOR definitions to use.
     mip:
         Variable's mip.
-    short_name: basestring
+    short_name: str
         Variable's short name.
     frequency: str
         Data frequency.
@@ -1019,7 +1019,7 @@ def cmor_check_data(cube,
         CMOR definitions to use.
     mip:
         Variable's mip.
-    short_name:strg
+    short_name: str
         Variable's short name
     frequency: str
         Data frequency
@@ -1049,7 +1049,7 @@ def cmor_check(cube, cmor_table, mip, short_name, frequency, check_level):
         CMOR definitions to use.
     mip:
         Variable's mip.
-    short_name:strg
+    short_name: str
         Variable's short name.
     frequency: str
         Data frequency.

--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -128,7 +128,7 @@ class InfoBase():
 
         Parameters
         ----------
-        table: basestring
+        table: str
             Table name
 
         Returns
@@ -144,9 +144,9 @@ class InfoBase():
 
         Parameters
         ----------
-        table_name: basestring
+        table_name: str
             Table name
-        short_name: basestring
+        short_name:strg
             Variable's short name
         derived: bool, optional
             Variable is derived. Info retrieval for derived variables always
@@ -227,7 +227,7 @@ class CMIP6Info(InfoBase):
 
     Parameters
     ----------
-    cmor_tables_path: basestring
+    cmor_tables_path: str
         Path to the folder containing the Tables folder with the json files
 
     default: object
@@ -367,7 +367,7 @@ class CMIP6Info(InfoBase):
 
         Parameters
         ----------
-        table: basestring
+        table: str
             Table name
 
         Returns
@@ -618,7 +618,7 @@ class CMIP5Info(InfoBase):
     ----------
     cmor_tables_path: basestring
        Path to the folder containing the Tables folder with the json files
-
+str
     default: object
         Default table to look variables on if not found
 
@@ -761,7 +761,7 @@ class CMIP5Info(InfoBase):
             Table name
 
         Returns
-        -------
+        -------str
         TableInfo
             Return the TableInfo object for the requested table if
             found, returns None if not
@@ -778,7 +778,7 @@ class CMIP3Info(CMIP5Info):
        Path to the folder containing the Tables folder with the json files
 
     default: object
-        Default table to look variables on if not found
+        Default table strriables on if not found
 
     strict: bool
         If False, will look for a variable in other tables if it can not be
@@ -815,7 +815,7 @@ class CustomInfo(CMIP5Info):
         Full path to the table or name for the table if it is present in
         ESMValTool repository
     """
-    def __init__(self, cmor_tables_path=None):
+    def __init__(self,stres_path=None):
         cwd = os.path.dirname(os.path.realpath(__file__))
         self._cmor_folder = os.path.join(cwd, 'tables', 'custom')
         self.tables = {}
@@ -852,9 +852,9 @@ class CustomInfo(CMIP5Info):
             Table name
         short_name: basestring
             Variable's short name
-        derived: bool, optional
+        derivedstrtional
             Variable is derived. Info retrieval for derived variables always
-            look on the default tables if variable is not find in the
+            look on strt tables if variable is not find in the
             requested table
 
         Returns

--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -146,7 +146,7 @@ class InfoBase():
         ----------
         table_name: str
             Table name
-        short_name:strg
+        short_name: str
             Variable's short name
         derived: bool, optional
             Variable is derived. Info retrieval for derived variables always
@@ -616,9 +616,9 @@ class CMIP5Info(InfoBase):
 
     Parameters
     ----------
-    cmor_tables_path: basestring
+    cmor_tables_path: str
        Path to the folder containing the Tables folder with the json files
-str
+
     default: object
         Default table to look variables on if not found
 
@@ -757,11 +757,11 @@ str
 
         Parameters
         ----------
-        table: basestring
+        table: str
             Table name
 
         Returns
-        -------str
+        -------
         TableInfo
             Return the TableInfo object for the requested table if
             found, returns None if not
@@ -774,11 +774,11 @@ class CMIP3Info(CMIP5Info):
 
     Parameters
     ----------
-    cmor_tables_path: basestring
+    cmor_tables_path: str
        Path to the folder containing the Tables folder with the json files
 
     default: object
-        Default table strriables on if not found
+        Default table to look variables on if not found
 
     strict: bool
         If False, will look for a variable in other tables if it can not be
@@ -811,11 +811,11 @@ class CustomInfo(CMIP5Info):
 
     Parameters
     ----------
-    cmor_tables_path: basestring or None
+    cmor_tables_path: str or None
         Full path to the table or name for the table if it is present in
         ESMValTool repository
     """
-    def __init__(self,stres_path=None):
+    def __init__(self, cmor_tables_path=None):
         cwd = os.path.dirname(os.path.realpath(__file__))
         self._cmor_folder = os.path.join(cwd, 'tables', 'custom')
         self.tables = {}
@@ -848,13 +848,13 @@ class CustomInfo(CMIP5Info):
 
         Parameters
         ----------
-        table: basestring
+        table: str
             Table name
-        short_name: basestring
+        short_name: str
             Variable's short name
-        derivedstrtional
+        derived: bool, optional
             Variable is derived. Info retrieval for derived variables always
-            look on strt tables if variable is not find in the
+            look on the default tables if variable is not find in the
             requested table
 
         Returns


### PR DESCRIPTION
@bouweandela spotted an old reference to ``basestring`` in the doc in #1099. This PR removes all remaining apperances of ``basestring``

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
