### PR TITLE
Fix alignment of daily data with inconsistent calendars in multimodel statistics

### DIFF
--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -142,63 +142,18 @@ def _time_coords_are_aligned(cubes):
     return True
 
 
-def _subset(cube, time_points):
-    """Subset cube to given time range."""
-    begin = cube.coord('time').units.num2date(time_points[0])
-    end = cube.coord('time').units.num2date(time_points[-1])
-    constraint = iris.Constraint(time=lambda cell: begin <= cell.point <= end)
-    try:
-        return cube.extract(constraint)
-    except Exception as excinfo:
-        raise ValueError(
-            "Tried to align cubes in multi-model statistics, but failed for"
-            f" cube {cube} and time points {time_points}. Encountered the "
-            f"following exception: {excinfo}")
+def _map_to_new_time(cube, time_points):
+    """Map cube onto new cube with specified time points.
 
-
-def _extend(cube, time_points):
-    """Extend cube to a specified time range.
-
-    If time points are missing before the start/after the end of the
-    time range, cubes for each missing time pointwith masked data will
-    be added to pad the time range to match `time_points`. This method
-    supports lazy operation.
+    Missing data inside original bounds is filled with nearest neighbour
+    Missing data outside original bounds is masked.
     """
-    cube.coord('time').bounds = None
-    cube_points = cube.coord('time').points
-
-    begin = cube_points[0]
-    end = cube_points[-1]
-
-    pad_begin = time_points[time_points < begin]
-    pad_end = time_points[time_points > end]
-
-    if (len(pad_begin)) == 0 and (len(pad_end) == 0):
-        return cube
-
-    template_cube = cube[:1].copy()
-    template_cube.data = np.ma.array(da.zeros_like(template_cube.data),
-                                     mask=True,
-                                     dtype=template_cube.data.dtype)
-
-    cube_list = []
-
-    for time_point in pad_begin:
-        new_slice = template_cube.copy()
-        new_slice.coord('time').points = float(time_point)
-        cube_list.append(new_slice)
-
-    cube_list.append(cube)
-
-    for time_point in pad_end:
-        new_slice = template_cube.copy()
-        new_slice.coord('time').points = float(time_point)
-        cube_list.append(new_slice)
-
-    cube_list = iris.cube.CubeList(cube_list)
+    time_points = cube.coord('time').units.num2date(time_points)
+    sample_points = [('time', time_points)]
+    scheme = iris.analysis.Nearest(extrapolation_mode='mask')
 
     try:
-        new_cube = cube_list.concatenate_cube()
+        new_cube = cube.interpolate(sample_points, scheme)
     except Exception as excinfo:
         raise ValueError(
             "Tried to align cubes in multi-model statistics, but failed for"
@@ -218,14 +173,14 @@ def _align(cubes, span):
     all_time_arrays = [cube.coord('time').points for cube in cubes]
 
     if span == 'overlap':
-        common_time_points = reduce(np.intersect1d, all_time_arrays)
-        new_cubes = [_subset(cube, common_time_points) for cube in cubes]
+        new_time_points = reduce(np.intersect1d, all_time_arrays)
     elif span == 'full':
-        all_time_points = reduce(np.union1d, all_time_arrays)
-        new_cubes = [_extend(cube, all_time_points) for cube in cubes]
+        new_time_points = reduce(np.union1d, all_time_arrays)
     else:
         raise ValueError(f"Invalid argument for span: {span!r}"
                          "Must be one of 'overlap', 'full'.")
+
+    new_cubes = [_map_to_new_time(cube, new_time_points) for cube in cubes]
 
     for cube in new_cubes:
         # Make sure bounds exist and are consistent

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from functools import reduce
 
 import cf_units
-import dask.array as da
 import iris
 import numpy as np
 from iris.util import equalise_attributes

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -8,7 +8,8 @@ import numpy as np
 import pytest
 from cf_units import Unit
 from iris.cube import Cube
-from xarray import cftime_range
+
+import cftime
 
 import esmvalcore.preprocessor._multimodel as mm
 from esmvalcore.preprocessor import multi_model_statistics
@@ -547,8 +548,19 @@ def test_daily_inconsistent_calendars():
     Missing data inside original bounds is filled with nearest neighbour
     Missing data outside original bounds is masked.
     """
-    # end date: 01-01-1853
-    leapdates = cftime_range("1852-01-01", periods=367)  # 1852 is a leap year
+    start = cftime.date2num(datetime(1852, 1, 1),
+                            "days since 1850-01-01",
+                            calendar="standard")
+
+    # 1852 is a leap year, and include 1 extra day at the end
+    leapdates = cftime.num2date(start + np.arange(367),
+                                "days since 1850-01-01",
+                                calendar="standard")
+
+    noleapdates = cftime.num2date(start + np.arange(365),
+                                  "days since 1850-01-01",
+                                  calendar="noleap")
+
     leapcube = generate_cube_from_dates(
         leapdates,
         calendar='gregorian',
@@ -556,8 +568,6 @@ def test_daily_inconsistent_calendars():
         fill_val=1,
     )
 
-    # end date: 31-12-1852
-    noleapdates = cftime_range("1852-01-01", periods=365, calendar="noleap")
     noleapcube = generate_cube_from_dates(
         noleapdates,
         calendar='noleap',


### PR DESCRIPTION
## Description

Following #1210 this PR implements the following behavior for multimodel statistics, when the input data is a daily frequency with inconsistent calendars:

- `span='overlap'`: discard those days that occur only in certain calendars but not in others
- `span='full'`: use nearest-neighbour lookup to fill missing days. Missing dates outside the original date range are masked.

This is in contrast to the previous behavior, which was:
- `span='overlap'`: Find the first and last day that is present in all datasets; remove everything before the first and after the last day.
- `span='full'`: Find the very first and the very last day across all cubes; pad every cube with masked out data before and after its actual data to cover the full time range.

This only worked for data with the same number of days per year, raising an exception otherwise.

Closes #1198

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] ~[🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available~
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
