### PR TITLE
Set circular attribute in MCM-UA-1-0 fix

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/mcm_ua_1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip6/mcm_ua_1_0.py
@@ -2,6 +2,7 @@
 import iris
 import numpy as np
 from dask import array as da
+from iris.util import _is_circular
 
 from ..fix import Fix
 from ..shared import add_scalar_height_coord, fix_ocean_depth_coord
@@ -70,6 +71,9 @@ class AllVars(Fix):
                             lon_bnds[-1][-1] == 360.:
                         lon_bnds[-1][-1] = 358.125
                         lon_coord.bounds = lon_bnds
+                        lon_coord.circular = _is_circular(lon_coord.points,
+                                                          360,
+                                                          lon_coord.bounds)
                     # ocean & seaice
                     if lon_coord.points[0] == -0.9375:
                         lon_dim = cube.coord_dims('longitude')[0]

--- a/esmvalcore/cmor/_fixes/cmip6/mcm_ua_1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip6/mcm_ua_1_0.py
@@ -2,7 +2,6 @@
 import iris
 import numpy as np
 from dask import array as da
-from iris.util import _is_circular
 
 from ..fix import Fix
 from ..shared import add_scalar_height_coord, fix_ocean_depth_coord
@@ -71,9 +70,7 @@ class AllVars(Fix):
                             lon_bnds[-1][-1] == 360.:
                         lon_bnds[-1][-1] = 358.125
                         lon_coord.bounds = lon_bnds
-                        lon_coord.circular = _is_circular(lon_coord.points,
-                                                          360,
-                                                          lon_coord.bounds)
+                        lon_coord.circular = True
                     # ocean & seaice
                     if lon_coord.points[0] == -0.9375:
                         lon_dim = cube.coord_dims('longitude')[0]

--- a/tests/integration/cmor/_fixes/cmip6/test_mcm_ua_1_0.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_mcm_ua_1_0.py
@@ -177,7 +177,7 @@ def test_allvars_fix_lon_bounds(cubes_bounds):
             pass
         else:
             assert lon_coord.bounds[-1][-1] == 358.125
-            assert lon_coord.circular is True
+            assert lon_coord.circular
 
 
 def test_tas_fix_metadata(cubes):

--- a/tests/integration/cmor/_fixes/cmip6/test_mcm_ua_1_0.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_mcm_ua_1_0.py
@@ -96,7 +96,8 @@ def cubes_bounds():
                                              bounds=[[-1.875, 1.875],
                                                      [354.375, 358.125]],
                                              var_name='lon',
-                                             standard_name='longitude')
+                                             standard_name='longitude',
+                                             circular=True)
     wrong_lon_coord = iris.coords.DimCoord([0, 356.25],
                                            bounds=[[-1.875, 1.875],
                                                    [354.375, 360]],
@@ -176,6 +177,7 @@ def test_allvars_fix_lon_bounds(cubes_bounds):
             pass
         else:
             assert lon_coord.bounds[-1][-1] == 358.125
+            assert lon_coord.circular is True
 
 
 def test_tas_fix_metadata(cubes):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description
This PR checks and changes the circular attribute for dataset MCM-UA-1-0 after fixing the longitudes. This is done to avoid getting masked values after regridding.
<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1175 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
~- [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available~
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
~-  [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
