### PR TITLE
Update CORDEX CMOR tables with valid_max and valid_min

### DIFF
--- a/esmvalcore/cmor/tables/cordex/Tables/CORDEX_3h
+++ b/esmvalcore/cmor/tables/cordex/Tables/CORDEX_3h
@@ -46,6 +46,8 @@ out_name:         lon
 stored_direction: increasing
 type:             double
 must_have_bounds: yes
+valid_max:        360.0
+valid_min:        0.0
 !----------------------------------
 !
 

--- a/esmvalcore/cmor/tables/cordex/Tables/CORDEX_6h
+++ b/esmvalcore/cmor/tables/cordex/Tables/CORDEX_6h
@@ -45,6 +45,8 @@ out_name:         lon
 stored_direction: increasing
 type:             double
 must_have_bounds: yes
+valid_max:        360.0
+valid_min:        0.0
 !----------------------------------
 !
 

--- a/esmvalcore/cmor/tables/cordex/Tables/CORDEX_day
+++ b/esmvalcore/cmor/tables/cordex/Tables/CORDEX_day
@@ -45,6 +45,8 @@ out_name:         lon
 stored_direction: increasing
 type:             double
 must_have_bounds: yes
+valid_max:        360.0
+valid_min:        0.0
 !----------------------------------
 !
 

--- a/esmvalcore/cmor/tables/cordex/Tables/CORDEX_fx
+++ b/esmvalcore/cmor/tables/cordex/Tables/CORDEX_fx
@@ -46,6 +46,8 @@ out_name:         lon
 stored_direction: increasing
 type:             double
 must_have_bounds: yes
+valid_max:        360.0
+valid_min:        0.0
 !----------------------------------
 !
 

--- a/esmvalcore/cmor/tables/cordex/Tables/CORDEX_grids
+++ b/esmvalcore/cmor/tables/cordex/Tables/CORDEX_grids
@@ -223,6 +223,8 @@ dimensions:	  longitude latitude
 ! Additional axis information:
 !----------------------------------	
 out_name:         lon
+valid_max:        360.0
+valid_min:        0.0
 !----------------------------------	
 !
 !

--- a/esmvalcore/cmor/tables/cordex/Tables/CORDEX_mon
+++ b/esmvalcore/cmor/tables/cordex/Tables/CORDEX_mon
@@ -45,6 +45,8 @@ out_name:         lon
 stored_direction: increasing
 type:             double
 must_have_bounds: yes
+valid_max:        360.0
+valid_min:        0.0
 !----------------------------------
 !
 

--- a/esmvalcore/cmor/tables/cordex/Tables/CORDEX_sem
+++ b/esmvalcore/cmor/tables/cordex/Tables/CORDEX_sem
@@ -45,6 +45,8 @@ out_name:         lon
 stored_direction: increasing
 type:             double
 must_have_bounds: yes
+valid_max:        360.0
+valid_min:        0.0
 !----------------------------------
 !
 

--- a/esmvalcore/cmor/tables/cordex/VERSION
+++ b/esmvalcore/cmor/tables/cordex/VERSION
@@ -1,1 +1,3 @@
 commit f6df61362c7fb6745679043f47e10cd932b5b279
+
+Modified to add valid_min and valid_max values to the longitude coordinate


### PR DESCRIPTION
Closes #1141

Add `valid_max` and `valid_min` attributes to longitude entries in CORDEX CMOR tables so that longitude coords are processed correctly by CMOR checker.

One aside, the entries in `CORDEX_grids` had no effect, it was the entries in `CORDEX_mon` that the checker picked up. I'm not sure if this is intended but it was not what I expected.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
