### PR TITLE
Fixed search for fx files when no ``mip`` is given

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -205,16 +205,20 @@ the variables, e.g.,
       areacello:
       volcello:
 
-or by explicitly adding variable parameters (the key-value pair may be as
-specific as a CMOR variable can permit):
+or by additionally specifying further keys that are used to define the fx
+datsets, e.g.,
 
 .. code-block:: yaml
 
     fx_variables:
       areacello:
         mip: Ofx
+        exp: piControl
       volcello:
         mip: Omon
+
+This might be useful to select fx files from a specific ``mip`` table or from a
+specific ``exp`` in case not all experiments provide the fx variable.
 
 Alternatively, the ``fx_variables`` argument can also be specified as a list:
 
@@ -226,7 +230,7 @@ or as a list of dictionaries:
 
 .. code-block:: yaml
 
-    fx_variables: [{'short_name': 'areacello', 'mip': 'Ofx'}, {'short_name': 'volcello', 'mip': 'Omon'}]
+    fx_variables: [{'short_name': 'areacello', 'mip': 'Ofx', 'exp': 'piControl'}, {'short_name': 'volcello', 'mip': 'Omon'}]
 
 The recipe parser will automatically find the data files that are associated
 with these variables and pass them to the function for loading and processing.

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -180,19 +180,24 @@ To get an overview on data fixes and how to implement new ones, please go to
 
 Fx variables as cell measures or ancillary variables
 ====================================================
-The following preprocessor may require the use of ``fx_variables`` to be able
+The following preprocessors may require the use of ``fx_variables`` to be able
 to perform the computations:
 
-    - area_statistics_ (``areacella``, ``areacello``)
-    - :ref:`mask_landsea<land/sea/ice masking>` (``sftlf``, ``sftof``)
-    - :ref:`mask_landseaice<ice masking>` (``sftgif``)
-    - volume_statistics_ (``volcello``)
-    - :ref:`weighting_landsea_fraction<land/sea fraction weighting>` (``sftlf``, ``sftof``)
+============================================================== =====================
+Preprocessor                                                   Default fx variables
+============================================================== =====================
+area_statistics_                                               ``areacella``, ``areacello``
+:ref:`mask_landsea<land/sea/ice masking>`                      ``sftlf``, ``sftof``
+:ref:`mask_landseaice<ice masking>`                            ``sftgif``
+volume_statistics_                                             ``volcello``
+:ref:`weighting_landsea_fraction<land/sea fraction weighting>` ``sftlf``, ``sftof``
+============================================================== =====================
 
 If no ``fx_variables`` are specified for these preprocessors, the fx variables
-given in brackets are used. If given, the ``fx_variables`` argument specifies
-the fx variables that the user wishes to input to the corresponding
-preprocessor function; the user may specify it calling the variables e.g.
+in the second column are used. If given, the ``fx_variables`` argument
+specifies the fx variables that the user wishes to input to the corresponding
+preprocessor function. The user may specify these by simply adding the names of
+the variables, e.g.,
 
 .. code-block:: yaml
 
@@ -200,16 +205,16 @@ preprocessor function; the user may specify it calling the variables e.g.
       areacello:
       volcello:
 
-or calling the variables and adding specific variable parameters (the key-value
-pair may be as specific as a CMOR variable can permit):
+or by explicitly adding variable parameters (the key-value pair may be as
+specific as a CMOR variable can permit):
 
 .. code-block:: yaml
 
     fx_variables:
       areacello:
+        mip: Ofx
+      volcello:
         mip: Omon
-      volcello:
-        mip: fx
 
 Alternatively, the ``fx_variables`` argument can also be specified as a list:
 
@@ -221,7 +226,7 @@ or as a list of dictionaries:
 
 .. code-block:: yaml
 
-    fx_variables: [{'short_name': 'areacello', 'mip': 'Omon'}, {'short_name': 'volcello', 'mip': 'fx'}]
+    fx_variables: [{'short_name': 'areacello', 'mip': 'Ofx'}, {'short_name': 'volcello', 'mip': 'Omon'}]
 
 The recipe parser will automatically find the data files that are associated
 with these variables and pass them to the function for loading and processing.
