### PR TITLE
Project's attribute 'output_file' can be a dict

### DIFF
--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -269,19 +269,18 @@ with varied set of dataset attributes, such as the native6 project :
 
 .. code-block:: yaml
 
-native6:
-  cmor_strict: false
-  input_dir:
-    default: 'Tier{tier}/{dataset}/{latestversion}/{frequency}/{short_name}'
-    IPSL: '{account}/{model}/{status}/{exp}/{simulation}/{igcm_dir}/Analyse/{freq}'
-  input_file:
-    default: '*.nc'
-    IPSL:'{simulation}_*_{ipsl_varname}.nc'
-  output_file:
-    default: '{project}_{dataset}_{type}_{version}_{mip}_{short_name}'
-    IPSL: '{account}_{model}_{status}_{exp}_{simulation}_{short_name}'
-  cmor_type: 'CMIP6'
-  cmor_default_table_prefix: 'CMIP6_'
+  native6:
+    ...
+    input_dir:
+      default: 'Tier{tier}/{dataset}/{latestversion}/{frequency}/{short_name}'
+      IPSL: '{account}/{model}/{status}/{exp}/{simulation}/{igcm_dir}/Analyse/{freq}'
+    input_file:
+      default: '*.nc'
+      IPSL:'{simulation}_*_{ipsl_varname}.nc'
+    output_file:
+      default: '{project}_{dataset}_{type}_{version}_{mip}_{short_name}'
+      IPSL: '{account}_{model}_{status}_{exp}_{simulation}_{short_name}'
+    ...
 
 		
 Note that the extension ``.nc`` (and if applicable, a start and end

--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -260,9 +260,32 @@ your data please see :ref:`CMOR-DRS`.
 Preprocessor output files
 -------------------------
 
-The filename to use for preprocessed data is configured in a similar manner
-using ``output_file``. Note that the extension ``.nc`` (and if applicable,
-a start and end time) will automatically be appended to the filename.
+The filename to use for preprocessed data is configured in a similar
+manner using ``output_file``, which can be either a single value or a
+dictionnary of values.
+
+This latter case is useful for projects which gather much varied cases
+with varied set of dataset attributes, such as the native6 project :
+
+.. code-block:: yaml
+
+native6:
+  cmor_strict: false
+  input_dir:
+    default: 'Tier{tier}/{dataset}/{latestversion}/{frequency}/{short_name}'
+    IPSL: '{account}/{model}/{status}/{exp}/{simulation}/{igcm_dir}/Analyse/{freq}'
+  input_file:
+    default: '*.nc'
+    IPSL:'{simulation}_*_{ipsl_varname}.nc'
+  output_file:
+    default: '{project}_{dataset}_{type}_{version}_{mip}_{short_name}'
+    IPSL: '{account}_{model}_{status}_{exp}_{simulation}_{short_name}'
+  cmor_type: 'CMIP6'
+  cmor_default_table_prefix: 'CMIP6_'
+
+		
+Note that the extension ``.nc`` (and if applicable, a start and end
+time) will automatically be appended to the filename.
 
 .. _cmor_table_configuration:
 

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -260,7 +260,7 @@ def get_input_filelist(variable, rootpath, drs):
     return (files, dirnames, filenames)
 
 
-def get_output_file(variable, preproc_dir):
+def get_output_file(variable, preproc_dir, drs):
     """Return the full path to the output (preprocessed) file."""
     cfg = get_project_config(variable['project'])
 
@@ -269,11 +269,18 @@ def get_output_file(variable, preproc_dir):
         variable = dict(variable)
         variable['exp'] = '-'.join(variable['exp'])
 
+    output_file = cfg['output_file']
+    if type(output_file) is dict :
+        project = variable['project']
+        output_file = output_file.get(drs.get(project,'default'))
+        if output_file is None :
+            logger.error("No valid output_file pattern for {} in project {}"
+                         .format(drs.get(project,'default'),project))
     outfile = os.path.join(
         preproc_dir,
         variable['diagnostic'],
         variable['variable_group'],
-        _replace_tags(cfg['output_file'], variable)[0],
+        _replace_tags(output_file, variable)[0],
     )
     if variable['frequency'] != 'fx':
         outfile += '_{start_year}-{end_year}'.format(**variable)

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -270,11 +270,11 @@ def get_output_file(variable, preproc_dir, drs):
         variable['exp'] = '-'.join(variable['exp'])
 
     output_file = cfg['output_file']
-    if isinstance(output_file,dict):
+    if isinstance(output_file, dict):
         project = variable['project']
         output_file = output_file.get(drs.get(project, 'default'))
         if output_file is None:
-            logger.error("No valid output_file pattern for %s in project %s"
+            logger.error("No valid output_file pattern for %s in project %s",
                          drs.get(project, 'default'), project)
     outfile = os.path.join(
         preproc_dir,

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -262,20 +262,12 @@ def get_input_filelist(variable, rootpath, drs):
 
 def get_output_file(variable, preproc_dir, drs):
     """Return the full path to the output (preprocessed) file."""
-    cfg = get_project_config(variable['project'])
-
     # Join different experiment names
     if isinstance(variable.get('exp'), (list, tuple)):
         variable = dict(variable)
         variable['exp'] = '-'.join(variable['exp'])
 
-    output_file = cfg['output_file']
-    if isinstance(output_file, dict):
-        project = variable['project']
-        output_file = output_file.get(drs.get(project, 'default'))
-        if output_file is None:
-            logger.error("No valid output_file pattern for %s in project %s",
-                         drs.get(project, 'default'), project)
+    output_file = _select_drs('output_file', drs, variable['project'])
     outfile = os.path.join(
         preproc_dir,
         variable['diagnostic'],

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -270,12 +270,12 @@ def get_output_file(variable, preproc_dir, drs):
         variable['exp'] = '-'.join(variable['exp'])
 
     output_file = cfg['output_file']
-    if type(output_file) is dict:
+    if isinstance(output_file,dict):
         project = variable['project']
         output_file = output_file.get(drs.get(project, 'default'))
         if output_file is None:
-            logger.error("No valid output_file pattern for {} in project {}"
-                         .format(drs.get(project, 'default'), project))
+            logger.error("No valid output_file pattern for %s in project %s"
+                         drs.get(project, 'default'), project)
     outfile = os.path.join(
         preproc_dir,
         variable['diagnostic'],

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -270,12 +270,12 @@ def get_output_file(variable, preproc_dir, drs):
         variable['exp'] = '-'.join(variable['exp'])
 
     output_file = cfg['output_file']
-    if type(output_file) is dict :
+    if type(output_file) is dict:
         project = variable['project']
-        output_file = output_file.get(drs.get(project,'default'))
-        if output_file is None :
+        output_file = output_file.get(drs.get(project, 'default'))
+        if output_file is None:
             logger.error("No valid output_file pattern for {} in project {}"
-                         .format(drs.get(project,'default'),project))
+                         .format(drs.get(project, 'default'), project))
     outfile = os.path.join(
         preproc_dir,
         variable['diagnostic'],

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -691,7 +691,8 @@ def _get_preprocessor_products(variables, profile, order, ancestor_products,
     products = set()
     for variable in variables:
         variable['filename'] = get_output_file(variable,
-                                               config_user['preproc_dir'])
+                                               config_user['preproc_dir'],
+                                               config_user['drs'])
 
     if ancestor_products:
         grouped_ancestors = _match_products(ancestor_products, variables)

--- a/tests/integration/test_data_finder.py
+++ b/tests/integration/test_data_finder.py
@@ -64,7 +64,8 @@ def create_tree(path, filenames=None, symlinks=None):
 @pytest.mark.parametrize('cfg', CONFIG['get_output_file'])
 def test_get_output_file(cfg):
     """Test getting output name for preprocessed files."""
-    output_file = get_output_file(cfg['variable'], cfg['preproc_dir'], cfg['drs'])
+    output_file = get_output_file(cfg['variable'], cfg['preproc_dir'],
+                                  cfg.get('drs'))
     assert output_file == cfg['output_file']
 
 

--- a/tests/integration/test_data_finder.py
+++ b/tests/integration/test_data_finder.py
@@ -64,7 +64,7 @@ def create_tree(path, filenames=None, symlinks=None):
 @pytest.mark.parametrize('cfg', CONFIG['get_output_file'])
 def test_get_output_file(cfg):
     """Test getting output name for preprocessed files."""
-    output_file = get_output_file(cfg['variable'], cfg['preproc_dir'])
+    output_file = get_output_file(cfg['variable'], cfg['preproc_dir'], config_user['drs'])
     assert output_file == cfg['output_file']
 
 

--- a/tests/integration/test_data_finder.py
+++ b/tests/integration/test_data_finder.py
@@ -64,7 +64,7 @@ def create_tree(path, filenames=None, symlinks=None):
 @pytest.mark.parametrize('cfg', CONFIG['get_output_file'])
 def test_get_output_file(cfg):
     """Test getting output name for preprocessed files."""
-    output_file = get_output_file(cfg['variable'], cfg['preproc_dir'], config_user['drs'])
+    output_file = get_output_file(cfg['variable'], cfg['preproc_dir'], cfg['drs'])
     assert output_file == cfg['output_file']
 
 


### PR DESCRIPTION
## Description

Numerous projects have various  organization of 'data sources' (e.g. CMIP6 has : BADC, DKRZ ...) and have no need to change their 'output_file' attribute from one data source to the other, because the same datasets attributes are used across all data sources (e.g;. mip, exp, ...)

Other projects, however, may host more varied data sources , as e.g. projects native6 which can host both ERA5 and ICON data. In that case, one need to write e.g. :

```
native6:
  cmor_strict: false
  input_dir:
    default: 'Tier{tier}/{dataset}/{latestversion}/{frequency}/{short_name}'
    IPSL: '{account}/{model}/{status}/{exp}/{simulation}/{igcm_dir}/Analyse/{freq}'
  input_file:
    default: '*.nc'
    IPSL:'{simulation}_*_{ipsl_varname}.nc'
  output_file:
    default: '{project}_{dataset}_{type}_{version}_{mip}_{short_name}'
    IPSL: '{account}_{model}_{status}_{exp}_{simulation}_{short_name}'

```
The present PR allows for entry `output file` to be a dictionary, parallel to entries `input_dir` and `input_file`. It offers backward compatibility , i.e. allows to have a single entry (without any key, or with key `default`)

Link to documentation: [preprocessor output files](https://esmvaltool--1152.org.readthedocs.build/projects/ESMValCore/en/1152/quickstart/configure.html#preprocessor-output-files)

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do : **I by-passed that, explanations stand above; I took the risk of a non-conclusive PR** 

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance) : **science is N/A here** 
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available : **technical doc is available, see section** [preprocessor output files](https://esmvaltool--1152.org.readthedocs.build/projects/ESMValCore/en/1152/quickstart/configure.html#preprocessor-output-files)
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added : **No, just adapted**
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
