### PR TITLE
Run fgco2 fix for all CESM2 models

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_fv2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_fv2.py
@@ -1,6 +1,7 @@
 """Fixes for CESM2-FV2 model."""
 from .cesm2 import Cl as BaseCl
 from .cesm2 import Tas as BaseTas
+from .cesm2 import Fgco2 as BaseFgco2
 
 
 Cl = BaseCl
@@ -13,3 +14,6 @@ Clw = Cl
 
 
 Tas = BaseTas
+
+
+Fgco2 = BaseFgco2

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm.py
@@ -3,6 +3,7 @@ from netCDF4 import Dataset
 
 from .cesm2 import Cl as BaseCl
 from .cesm2 import Tas as BaseTas
+from .cesm2 import Fgco2 as BaseFgco2
 
 
 class Cl(BaseCl):
@@ -48,3 +49,6 @@ Clw = Cl
 
 
 Tas = BaseTas
+
+
+Fgco2 = BaseFgco2

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm_fv2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm_fv2.py
@@ -1,5 +1,6 @@
 """Fixes for CESM2-WACCM-FV2 model."""
 from .cesm2 import Tas as BaseTas
+from .cesm2 import Fgco2 as BaseFgco2
 from .cesm2_waccm import Cl as BaseCl
 from .cesm2_waccm import Cli as BaseCli
 from .cesm2_waccm import Clw as BaseClw
@@ -14,3 +15,6 @@ Clw = BaseClw
 
 
 Tas = BaseTas
+
+
+Fgco2 = BaseFgco2

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2_fv2.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2_fv2.py
@@ -1,7 +1,8 @@
 """Tests for the fixes of CESM2-FV2."""
 from esmvalcore.cmor._fixes.cmip6.cesm2 import Cl as BaseCl
+from esmvalcore.cmor._fixes.cmip6.cesm2 import Fgco2 as BaseFgco2
 from esmvalcore.cmor._fixes.cmip6.cesm2 import Tas as BaseTas
-from esmvalcore.cmor._fixes.cmip6.cesm2_fv2 import Cl, Cli, Clw, Tas
+from esmvalcore.cmor._fixes.cmip6.cesm2_fv2 import Cl, Cli, Clw, Fgco2, Tas
 from esmvalcore.cmor.fix import Fix
 
 
@@ -36,6 +37,17 @@ def test_get_clw_fix():
 def test_clw_fix():
     """Test fix for ``clw``."""
     assert Clw is BaseCl
+
+
+def test_get_fgco2_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-FV2', 'Omon', 'fgco2')
+    assert fix == [Fgco2(None)]
+
+
+def test_fgco2_fix():
+    """Test fix for ``fgco2``."""
+    assert Fgco2 is BaseFgco2
 
 
 def test_get_tas_fix():

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm.py
@@ -8,8 +8,9 @@ import numpy as np
 import pytest
 
 from esmvalcore.cmor._fixes.cmip6.cesm2 import Cl as BaseCl
+from esmvalcore.cmor._fixes.cmip6.cesm2 import Fgco2 as BaseFgco2
 from esmvalcore.cmor._fixes.cmip6.cesm2 import Tas as BaseTas
-from esmvalcore.cmor._fixes.cmip6.cesm2_waccm import Cl, Cli, Clw, Tas
+from esmvalcore.cmor._fixes.cmip6.cesm2_waccm import Cl, Cli, Clw, Fgco2, Tas
 from esmvalcore.cmor.fix import Fix
 
 
@@ -70,6 +71,17 @@ def test_get_clw_fix():
 def test_clw_fix():
     """Test fix for ``clw``."""
     assert Clw is Cl
+
+
+def test_get_fgco2_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-WACCM', 'Omon', 'fgco2')
+    assert fix == [Fgco2(None)]
+
+
+def test_fgco2_fix():
+    """Test fix for ``fgco2``."""
+    assert Fgco2 is BaseFgco2
 
 
 @pytest.fixture

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm_fv2.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm_fv2.py
@@ -1,7 +1,14 @@
 """Tests for the fixes of CESM2-WACCM-FV2."""
 from esmvalcore.cmor._fixes.cmip6.cesm2 import Tas as BaseTas
+from esmvalcore.cmor._fixes.cmip6.cesm2 import Fgco2 as BaseFgco2
 from esmvalcore.cmor._fixes.cmip6.cesm2_waccm import Cl as BaseCl
-from esmvalcore.cmor._fixes.cmip6.cesm2_waccm_fv2 import Cl, Cli, Clw, Tas
+from esmvalcore.cmor._fixes.cmip6.cesm2_waccm_fv2 import (
+    Cl,
+    Cli,
+    Clw,
+    Fgco2,
+    Tas,
+)
 from esmvalcore.cmor.fix import Fix
 
 
@@ -36,6 +43,17 @@ def test_get_clw_fix():
 def test_clw_fix():
     """Test fix for ``clw``."""
     assert Clw is BaseCl
+
+
+def test_get_fgco2_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'CESM2-WACCM-FV2', 'Omon', 'fgco2')
+    assert fix == [Fgco2(None)]
+
+
+def test_fgco2_fix():
+    """Test fix for ``fgco2``."""
+    assert Fgco2 is BaseFgco2
 
 
 def test_get_tas_fix():


### PR DESCRIPTION
## Description

Closes #1107. Adds 0m-depth coordinate for fgco2 in CESM2 models.

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