@@ -231,14 +236,21 @@ available tables of the specified project.
 
 .. warning::
    Some fx variables exist in more than one table (e.g., ``volcello`` exists in
-   CMIP6's ``Ofx``, ``Oyr``, ``Odec`` and ``Omon`` tables or ``sftgif`` exists
-   in CMIP6's ``fx``, ``LImon``, ``IyrGre`` and ``IyrAnt`` tables). In these
-   cases, ``mip`` needs to be specified, otherwise an error is raised.
+   CMIP6's ``Odec``, ``Ofx``, ``Omon``, and ``Oyr`` tables; ``sftgif`` exists
+   in CMIP6's ``fx``, ``IyrAnt`` and ``IyrGre``, and ``LImon`` tables).  In
+   these cases, ``mip`` needs to be specified, otherwise an error is raised.
 
-The preprocessor step ``add_fx_variables`` loads the required ``fx_variables``,
-checks them against CMOR standards and adds them either as ``cell_measure``
-or ``ancillary_variable`` inside the cube data. This ensures that the
-defined preprocessor chain is applied to both ``variables`` and ``fx_variables``.
+Internally, the required ``fx_variables`` are automatically loaded by the
+preprocessor step ``add_fx_variables`` which also checks them against CMOR
+standards and adds them either as ``cell_measure`` (see `CF conventions on cell
+measures
+<https://cfconventions.org/cf-conventions/cf-conventions.html#cell-measures>`_
+and :class:`iris.coords.CellMeasure`) or ``ancillary_variable`` (see `CF
+conventions on ancillary variables
+<https://cfconventions.org/cf-conventions/cf-conventions.html#ancillary-data>`_
+and :class:`iris.coords.AncillaryVariable`) inside the cube data. This ensures
+that the defined preprocessor chain is applied to both ``variables`` and
+``fx_variables``.
 
 Note that when calling steps that require ``fx_variables`` inside diagnostic
 scripts, the variables are expected to contain the required ``cell_measures`` or
@@ -428,7 +440,7 @@ or alternatively:
             ]
 
 More details on the argument ``fx_variables`` and its default values are given
-:ref:`here<Fx variables as cell measures or ancillary variables>`.
+in :ref:`Fx variables as cell measures or ancillary variables`.
 
 See also :func:`esmvalcore.preprocessor.weighting_landsea_fraction`.
 
@@ -507,7 +519,7 @@ or alternatively:
             ]
 
 More details on the argument ``fx_variables`` and its default values are given
-:ref:`here<Fx variables as cell measures or ancillary variables>`.
+in :ref:`Fx variables as cell measures or ancillary variables`.
 
 If the corresponding fx file is not found (which is
 the case for some models and almost all observational datasets), the
@@ -561,7 +573,7 @@ or alternatively:
           fx_variables: [{'short_name': 'sftgif', 'exp': 'piControl'}]
 
 More details on the argument ``fx_variables`` and its default values are given
-:ref:`here<Fx variables as cell measures or ancillary variables>`.
+in :ref:`Fx variables as cell measures or ancillary variables`.
 
 See also :func:`esmvalcore.preprocessor.mask_landseaice`.
 
@@ -1470,8 +1482,8 @@ region, depth layer or time period is required, then those regions need to be
 removed using other preprocessor operations in advance.
 
 The optional ``fx_variables`` argument specifies the fx variables that the user
-wishes to input to the function. More details on this are given
-:ref:`here<Fx variables as cell measures or ancillary variables>`.
+wishes to input to the function. More details on this are given in :ref:`Fx
+variables as cell measures or ancillary variables`.
 
 See also :func:`esmvalcore.preprocessor.area_statistics`.
 
@@ -1516,8 +1528,8 @@ apply over the volume.
 No depth coordinate is required as this is determined by Iris. This function
 works best when the ``fx_variables`` provide the cell volume. The optional
 ``fx_variables`` argument specifies the fx variables that the user wishes to
-input to the function. More details on this are given
-:ref:`here<Fx variables as cell measures or ancillary variables>`.
+input to the function. More details on this are given in :ref:`Fx variables as
+cell measures or ancillary variables`.
 
 See also :func:`esmvalcore.preprocessor.volume_statistics`.
 

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -229,7 +229,7 @@ with these variables and pass them to the function for loading and processing.
 If ``mip`` is not given, ESMValTool will search for the fx variable in all
 available tables of the specified project.
 
-.. note::
+.. warning::
    Some fx variables exist in more than one table (e.g., ``volcello`` exists in
    CMIP6's ``Ofx``, ``Oyr``, ``Odec`` and ``Omon`` tables or ``sftgif`` exists
    in CMIP6's ``fx``, ``LImon``, ``IyrGre`` and ``IyrAnt`` tables). In these

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -186,10 +186,10 @@ to perform the computations:
 ============================================================== =====================
 Preprocessor                                                   Default fx variables
 ============================================================== =====================
-area_statistics_                                               ``areacella``, ``areacello``
+:ref:`area_statistics<area_statistics>`                        ``areacella``, ``areacello``
 :ref:`mask_landsea<land/sea/ice masking>`                      ``sftlf``, ``sftof``
 :ref:`mask_landseaice<ice masking>`                            ``sftgif``
-volume_statistics_                                             ``volcello``
+:ref:`volume_statistics<volume_statistics>`                    ``volcello``
 :ref:`weighting_landsea_fraction<land/sea fraction weighting>` ``sftlf``, ``sftof``
 ============================================================== =====================
 
@@ -1467,6 +1467,8 @@ argument:
 See also :func:`esmvalcore.preprocessor.meridional_means`.
 
 
+.. _area_statistics:
+
 ``area_statistics``
 -------------------
 
@@ -1515,6 +1517,8 @@ as the Iris cube. That is, if the cube has `z`-coordinate as negative, then
 
 See also :func:`esmvalcore.preprocessor.extract_volume`.
 
+
+.. _volume_statistics:
 
 ``volume_statistics``
 ---------------------

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -206,7 +206,7 @@ the variables, e.g.,
       volcello:
 
 or by additionally specifying further keys that are used to define the fx
-datsets, e.g.,
+datasets, e.g.,
 
 .. code-block:: yaml
 
@@ -241,8 +241,9 @@ available tables of the specified project.
 .. warning::
    Some fx variables exist in more than one table (e.g., ``volcello`` exists in
    CMIP6's ``Odec``, ``Ofx``, ``Omon``, and ``Oyr`` tables; ``sftgif`` exists
-   in CMIP6's ``fx``, ``IyrAnt`` and ``IyrGre``, and ``LImon`` tables).  In
-   these cases, ``mip`` needs to be specified, otherwise an error is raised.
+   in CMIP6's ``fx``, ``IyrAnt`` and ``IyrGre``, and ``LImon`` tables). If (for
+   a given dataset) fx files are found in more than one table, ``mip`` needs to
+   be specified, otherwise an error is raised.
 
 Internally, the required ``fx_variables`` are automatically loaded by the
 preprocessor step ``add_fx_variables`` which also checks them against CMOR

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -227,15 +227,13 @@ The recipe parser will automatically find the data files that are associated
 with these variables and pass them to the function for loading and processing.
 
 If ``mip`` is not given, ESMValTool will search for the fx variable in all
-available tables of the specified project (in alphabetical order) and return
-the first match.
+available tables of the specified project.
 
 .. note::
    Some fx variables exist in more than one table (e.g., ``volcello`` exists in
-   CMIP6's ``Ofx`` and ``Omon`` table or ``sftgif`` exists in CMIP6's ``fx``
-   and ``IyrAnt`` table). If a specific table is desired, this needs to be
-   specified by ``mip``, otherwise the table is selected based on the
-   alphabetical order and data availability.
+   CMIP6's ``Ofx``, ``Oyr``, ``Odec`` and ``Omon`` tables or ``sftgif`` exists
+   in CMIP6's ``fx``, ``LImon``, ``IyrGre`` and ``IyrAnt`` tables). In these
+   cases, ``mip`` needs to be specified, otherwise an error is raised.
 
 The preprocessor step ``add_fx_variables`` loads the required ``fx_variables``,
 checks them against CMOR standards and adds them either as ``cell_measure``
@@ -1072,7 +1070,7 @@ See also :func:`esmvalcore.preprocessor.decadal_statistics`.
 ----------------------
 
 This function produces statistics for the whole dataset. It can produce scalars
-(if the full period is chosen) or daily, monthly or seasonal statics.
+(if the full period is chosen) or daily, monthly or seasonal statistics.
 
 Parameters:
     * operator: operation to apply. Accepted values are 'mean', 'median',

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -383,7 +383,7 @@ def _search_fx_mip(tables, variable, fx_info, config_user):
             f"Requested fx variable '{fx_info['short_name']}' for dataset "
             f"'{variable['dataset']}' of project '{variable['project']}' is "
             f"available in more than one CMOR table for "
-            f"'{variable['project']}': {list(fx_files_for_mips)}")
+            f"'{variable['project']}': {sorted(list(fx_files_for_mips))}")
 
     # Dict is empty -> no files found -> handled at later stage
     if not fx_files_for_mips:

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -295,8 +295,6 @@ def patched_failing_datafinder(tmp_path, monkeypatch):
                 return []
             if 'sftlf' in filename:
                 return []
-            if 'IyrAnt_' in filename:
-                return []
         return _get_filenames(tmp_path, filenames, tracking_id)
 
     monkeypatch.setattr(esmvalcore._data_finder, 'find_files', find_files)
