### PR TITLE
Fixed time coordinate of MIRCO-ESM

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
@@ -1,11 +1,12 @@
 """Fixes for MIROC-ESM model."""
 
+import numpy as np
+from cf_units import Unit
 from iris.coords import DimCoord
 from iris.exceptions import CoordinateNotFoundError
 
 from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
-
 
 Cl = ClFixHybridPressureCoord
 
@@ -65,7 +66,8 @@ class AllVars(Fix):
         """
         Fix metadata.
 
-        Fixes error in air_pressure coordinate, sometimes called AR5PL35
+        Fixes error in air_pressure coordinate, sometimes called AR5PL35, and
+        error in time coordinate.
 
         Parameters
         ----------
@@ -78,6 +80,7 @@ class AllVars(Fix):
 
         """
         for cube in cubes:
+            # Fix air_pressure
             try:
                 old = cube.coord('AR5PL35')
                 dims = cube.coord_dims(old)
@@ -90,5 +93,19 @@ class AllVars(Fix):
                 cube.add_dim_coord(plev, dims)
             except CoordinateNotFoundError:
                 pass
+
+            # Fix time
+            if cube.coords('time'):
+                expected_time_units = Unit('days since 1950-1-1 00:00:00',
+                                           calendar='gregorian')
+                if cube.coord('time').units != expected_time_units:
+                    continue
+                if cube.coord('time').bounds is None:
+                    continue
+                if np.isclose(cube.coord('time').bounds[0][0], -711860.5):
+                    new_points = cube.coord('time').points.copy() + 3.5
+                    new_bounds = cube.coord('time').bounds.copy() + 3.5
+                    cube.coord('time').points = new_points
+                    cube.coord('time').bounds = new_bounds
 
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
@@ -94,7 +94,7 @@ class AllVars(Fix):
             except CoordinateNotFoundError:
                 pass
 
-            # Fix time
+            # Fix time for files that contain year < 1 (which is not allowed)
             if cube.coords('time'):
                 expected_time_units = Unit('days since 1950-1-1 00:00:00',
                                            calendar='gregorian')
@@ -102,6 +102,10 @@ class AllVars(Fix):
                     continue
                 if cube.coord('time').bounds is None:
                     continue
+
+                # Only apply fix if there is a year < 1 in the first element
+                # of the time bounds (-711860.5 days from 1950-01-01 is <
+                # year 1)
                 if np.isclose(cube.coord('time').bounds[0][0], -711860.5):
                     new_points = cube.coord('time').points.copy() + 3.5
                     new_bounds = cube.coord('time').bounds.copy() + 3.5

--- a/tests/integration/cmor/_fixes/cmip5/test_miroc_esm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_miroc_esm.py
@@ -133,3 +133,11 @@ class TestAll(unittest.TestCase):
         np.testing.assert_allclose(
             time_coord.bounds,
             [[-711857.0, -711826.0], [-711826.0, -711796.5]])
+
+    def test_fix_metadata_wrong_time_no_bounds(self):
+        """Test fix for time."""
+        self.cube_with_wrong_time.coord('time').bounds = None
+        fixed_cube = self.fix.fix_metadata([self.cube_with_wrong_time])[0]
+        time_coord = fixed_cube.coord('time')
+        np.testing.assert_allclose(time_coord.points, [-711845.0, -711814.0])
+        assert time_coord.bounds is None

--- a/tests/integration/cmor/_fixes/cmip5/test_miroc_esm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_miroc_esm.py
@@ -81,6 +81,9 @@ class TestAll(unittest.TestCase):
         self.cube.add_dim_coord(DimCoord([0, 1], long_name='AR5PL35'), 1)
 
         time_units = Unit('days since 1950-1-1 00:00:00', calendar='gregorian')
+
+        # Setup wrong time coordinate that is present in some files
+        # (-711860.5 days from 1950-01-01 is < year 1)
         time_coord = DimCoord(
             [-711845.0, -711814.0],
             bounds=[[-711860.5, -711829.5], [-711829.5, -711800.0]],

--- a/tests/integration/cmor/_fixes/cmip5/test_miroc_esm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_miroc_esm.py
@@ -1,6 +1,7 @@
 """Test MIROC-ESM fixes."""
 import unittest
 
+import numpy as np
 from cf_units import Unit
 from iris.coords import DimCoord
 from iris.cube import Cube
@@ -79,6 +80,19 @@ class TestAll(unittest.TestCase):
                                 calendar='gregorian')), 0)
         self.cube.add_dim_coord(DimCoord([0, 1], long_name='AR5PL35'), 1)
 
+        time_units = Unit('days since 1950-1-1 00:00:00', calendar='gregorian')
+        time_coord = DimCoord(
+            [-711845.0, -711814.0],
+            bounds=[[-711860.5, -711829.5], [-711829.5, -711800.0]],
+            var_name='time',
+            standard_name='time',
+            long_name='time',
+            units=time_units,
+        )
+        self.cube_with_wrong_time = Cube([0.0, 1.0], var_name='co2',
+                                         units='ppm',
+                                         dim_coords_and_dims=[(time_coord, 0)])
+
         self.fix = AllVars(None)
 
     def test_get(self):
@@ -100,3 +114,19 @@ class TestAll(unittest.TestCase):
         cube = self.fix.fix_metadata([self.cube])[0]
         with self.assertRaises(CoordinateNotFoundError):
             cube.coord('air_pressure')
+
+    def test_fix_metadata_correct_time(self):
+        """Test fix for time."""
+        fixed_cube = self.fix.fix_metadata([self.cube])[0]
+        time_coord = fixed_cube.coord('time')
+        np.testing.assert_allclose(time_coord.points, [0, 1])
+        assert time_coord.bounds is None
+
+    def test_fix_metadata_wrong_time(self):
+        """Test fix for time."""
+        fixed_cube = self.fix.fix_metadata([self.cube_with_wrong_time])[0]
+        time_coord = fixed_cube.coord('time')
+        np.testing.assert_allclose(time_coord.points, [-711841.5, -711810.5])
+        np.testing.assert_allclose(
+            time_coord.bounds,
+            [[-711857.0, -711826.0], [-711826.0, -711796.5]])


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

Fix time coordinate of `gpp_Lmon_MIROC-ESM_esmFixClim1_r1i1p1_000101-014012.nc`.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1187.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
