### PR TITLE
Kludge fix of fx recipe test; not needed but uncovering possible bug

### DIFF
--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -2168,7 +2168,7 @@ def test_fx_list_mip_change_cmip6(tmp_path, patched_datafinder, config_user):
     assert '_Ofx_' in fx_variables['areacello']['filename']
     assert '_Efx_' in fx_variables['clayfrac']['filename']
     assert '_fx_' in fx_variables['sftlf']['filename']
-    assert '_fx_' in fx_variables['sftgif']['filename']
+    assert '_IyrAnt_' in fx_variables['sftgif']['filename'][0]
     assert '_Ofx_' in fx_variables['sftof']['filename']
 
     # Check mask_landsea


### PR DESCRIPTION
**DO NOT MERGE - this is a hidden bug uncovered by test**

Offending test: `tests/integration/test_recipe.py` l.2171

Can our fx variables experts @sloosvel or @schlunma please tell me why we need this "fix" (tests fail both locally and on [GA tests](https://github.com/ESMValGroup/ESMValCore/actions/runs/880551785) ) - this should not be needed because of two things:

- temporary data files get written for the fx mip as well:
```
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_fx_CanESM5_historical_r1i1p1f1_gn_1990_1999.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_fx_CanESM5_historical_r1i1p1f1_gn_2000_2009.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_fx_CanESM5_historical_r1i1p1f1_gn_2010_2019.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_IyrAnt_CanESM5_historical_r1i1p1f1_gn_1990_1999.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_IyrAnt_CanESM5_historical_r1i1p1f1_gn_2000_2009.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_IyrAnt_CanESM5_historical_r1i1p1f1_gn_2010_2019.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_IyrGre_CanESM5_historical_r1i1p1f1_gn_1990_1999.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_IyrGre_CanESM5_historical_r1i1p1f1_gn_2000_2009.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_IyrGre_CanESM5_historical_r1i1p1f1_gn_2010_2019.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_LImon_CanESM5_historical_r1i1p1f1_gn_1990_1999.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_LImon_CanESM5_historical_r1i1p1f1_gn_2000_2009.nc
-rw-rw-r-- 1 valeriu valeriu 6144 May 27 14:23 sftgif_LImon_CanESM5_historical_r1i1p1f1_gn_2010_2019.nc
```
- the returned object should not be a list but a file name (string)

When you have figured it out could you please close this PR (I am more than sure this "fix" is not needed) and open a new one with the fix plss :beer: 