### PR TITLE
Crop on the ID-selected region(s) and not on the whole shapefile

### DIFF
--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -451,10 +451,10 @@ def _get_bounds(geometries, ids=None):
     ]
     all_points = np.vstack(all_points)
 
-    lat_max, lon_max = all_points.max(axis=0)
-    lat_min, lon_min = all_points.min(axis=0)
+    lon_max, lat_max = all_points.max(axis=0)
+    lon_min, lat_min = all_points.min(axis=0)
 
-    return lat_min, lon_min, lat_max, lon_max
+    return lon_min, lat_min, lon_max, lat_max
 
 
 def _get_shape(lon, lat, method, item):

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -416,7 +416,6 @@ def _geometry_matches_ids(geometry: dict, ids: list):
 
     geom_id = [props.get(key, None) for key in SHAPE_ID_KEYS]
     geom_id = [key for key in geom_id if key is not None]
-    geom_id = list(geom_id)
 
     if not geom_id:
         raise KeyError(f'{props} dict has no `name` or `id` key')

--- a/tests/unit/preprocessor/_area/test_area.py
+++ b/tests/unit/preprocessor/_area/test_area.py
@@ -755,30 +755,34 @@ def test_extract_specific_shape(make_testcube, tmp_path, ids):
     polyg = []
     for n in range(nshape):
         polyg.append(
-            Polygon([(1.0 + n, 1.0 + slat), (1.0 + n, 1.0),
-                     (1.0 + n + slon, 1.0), (1.0 + n + slon, 1.0 + slat)]))
+            Polygon([
+                (1.0 + n, 1.0 + slat),
+                (1.0 + n, 1.0),
+                (1.0 + n + slon, 1.0),
+                (1.0 + n + slon, 1.0 + slat),
+            ])
+        )
     write_shapefile(polyg, tmp_path / 'test_shape.shp')
-
-    # Make corresponding expected masked array
-    (slat, slon) = np.ceil([slat, slon]).astype(int)
-    vals = np.ones((nshape, min(slat + 2, 5), min(slon + 1 + nshape, 5)))
-    mask = vals.copy()
-    for n in ids:
-        mask[n, 1:1 + slat, 1 + n:1 + n + slon] = 0
-    expected = np.ma.masked_array(vals, mask)
-
-    # this detour is necessary, otherwise the data will not agree
-    data = expected.data.max(axis=0)
-    mask = expected.max(axis=0).mask
-    expected = np.ma.masked_array(data=data, mask=mask)
 
     result = extract_shape(make_testcube,
                            tmp_path / 'test_shape.shp',
                            crop=True,
                            decomposed=False,
                            ids=ids)
-    np.testing.assert_array_equal(result.data.data, expected.data)
-    np.testing.assert_array_equal(result.data.mask, expected.mask)
+
+    expected_bounds = np.vstack([polyg[i].bounds for i in ids])
+
+    lon_min = expected_bounds[:, 0]
+    lat_min = expected_bounds[:, 1]
+    lon_max = expected_bounds[:, 2]
+    lat_max = expected_bounds[:, 3]
+
+    # results from `extract_shape` are padded with masked values
+    lats = result.coord('latitude')[1:-1]
+    lons = result.coord('longitude')[1:-1]
+
+    assert np.all((lats.points >= lat_min) & (lats.points <= lat_max))
+    assert np.all((lons.points >= lon_min) & (lons.points <= lon_max))
 
 
 def test_extract_specific_shape_raises_if_not_present(make_testcube, tmp_path):


### PR DESCRIPTION
## Description

Hi all! This PR fixes a bug where the the `extract_shape` preprocessor crops on the whole shapefile when a subset of ids is specified. For example, if the whole shapefile covers regions all over the world, let's say A, B and C, but you are only interested in A. `extract_region` currently will return a cube with coordinates defined by a bounding box fitting A, B and C, masking everything 
outside of A. This can result in unexpectedly large cubes.

This PR crops on the selected regions, so the bounding box will fit _just_ A. This works for multiple regions, e.g. if A and B are specified, the bounding box will fit A and B (but not C).

This only applies if the `ids` keyword is specified. If `ids` is not specified (`None`), there is no change in behaviour.

Closes #1072 

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