@@ -2144,56 +2142,6 @@ def test_landmask_no_fx(tmp_path, patched_failing_datafinder, config_user):
         assert not any(fx_variables)
 
 
-def test_fx_vars_not_all_available(tmp_path, patched_failing_datafinder,
-                                   config_user):
-    """Check that IyrGre is used for sftgif if IyrAnt is not available."""
-    content = dedent("""
-        preprocessors:
-          preproc:
-           mask_landseaice:
-             mask_out: sea
-
-        diagnostics:
-          diagnostic_name:
-            variables:
-              tos:
-                preprocessor: preproc
-                project: CMIP6
-                mip: Omon
-                exp: historical
-                start_year: 2000
-                end_year: 2005
-                ensemble: r1i1p1f1
-                grid: gn
-                additional_datasets:
-                  - {dataset: CanESM5}
-            scripts: null
-        """)
-    recipe = get_recipe(tmp_path, content, config_user)
-
-    # Check generated tasks
-    assert len(recipe.tasks) == 1
-    task = recipe.tasks.pop()
-    assert task.name == 'diagnostic_name' + TASKSEP + 'tos'
-    assert len(task.products) == 1
-    product = task.products.pop()
-
-    # Check mask_landseaice
-    assert 'mask_landseaice' in product.settings
-    settings = product.settings['mask_landseaice']
-    assert len(settings) == 1
-    assert settings['mask_out'] == 'sea'
-
-    # Check add_fx_variables
-    fx_variables = product.settings['add_fx_variables']['fx_variables']
-    assert isinstance(fx_variables, dict)
-    assert len(fx_variables) == 1
-    filenames = fx_variables['sftgif']['filename']
-    assert isinstance(filenames, list)  # assert list since frequency != fx
-    assert len(filenames) == 1
-    assert '_IyrGre_' in filenames[0]
-
-
 def test_fx_vars_fixed_mip_cmip6(tmp_path, patched_datafinder, config_user):
     """Test fx variables with given mips."""
     TAGS.set_tag_values(TAGS_FOR_TESTING)
@@ -2261,6 +2209,44 @@ def test_fx_vars_invalid_mip_cmip6(tmp_path, patched_datafinder, config_user):
              operator: mean
              fx_variables:
                areacella:
+                 mip: INVALID
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: preproc
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+            scripts: null
+        """)
+    msg = ("Requested mip table 'INVALID' for fx variable 'areacella' not "
+           "available for project 'CMIP6'")
+    with pytest.raises(RecipeError) as rec_err_exp:
+        get_recipe(tmp_path, content, config_user)
+    assert str(rec_err_exp.value) == INITIALIZATION_ERROR_MSG
+    assert msg in rec_err_exp.value.failed_tasks[0].message
+
+
+def test_fx_vars_invalid_mip_for_var_cmip6(tmp_path, patched_datafinder,
+                                           config_user):
+    """Test fx variables with invalid mip for variable."""
+    TAGS.set_tag_values(TAGS_FOR_TESTING)
+
+    content = dedent("""
+        preprocessors:
+          preproc:
+           area_statistics:
+             operator: mean
+             fx_variables:
+               areacella:
                  mip: Lmon
 
         diagnostics:
@@ -2302,8 +2288,6 @@ def test_fx_vars_mip_search_cmip6(tmp_path, patched_datafinder, config_user):
                clayfrac:
            mask_landsea:
              mask_out: sea
-           volume_statistics:
-             operator: mean
 
         diagnostics:
           diagnostic_name:
@@ -2342,25 +2326,15 @@ def test_fx_vars_mip_search_cmip6(tmp_path, patched_datafinder, config_user):
     assert len(settings) == 1
     assert settings['mask_out'] == 'sea'
 
-    # Check volume_statistics
-    assert 'volume_statistics' in product.settings
-    settings = product.settings['volume_statistics']
-    assert len(settings) == 1
-    assert settings['operator'] == 'mean'
-
     # Check add_fx_variables
     fx_variables = product.settings['add_fx_variables']['fx_variables']
     assert isinstance(fx_variables, dict)
-    assert len(fx_variables) == 6
+    assert len(fx_variables) == 5
     assert '_fx_' in fx_variables['areacella']['filename']
     assert '_Ofx_' in fx_variables['areacello']['filename']
     assert '_Efx_' in fx_variables['clayfrac']['filename']
     assert '_fx_' in fx_variables['sftlf']['filename']
     assert '_Ofx_' in fx_variables['sftof']['filename']
