### PR TITLE
Allow more recent version of `scipy`

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
     - main
-    - unpin_scipy
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
     - main
+    - unpin_scipy
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,4 @@ dependencies:
   - graphviz
   - python>=3.6
   - python-stratify
-  - scipy<1.6  # until ESMValGroup/ESMValCore/issues/927 gets resolved
+  - scipy>=1.6

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - graphviz
     - iris>=3.0.1
     - python-stratify
-    - scipy<1.6  # until ESMValGroup/ESMValCore/issues/927 gets resolved
+    - scipy>=1.6
     # Normally installed via pip:
     - cftime # iris=3.0.1 needs <=1.2.1; >=1.3.0 years<999 get a 0 instead of empty space
     - cf-units>=2.1.5

--- a/tests/integration/cmor/_fixes/cmip5/test_bcc_csm1_1.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_bcc_csm1_1.py
@@ -111,12 +111,14 @@ def test_tos_fix_metadata():
     np.testing.assert_allclose(j_coord.bounds, [[-0.5, 0.5], [0.5, 1.5]])
     assert fixed_cube.coord('latitude').bounds is not None
     assert fixed_cube.coord('longitude').bounds is not None
-    latitude_bounds = np.array([[[-40, -33.75, -23.75, -30.0],
-                                 [-33.75, -6.25, 3.75, -23.75],
-                                 [-6.25, -1.02418074021670e-14, 10.0, 3.75]],
-                                [[-30.0, -23.75, -13.75, -20.0],
-                                 [-23.75, 3.75, 13.75, -13.75],
-                                 [3.75, 10.0, 20.0, 13.75]]])
+    latitude_bounds = np.array(
+        [[[-43.48076211, -34.01923789, -22.00961894, -31.47114317],
+          [-34.01923789, -10.0, 2.00961894, -22.00961894],
+          [-10.0, -0.53847577, 11.47114317, 2.00961894]],
+         [[-31.47114317, -22.00961894, -10.0, -19.46152423],
+          [-22.00961894, 2.00961894, 14.01923789, -10.0],
+          [2.00961894, 11.47114317, 23.48076211, 14.01923789]]]
+    )
     np.testing.assert_allclose(fixed_cube.coord('latitude').bounds,
                                latitude_bounds)
     longitude_bounds = np.array([[[140.625, 99.375, 99.375, 140.625],

--- a/tests/integration/cmor/_fixes/test_common.py
+++ b/tests/integration/cmor/_fixes/test_common.py
@@ -329,12 +329,14 @@ def test_ocean_fix_grid_wrong_ij_names(tos_cubes_wrong_ij_names):
     assert len(fixed_cube.coords('longitude')) == 1
     assert fixed_cube.coord('latitude').bounds is not None
     assert fixed_cube.coord('longitude').bounds is not None
-    latitude_bounds = np.array([[[-40, -33.75, -23.75, -30.0],
-                                 [-33.75, -6.25, 3.75, -23.75],
-                                 [-6.25, -1.02418074021670e-14, 10.0, 3.75]],
-                                [[-30.0, -23.75, -13.75, -20.0],
-                                 [-23.75, 3.75, 13.75, -13.75],
-                                 [3.75, 10.0, 20.0, 13.75]]])
+    latitude_bounds = np.array(
+        [[[-43.48076211, -34.01923789, -22.00961894, -31.47114317],
+          [-34.01923789, -10.0, 2.00961894, -22.00961894],
+          [-10.0, -0.53847577, 11.47114317, 2.00961894]],
+         [[-31.47114317, -22.00961894, -10.0, -19.46152423],
+          [-22.00961894, 2.00961894, 14.01923789, -10.0],
+          [2.00961894, 11.47114317, 23.48076211, 14.01923789]]]
+    )
     np.testing.assert_allclose(fixed_cube.coord('latitude').bounds,
                                latitude_bounds)
     longitude_bounds = np.array([[[140.625, 99.375, 99.375, 140.625],
@@ -398,12 +400,14 @@ def test_ocean_fix_grid_no_ij_bounds(tos_cubes_no_ij_bounds):
     assert len(fixed_cube.coords('longitude')) == 1
     assert fixed_cube.coord('latitude').bounds is not None
     assert fixed_cube.coord('longitude').bounds is not None
-    latitude_bounds = np.array([[[-40, -33.75, -23.75, -30.0],
-                                 [-33.75, -6.25, 3.75, -23.75],
-                                 [-6.25, -1.02418074021670e-14, 10.0, 3.75]],
-                                [[-30.0, -23.75, -13.75, -20.0],
-                                 [-23.75, 3.75, 13.75, -13.75],
-                                 [3.75, 10.0, 20.0, 13.75]]])
+    latitude_bounds = np.array(
+        [[[-43.48076211, -34.01923789, -22.00961894, -31.47114317],
+          [-34.01923789, -10.0, 2.00961894, -22.00961894],
+          [-10.0, -0.53847577, 11.47114317, 2.00961894]],
+         [[-31.47114317, -22.00961894, -10.0, -19.46152423],
+          [-22.00961894, 2.00961894, 14.01923789, -10.0],
+          [2.00961894, 11.47114317, 23.48076211, 14.01923789]]]
+    )
     np.testing.assert_allclose(fixed_cube.coord('latitude').bounds,
                                latitude_bounds)
     longitude_bounds = np.array([[[140.625, 99.375, 99.375, 140.625],


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

This PR fixes a test that fails in a more recent version of `scipy` (>1.6). Note that now the pin is `scipy>=1.6` instead of `scipy<1.6` to make sure that the newer version is picked up. Without the pin, I still got version 1.5.3 from `conda env create`.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #927.

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
