### PR TITLE
Updated references master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ commands:
   check_changes:
     steps:
       - run: |
-          if (test "$CIRCLE_BRANCH" = master ||
-            git --no-pager diff --name-only origin/master... |
+          if (test "$CIRCLE_BRANCH" = main ||
+            git --no-pager diff --name-only origin/main... |
             grep -q -E -f .circleci/install_triggers)
           then
             echo Running installation tests
@@ -209,7 +209,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - test
       - install

--- a/.github/workflows/action-conda-publish.yml
+++ b/.github/workflows/action-conda-publish.yml
@@ -6,7 +6,7 @@ on:
   # use this to test before actual release and publish
   push:
     branches:
-      - master
+      - main
 
 jobs:
 

--- a/.github/workflows/action-install-from-conda.yml
+++ b/.github/workflows/action-install-from-conda.yml
@@ -13,19 +13,19 @@
 
 name: Conda Base Install
 
-# runs on a push on master and at the end of every day
+# runs on a push on maain and at the end of every day
 on:
   # triggering on push without branch name will run tests everytime
   # there is a push on any branch
   # turn it on only if needed
   push:
     branches:
-    - master
-  # run the test only if the PR is to master
+    - main
+  # run the test only if the PR is to maain
   # turn it on if required
   #pull_request:
   #  branches:
-  #  - master
+  #  - main
   schedule:
     - cron: '0 4 * * *'
 

--- a/.github/workflows/action-install-from-conda.yml
+++ b/.github/workflows/action-install-from-conda.yml
@@ -13,7 +13,7 @@
 
 name: Conda Base Install
 
-# runs on a push on maain and at the end of every day
+# runs on a push on main and at the end of every day
 on:
   # triggering on push without branch name will run tests everytime
   # there is a push on any branch

--- a/.github/workflows/action-install-from-pypi.yml
+++ b/.github/workflows/action-install-from-pypi.yml
@@ -13,21 +13,20 @@
 
 name: PyPi Install
 
-# runs on a push on master and at the end of every day
+# runs on a push on main and at the end of every day
 on:
   # triggering on push without branch name will run tests everytime
   # there is a push on any branch
   # turn it on only if needed
   push:
     branches:
-    - master
-    - github-actions2
+    - main
 
-  # run the test only if the PR is to master
+  # run the test only if the PR is to main
   # turn it on if required
   #pull_request:
   #  branches:
-  #  - master
+  #  - main
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/action-install-from-source.yml
+++ b/.github/workflows/action-install-from-source.yml
@@ -14,20 +14,20 @@
 
 name: Source Install
 
-# runs on a push on master and at the end of every day
+# runs on a push on main and at the end of every day
 on:
   # triggering on push without branch name will run tests everytime
   # there is a push on any branch
   # turn it on only if needed
   push:
     branches:
-    - master
+    - main
     - github-actions2
-  # run the test only if the PR is to master
+  # run the test only if the PR is to main
   # turn it on if required
   #pull_request:
   #  branches:
-  #  - master
+  #  - main
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/action-pypi-build-and-deploy.yml
+++ b/.github/workflows/action-pypi-build-and-deploy.yml
@@ -6,7 +6,7 @@ on:
   # use this for testing
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-n-publish:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -13,19 +13,19 @@
 
 name: Test
 
-# runs on a push on master and at the end of every day
+# runs on a push on main and at the end of every day
 on:
   # triggering on push without branch name will run tests everytime
   # there is a push on any branch
   # turn it on only if needed
   push:
     branches:
-    - master
-  # run the test only if the PR is to master
+    - main
+  # run the test only if the PR is to main
   # turn it on if required
   #pull_request:
   #  branches:
-  #  - master
+  #  - main
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/esmvaltool/badge/?version=latest)](https://esmvaltool.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3387139.svg)](https://doi.org/10.5281/zenodo.3387139)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ESMValGroup?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![CircleCI](https://circleci.com/gh/ESMValGroup/ESMValCore/tree/master.svg?style=svg)](https://circleci.com/gh/ESMValGroup/ESMValCore/tree/master)
+[![CircleCI](https://circleci.com/gh/ESMValGroup/ESMValCore/tree/main.svg?style=svg)](https://circleci.com/gh/ESMValGroup/ESMValCore/tree/main)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/5d496dea9ef64ec68e448a6df5a65783)](https://www.codacy.com/gh/ESMValGroup/ESMValCore?utm_source=github.com&utm_medium=referral&utm_content=ESMValGroup/ESMValCore&utm_campaign=Badge_Coverage)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/5d496dea9ef64ec68e448a6df5a65783)](https://www.codacy.com/gh/ESMValGroup/ESMValCore?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ESMValGroup/ESMValCore&amp;utm_campaign=Badge_Grade)
 [![Docker Build Status](https://img.shields.io/docker/cloud/build/esmvalgroup/esmvalcore)](https://hub.docker.com/r/esmvalgroup/esmvalcore/)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,7 +41,7 @@ Documentation
 
 -  Fix numbering of steps in release instructions (`#838 <https://github.com/ESMValGroup/ESMValCore/pull/838>`__) `Bouwe Andela <https://github.com/bouweandela>`__
 -  Add labels to changelogs of individual versions for easy reference (`#899 <https://github.com/ESMValGroup/ESMValCore/pull/899>`__) `Klaus Zimmermann <https://github.com/zklaus>`__
--  Make CircleCI badge specific to master branch (`#902 <https://github.com/ESMValGroup/ESMValCore/pull/902>`__) `Bouwe Andela <https://github.com/bouweandela>`__
+-  Make CircleCI badge specific to main branch (`#902 <https://github.com/ESMValGroup/ESMValCore/pull/902>`__) `Bouwe Andela <https://github.com/bouweandela>`__
 -  Fix docker build badge url (`#906 <https://github.com/ESMValGroup/ESMValCore/pull/906>`__) `Stef Smeets <https://github.com/stefsmeets>`__
 -  Update github PR template (`#909 <https://github.com/ESMValGroup/ESMValCore/pull/909>`__) `Stef Smeets <https://github.com/stefsmeets>`__
 -  Refer to ESMValTool GitHub discussions page in the error message (`#900 <https://github.com/ESMValGroup/ESMValCore/pull/900>`__) `Bouwe Andela <https://github.com/bouweandela>`__

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -28,7 +28,7 @@ installation.
 New development should preferably be done in the
 `ESMValCore <https://github.com/ESMValGroup/ESMValCore>`__
 GitHub repository.
-The default git branch is ``master``.
+The default git branch is ``main``.
 Use this branch to create a new feature branch from and make a pull request
 against.
 This
@@ -74,7 +74,7 @@ Please keep the following considerations in mind when programming:
   are easy to understand and implement for scientific contributors.
 - No additional CMOR checks should be implemented inside preprocessor functions.
   The input cube is fixed and confirmed to follow the specification in
-  `esmvalcore/cmor/tables <https://github.com/ESMValGroup/ESMValCore/tree/master/esmvalcore/cmor/tables>`__
+  `esmvalcore/cmor/tables <https://github.com/ESMValGroup/ESMValCore/tree/main/esmvalcore/cmor/tables>`__
   before applying any other preprocessor functions.
   This design helps to keep the preprocessor functions and diagnostics scripts
   that use the preprocessed data from the tool simple and reliable.
@@ -288,9 +288,9 @@ The documentation is built by readthedocs_ using `Sphinx <https://www.sphinx-doc
 There are two main ways of adding documentation:
 
 #. As written text in the directory
-   `doc <https://github.com/ESMValGroup/ESMValCore/tree/master/doc/>`__.
+   `doc <https://github.com/ESMValGroup/ESMValCore/tree/main/doc/>`__.
    When writing
-   `reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+   `reStructuredText <https://www.sphinx-doc.org/en/main/usage/restructuredtext/basics.html>`_
    (``.rst``) files, please try to limit the line length to 80 characters and
    always start a sentence on a new line.
    This makes it easier to review changes to documentation on GitHub.
@@ -300,7 +300,7 @@ There are two main ways of adding documentation:
    `docstrings <https://www.python.org/dev/peps/pep-0257/>`__
    of Python modules, classes, and functions
    that are mentioned in
-   `doc/api <https://github.com/ESMValGroup/ESMValCore/tree/master/doc/api>`__
+   `doc/api <https://github.com/ESMValGroup/ESMValCore/tree/main/doc/api>`__
    are used to generate the online documentation.
    This results in the :ref:`api`.
    The standard document with best practices on writing docstrings is
@@ -380,7 +380,7 @@ CircleCI_ will build the documentation with the command:
 This will catch mistakes that can be detected automatically.
 
 The configuration file for Sphinx_ is
-`doc/shinx/source/conf.py <https://github.com/ESMValGroup/ESMValTool/blob/master/doc/sphinx/source/conf.py>`_.
+`doc/shinx/source/conf.py <https://github.com/ESMValGroup/ESMValTool/blob/main/doc/sphinx/source/conf.py>`_.
 
 See :ref:`esmvaltool:esmvalcore-documentation-integration` for information on
 how the ESMValCore documentation is integrated into the complete ESMValTool
@@ -395,7 +395,7 @@ Tests
 -----
 
 To check that the code works correctly, there tests available in the
-`tests directory <https://github.com/ESMValGroup/ESMValCore/tree/master/tests>`_.
+`tests directory <https://github.com/ESMValGroup/ESMValCore/tree/main/tests>`_.
 We use `pytest <https://docs.pytest.org>`_ to write and run our tests.
 
 Contributions to ESMValCore should be covered by unit tests.
@@ -439,7 +439,7 @@ Sample data
 New or modified preprocessor functions should preferably also be tested using
 the sample data.
 These tests are located in
-`tests/sample_data <https://github.com/ESMValGroup/ESMValCore/tree/master/tests/sample_data>`__.
+`tests/sample_data <https://github.com/ESMValGroup/ESMValCore/tree/main/tests/sample_data>`__.
 Please mark new tests that use the sample data with the
 `decorator <https://docs.python.org/3/glossary.html#term-decorator>`__
 ``@pytest.mark.use_sample_data``.
@@ -481,16 +481,16 @@ These nightly tests have been designed to follow the installation procedures
 described in the documentation, e.g. in the :ref:`install` chapter.
 The nightly tests are run using both CircleCI and GitHub Actions.
 The result of the tests ran by CircleCI can be seen on the
-`CircleCI project page <https://app.circleci.com/pipelines/github/ESMValGroup/ESMValCore?branch=master>`__
+`CircleCI project page <https://app.circleci.com/pipelines/github/ESMValGroup/ESMValCore?branch=main>`__
 and the result of the tests ran by GitHub Actions can be viewed on the
 `Actions tab <https://github.com/ESMValGroup/ESMValCore/actions>`__
 of the repository.
 
 The configuration of the tests run by CircleCI can be found in the directory
-`.circleci <https://github.com/ESMValGroup/ESMValCore/blob/master/.circleci>`__,
+`.circleci <https://github.com/ESMValGroup/ESMValCore/blob/main/.circleci>`__,
 while the configuration of the tests run by GitHub Actions can be found in the
 directory
-`.github/workflows <https://github.com/ESMValGroup/ESMValCore/blob/master/.github/workflows>`__.
+`.github/workflows <https://github.com/ESMValGroup/ESMValCore/blob/main/.github/workflows>`__.
 
 .. _backward_compatibility:
 
@@ -549,7 +549,7 @@ Before considering adding a new dependency, carefully check that the
 of the dependency you want to add and any of its dependencies are
 `compatible <https://the-turing-way.netlify.app/reproducible-research/licensing/licensing-compatibility.html>`__
 with the
-`Apache 2.0 <https://github.com/ESMValGroup/ESMValCore/blob/master/LICENSE/>`_
+`Apache 2.0 <https://github.com/ESMValGroup/ESMValCore/blob/main/LICENSE/>`_
 license that applies to the ESMValCore.
 Note that GPL version 2 license is considered incompatible with the Apache 2.0
 license, while the compatibility of GPL version 3 license with the Apache 2.0
@@ -625,7 +625,7 @@ You can attract the attention of the `@ESMValGroup/esmvaltool-coreteam`_ by
 mentioning them in the issue if it looks like no-one is working on solving the
 problem yet.
 The issue needs to be fixed in a separate pull request first.
-After that has been merged into the ``master`` branch and all checks on this
+After that has been merged into the ``main`` branch and all checks on this
 branch are green again, merge it into your own branch to get the tests to pass.
 
 When reviewing a pull request, always make sure that all checks were successful.
@@ -652,14 +652,14 @@ To make a new release of the package, follow these steps:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Check the ``nightly``
-`build on CircleCI <https://circleci.com/gh/ESMValGroup/ESMValCore/tree/master>`__
+`build on CircleCI <https://circleci.com/gh/ESMValGroup/ESMValCore/tree/main>`__
 and the
 `GitHub Actions run <https://github.com/ESMValGroup/ESMValCore/actions>`__.
 All tests should pass before making a release (branch).
 
 2. Create a release branch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-Create a branch off the ``master`` branch and push it to GitHub.
+Create a branch off the ``main`` branch and push it to GitHub.
 Ask someone with administrative permissions to set up branch protection rules
 for it so only you and the person helping you with the release can push to it.
 Announce the name of the branch in an issue and ask the members of the
@@ -673,7 +673,7 @@ The version number is stored in ``esmvalcore/_version.py``,
 ``package/meta.yaml``, ``CITATION.cff``. Make sure to update all files.
 Also update the release date in ``CITATION.cff``.
 See https://semver.org for more information on choosing a version number.
-Make a pull request and get it merged into ``master`` and cherry pick it into
+Make a pull request and get it merged into ``main`` and cherry pick it into
 the release branch.
 
 4. Add release notes
@@ -686,18 +686,18 @@ previous release.
 Review the results, and if anything needs changing, change it on GitHub and
 re-run the script until the changelog looks acceptable.
 Copy the result to the file ``doc/changelog.rst``.
-Make a pull request and get it merged into ``master`` and cherry pick it into
+Make a pull request and get it merged into ``main`` and cherry pick it into
 the release branch..
 
 5. Cherry pick bugfixes into the release branch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If a bug is found and fixed (i.e. pull request merged into the
-``master`` branch) during the period of testing, use the command
+``main`` branch) during the period of testing, use the command
 ``git cherry-pick`` to include the commit for this bugfix into
 the release branch.
 When the testing period is over, make a pull request to update
 the release notes with the latest changes, get it merged into
-``master`` and cherry-pick it into the release branch.
+``main`` and cherry-pick it into the release branch.
 
 6. Make the release on GitHub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -706,7 +706,7 @@ Do a final check that all tests on CircleCI and GitHub Actions completed
 successfully.
 Then click the
 `releases tab <https://github.com/ESMValGroup/ESMValCore/releases>`__
-and create the new release from the release branch (i.e. not from ``master``).
+and create the new release from the release branch (i.e. not from ``main``).
 
 7. Create and upload the Conda package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/develop/derivation.rst
+++ b/doc/develop/derivation.rst
@@ -8,7 +8,7 @@ The variable derivation preprocessor module allows to derive variables which are
 not in the CMIP standard data request using standard variables as input.
 This is a special type of :ref:`preprocessor function <preprocessor_function>`.
 All derivation scripts are located in
-`esmvalcore/preprocessor/_derive/ <https://github.com/ESMValGroup/ESMValCore/tree/master/esmvalcore/preprocessor/_derive>`_.
+`esmvalcore/preprocessor/_derive/ <https://github.com/ESMValGroup/ESMValCore/tree/main/esmvalcore/preprocessor/_derive>`_.
 A typical example looks like this:
 
 .. code-block:: py

--- a/doc/develop/preprocessor_function.rst
+++ b/doc/develop/preprocessor_function.rst
@@ -6,7 +6,7 @@ Preprocessor function
 Preprocessor functions are located in :py:mod:`esmvalcore.preprocessor`.
 To add a new preprocessor function, start by finding a likely looking file to
 add your function to in
-`esmvalcore/preprocessor <https://github.com/ESMValGroup/ESMValCore/tree/master/esmvalcore/preprocessor>`_.
+`esmvalcore/preprocessor <https://github.com/ESMValGroup/ESMValCore/tree/main/esmvalcore/preprocessor>`_.
 Create a new file in that directory if you cannot find a suitable place.
 
 The function should look like this:
@@ -51,7 +51,7 @@ The function should look like this:
 
 
 The above function needs to be imported in the file
-`esmvalcore/preprocessor/__init__.py <https://github.com/ESMValGroup/ESMValCore/tree/master/esmvalcore/preprocessor/__init__.py>`__:
+`esmvalcore/preprocessor/__init__.py <https://github.com/ESMValGroup/ESMValCore/tree/main/esmvalcore/preprocessor/__init__.py>`__:
 
 .. code-block:: python
 
@@ -110,7 +110,7 @@ The documentation in the function docstring will be shown in
 the :ref:`preprocessor_functions` chapter.
 In addition, you should add documentation on how to use the new preprocessor
 function from the recipe in
-`doc/recipe/preprocessor.rst <https://github.com/ESMValGroup/ESMValCore/tree/master/doc/recipe/preprocessor.rst>`__
+`doc/recipe/preprocessor.rst <https://github.com/ESMValGroup/ESMValCore/tree/main/doc/recipe/preprocessor.rst>`__
 so it is shown in the :ref:`preprocessor` chapter.
 See the introduction to :ref:`documentation` for more information on how to
 best write documentation.

--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -174,7 +174,7 @@ Most users and diagnostic developers will not need to change this file,
 but it may be useful to understand its content.
 It will be installed along with ESMValCore and can also be viewed on GitHub:
 `esmvalcore/config-developer.yml
-<https://github.com/ESMValGroup/ESMValCore/blob/master/esmvalcore/config-developer.yml>`_.
+<https://github.com/ESMValGroup/ESMValCore/blob/main/esmvalcore/config-developer.yml>`_.
 This configuration file describes the file system structure and CMOR tables for several
 key projects (CMIP6, CMIP5, obs4mips, OBS6, OBS) on several key machines (e.g. BADC, CP4CDS, DKRZ,
 ETHZ, SMHI, BSC). CMIP data is stored as part of the Earth System Grid
@@ -270,7 +270,7 @@ Project CMOR table configuration
 --------------------------------
 
 ESMValCore comes bundled with several CMOR tables, which are stored in the directory
-`esmvalcore/cmor/tables <https://github.com/ESMValGroup/ESMValCore/tree/master/esmvalcore/cmor/tables>`_.
+`esmvalcore/cmor/tables <https://github.com/ESMValGroup/ESMValCore/tree/main/esmvalcore/cmor/tables>`_.
 These are copies of the tables available from `PCMDI <https://github.com/PCMDI>`_.
 
 For every ``project`` that can be used in the recipe, there are four settings
@@ -294,7 +294,7 @@ related to CMOR table settings available:
 References configuration file
 =============================
 
-The `esmvaltool/config-references.yml <https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/config-references.yml>`__ file contains the list of ESMValTool diagnostic and recipe authors,
+The `esmvaltool/config-references.yml <https://github.com/ESMValGroup/ESMValTool/blob/main/esmvaltool/config-references.yml>`__ file contains the list of ESMValTool diagnostic and recipe authors,
 references and projects. Each author, project and reference referred to in the
 documentation section of a recipe needs to be in this file in the relevant
 section.

--- a/doc/quickstart/install.rst
+++ b/doc/quickstart/install.rst
@@ -45,11 +45,11 @@ By far the easiest way to install these dependencies is to use conda_.
 For a minimal conda installation (recommended) go to https://conda.io/miniconda.html.
 
 After installing Conda, download
-`the file with the list of dependencies <https://raw.githubusercontent.com/ESMValGroup/ESMValCore/master/environment.yml>`_:
+`the file with the list of dependencies <https://raw.githubusercontent.com/ESMValGroup/ESMValCore/main/environment.yml>`_:
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/ESMValGroup/ESMValCore/master/environment.yml
+    wget https://raw.githubusercontent.com/ESMValGroup/ESMValCore/main/environment.yml
 
 and install these dependencies into a new conda environment with the command
 
@@ -84,7 +84,7 @@ You can get the latest release with
 
    docker pull esmvalgroup/esmvalcore:stable
 
-If you want to use the current master branch, use
+If you want to use the current main branch, use
 
 .. code-block:: bash
 

--- a/doc/recipe/overview.rst
+++ b/doc/recipe/overview.rst
@@ -60,7 +60,7 @@ the following:
 
    Note that all authors, projects, and references mentioned in the description
    section of the recipe need to be included in the (locally installed copy of the) file
-   `esmvaltool/config-references.yml <https://github.com/ESMValGroup/ESMValTool/blob/master/esmvaltool/config-references.yml>`_,
+   `esmvaltool/config-references.yml <https://github.com/ESMValGroup/ESMValTool/blob/main/esmvaltool/config-references.yml>`_,
    see :ref:`config-ref`.
    The author name uses the format: ``surname_name``. For instance, John
    Doe would be: ``doe_john``. This information can be omitted by new users


### PR DESCRIPTION
This PR updates all references to "master" e.g. in the documentation and readme files (master branch) to "main" (the new GitHub standard, see https://github.com/github/renaming). See also corresponding PR in ESMValTool: https://github.com/ESMValGroup/ESMValTool/pull/2172.

Closes https://github.com/ESMValGroup/ESMValCore/issues/1031

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful