### PR TITLE
pin cf-units, remove github actions test for Python 3.6 and fix test_access1_0 and test_access1_3 to use cf-units for comparisons

### DIFF
--- a/.github/workflows/action-conda-publish.yml
+++ b/.github/workflows/action-conda-publish.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
     runs-on: ${{ matrix.os }}
     needs: publish
     steps:

--- a/.github/workflows/action-install-from-conda.yml
+++ b/.github/workflows/action-install-from-conda.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       # fail-fast set to False allows all other tests
       # in the worflow to run regardless of any fail
       fail-fast: false
@@ -71,7 +71,7 @@ jobs:
     runs-on: "macos-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     name: OSX Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/action-install-from-pypi.yml
+++ b/.github/workflows/action-install-from-pypi.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       # fail-fast set to False allows all other tests
       # in the worflow to run regardless of any fail
       fail-fast: false
@@ -72,7 +72,7 @@ jobs:
     runs-on: "macos-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     name: OSX Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/action-install-from-source.yml
+++ b/.github/workflows/action-install-from-source.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:
@@ -71,7 +71,7 @@ jobs:
     runs-on: "macos-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     name: OSX Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:
@@ -70,7 +70,7 @@ jobs:
     runs-on: "macos-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
     name: OSX Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
     - main
+    - fix_access_tests_again
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
     - main
-    - fix_access_tests_again
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
   - cftime  # iris=3.0.1 needs <=1.2.1; >=1.3.0 - years<999 get a 0 instead of empty space
+  - cf-units>=3.0.0
   - compilers
   - fiona  # 1.8.18/py39, they seem weary to build manylinux wheels and pypi ver built with older gdal
   - esmpy

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - scipy<1.6  # until ESMValGroup/ESMValCore/issues/927 gets resolved
     # Normally installed via pip:
     - cftime # iris=3.0.1 needs <=1.2.1; >=1.3.0 years<999 get a 0 instead of empty space
-    - cf-units>=2.1.5
+    - cf-units>=3.0.0
     - cython  # required by cf-units but not automatically installed
     - esmpy
     - fiona

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ REQUIREMENTS = {
     # Installation dependencies
     # Use with pip install . to install from source
     'install': [
-        'cf-units>=2.1.5',
+        'cf-units>=3.0.0',
         'dask[array]',
         'fiona',
         'fire',

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
@@ -2,7 +2,6 @@
 import unittest
 from datetime import datetime
 
-import cf_units
 import pytest
 from cf_units import Unit, date2num, num2date
 from iris.coords import AuxCoord, DimCoord
@@ -45,11 +44,9 @@ class TestAllVars(unittest.TestCase):
         time = cube.coord('time')
         dates = num2date(time.points, time.units.name, time.units.calendar)
         self.assertEqual(time.units.calendar, 'gregorian')
-        u = cf_units.Unit('days since 300-01-01 12:00:00',
-                          calendar='gregorian')
+        u = Unit('days since 300-01-01 12:00:00', calendar='gregorian')
         self.assertEqual(dates[0], u.num2date(15))
-        u = cf_units.Unit('days since 1850-01-01 12:00:00',
-                          calendar='gregorian')
+        u = Unit('days since 1850-01-01 12:00:00', calendar='gregorian')
         self.assertEqual(dates[1], u.num2date(15))
 
     def test_fix_metadata_if_not_time(self):

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
@@ -2,6 +2,7 @@
 import unittest
 from datetime import datetime
 
+import cf_units
 import pytest
 from cf_units import Unit, date2num, num2date
 from iris.coords import AuxCoord, DimCoord
@@ -44,8 +45,12 @@ class TestAllVars(unittest.TestCase):
         time = cube.coord('time')
         dates = num2date(time.points, time.units.name, time.units.calendar)
         self.assertEqual(time.units.calendar, 'gregorian')
-        self.assertEqual(dates[0], datetime(300, 1, 16, 12, 0))
-        self.assertEqual(dates[1], datetime(1850, 1, 16, 12, 0))
+        u = cf_units.Unit('days since 300-01-01 12:00:00',
+                          calendar='gregorian')
+        self.assertEqual(dates[0], u.num2date(15))
+        u = cf_units.Unit('days since 1850-01-01 12:00:00',
+                          calendar='gregorian')
+        self.assertEqual(dates[1], u.num2date(15))
 
     def test_fix_metadata_if_not_time(self):
         """Test calendar fix do not fail if no time coord present."""

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
@@ -2,6 +2,7 @@
 import unittest
 from datetime import datetime
 
+import cf_units
 from cf_units import Unit, date2num, num2date
 from iris.coords import DimCoord
 from iris.cube import Cube
@@ -43,8 +44,12 @@ class TestAllVars(unittest.TestCase):
         time = cube.coord('time')
         dates = num2date(time.points, time.units.name, time.units.calendar)
         self.assertEqual(time.units.calendar, 'gregorian')
-        self.assertEqual(dates[0], datetime(300, 1, 16, 12, 0))
-        self.assertEqual(dates[1], datetime(1850, 1, 16, 12, 0))
+        u = cf_units.Unit('days since 300-01-01 12:00:00',
+                          calendar='gregorian')
+        self.assertEqual(dates[0], u.num2date(15))
+        u = cf_units.Unit('days since 1850-01-01 12:00:00',
+                          calendar='gregorian')
+        self.assertEqual(dates[1], u.num2date(15))
 
     def test_fix_metadata_if_not_time(self):
         """Test calendar fix do not fail if no time coord present."""

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
@@ -2,7 +2,6 @@
 import unittest
 from datetime import datetime
 
-import cf_units
 from cf_units import Unit, date2num, num2date
 from iris.coords import DimCoord
 from iris.cube import Cube
@@ -44,11 +43,9 @@ class TestAllVars(unittest.TestCase):
         time = cube.coord('time')
         dates = num2date(time.points, time.units.name, time.units.calendar)
         self.assertEqual(time.units.calendar, 'gregorian')
-        u = cf_units.Unit('days since 300-01-01 12:00:00',
-                          calendar='gregorian')
+        u = Unit('days since 300-01-01 12:00:00', calendar='gregorian')
         self.assertEqual(dates[0], u.num2date(15))
-        u = cf_units.Unit('days since 1850-01-01 12:00:00',
-                          calendar='gregorian')
+        u = Unit('days since 1850-01-01 12:00:00', calendar='gregorian')
         self.assertEqual(dates[1], u.num2date(15))
 
     def test_fix_metadata_if_not_time(self):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

- `cf-units` went up to 3.0.0 and this broke the tests again, now we have use of `cf-units` for both reference and test dates
- I removed the Github Action tests for Python 3.6 - it is old and we should not support it anymore, on top of it all `cf-units=2.1.5` throws a very dubious error when comparing datetimes as we do in those tests, and 3.0.0 doesn't have a packaging for Python 3.6

Closes #issue_number

Link to documentation:

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