-    volcello_files = fx_variables['volcello']['filename']
-    assert isinstance(volcello_files, list)
-    assert len(volcello_files) == 1
-    assert '_Odec_' in volcello_files[0]
 
 
 def test_fx_list_mip_search_cmip6(tmp_path, patched_datafinder, config_user):
@@ -2375,7 +2349,6 @@ def test_fx_list_mip_search_cmip6(tmp_path, patched_datafinder, config_user):
                'areacello',
                'clayfrac',
                'sftlf',
-               'sftgif',
                'sftof',
                ]
 
@@ -2413,16 +2386,12 @@ def test_fx_list_mip_search_cmip6(tmp_path, patched_datafinder, config_user):
     # Check add_fx_variables
     fx_variables = product.settings['add_fx_variables']['fx_variables']
     assert isinstance(fx_variables, dict)
-    assert len(fx_variables) == 6
+    assert len(fx_variables) == 5
     assert '_fx_' in fx_variables['areacella']['filename']
     assert '_Ofx_' in fx_variables['areacello']['filename']
     assert '_Efx_' in fx_variables['clayfrac']['filename']
     assert '_fx_' in fx_variables['sftlf']['filename']
     assert '_Ofx_' in fx_variables['sftof']['filename']
-    sftgif_files = fx_variables['sftgif']['filename']
-    assert isinstance(sftgif_files, list)
-    assert len(sftgif_files) == 1
-    assert '_IyrAnt_' in sftgif_files[0]
 
 
 def test_fx_vars_volcello_in_ofx_cmip6(tmp_path, patched_datafinder,
@@ -2753,6 +2722,7 @@ def test_wrong_project(tmp_path, patched_datafinder, config_user):
 
 
 def test_invalid_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
+    """Test that error is raised for invalid fx variable."""
     TAGS.set_tag_values(TAGS_FOR_TESTING)
 
     content = dedent("""
@@ -2782,6 +2752,42 @@ def test_invalid_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
         """)
     msg = ("Requested fx variable 'wrong_fx_variable' not available in any "
            "CMOR table")
+    with pytest.raises(RecipeError) as rec_err_exp:
+        get_recipe(tmp_path, content, config_user)
+    assert str(rec_err_exp.value) == INITIALIZATION_ERROR_MSG
+    assert msg in rec_err_exp.value.failed_tasks[0].message
+
+
+def test_ambiguous_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
+    """Test that error is raised for fx variable available in multiple mips."""
+    TAGS.set_tag_values(TAGS_FOR_TESTING)
+
+    content = dedent("""
+        preprocessors:
+          preproc:
+           area_statistics:
+             operator: mean
+             fx_variables:
+               volcello:
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: preproc
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+            scripts: null
+        """)
+    msg = ("Requested fx variable 'volcello' is available in more than one "
+           "CMOR table for 'CMIP6': ['Ofx', 'Oyr', 'Odec', 'Omon']")
     with pytest.raises(RecipeError) as rec_err_exp:
         get_recipe(tmp_path, content, config_user)
     assert str(rec_err_exp.value) == INITIALIZATION_ERROR_MSG

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -2792,7 +2792,7 @@ def test_ambiguous_fx_var_cmip6(tmp_path, patched_datafinder, config_user):
         """)
     msg = ("Requested fx variable 'volcello' for dataset 'CanESM5' of project "
            "'CMIP6' is available in more than one CMOR table for 'CMIP6': "
-           "['Ofx', 'Oyr', 'Odec', 'Omon']")
+           "['Odec', 'Ofx', 'Omon', 'Oyr']")
     with pytest.raises(RecipeError) as rec_err_exp:
         get_recipe(tmp_path, content, config_user)
     assert str(rec_err_exp.value) == INITIALIZATION_ERROR_MSG


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

This PR fixes the automatic retrieval of fx files when no `mip` is specified.

I agree with @sloosvel that a predefined order for the mip tables is not useful due to the many different project tables. Therefore I just implemented an alphabetic ordering, i.e., the first `mip` that has data is automatically selected. To bypass this, the user has to define a specific `mip` in the recipe. I added a paragraph to the documentation that describes this process.

This should go into 2.3.1 since this fixes a bug that (1) lets the test fails and (2) might lead to the tool wrongly complaining about missing data. #1169 only disabled the tests and didn't actually fix the bug.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1159.

Link to documentation: https://esmvaltool--1216.org.readthedocs.build/projects/ESMValCore/en/1216/recipe/preprocessor.html#fx-variables-as-cell-measures-or-ancillary-variables

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
