### PR TITLE
Remove fx variables before computing multimodel statistics

### DIFF
--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -207,7 +207,7 @@ def _combine(cubes):
         # https://scitools-iris.readthedocs.io/en/stable/userguide/
         #    merge_and_concat.html#common-issues-with-merge-and-concatenate
 
-        cube = remove_fx_variables(cube)
+        remove_fx_variables(cube)
         cube.cell_methods = None
 
         for coord in cube.coords():

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -263,7 +263,7 @@ def _multicube_statistics(cubes, statistics, span):
     if len(cubes) == 1:
         raise ValueError('Cannot perform multicube statistics '
                          'for a single cube.')
-    
+
     copied_cubes = []
     for cube in cubes:
         # avoid modifying inputs

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -9,6 +9,7 @@ import cf_units
 import iris
 import numpy as np
 from iris.util import equalise_attributes
+from esmvalcore.preprocessor import remove_fx_variables
 
 logger = logging.getLogger(__name__)
 
@@ -262,8 +263,14 @@ def _multicube_statistics(cubes, statistics, span):
     if len(cubes) == 1:
         raise ValueError('Cannot perform multicube statistics '
                          'for a single cube.')
+    
+    copied_cubes = []
+    for cube in cubes:
+        # avoid modifying inputs
+        copied_cube = cube.copy()
+        copied_cube = remove_fx_variables(copied_cube)
+        copied_cubes.append(copied_cube)
 
-    copied_cubes = [cube.copy() for cube in cubes]  # avoid modifying inputs
     aligned_cubes = _align(copied_cubes, span=span)
 
     statistics_cubes = {}

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -207,6 +207,7 @@ def _combine(cubes):
         # https://scitools-iris.readthedocs.io/en/stable/userguide/
         #    merge_and_concat.html#common-issues-with-merge-and-concatenate
 
+        cube = remove_fx_variables(cube)
         cube.cell_methods = None
 
         for coord in cube.coords():
@@ -275,13 +276,7 @@ def _multicube_statistics(cubes, statistics, span):
         raise ValueError('Cannot perform multicube statistics '
                          'for a single cube.')
 
-    copied_cubes = []
-    for cube in cubes:
-        # avoid modifying inputs
-        copied_cube = cube.copy()
-        copied_cube = remove_fx_variables(copied_cube)
-        copied_cubes.append(copied_cube)
-
+    copied_cubes = [cube.copy() for cube in cubes]  # avoid modifying inputs
     aligned_cubes = _align(copied_cubes, span=span)
 
     statistics_cubes = {}

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -12,6 +12,7 @@ from iris.cube import Cube
 import cftime
 
 import esmvalcore.preprocessor._multimodel as mm
+from esmvalcore.preprocessor._ancillary_vars import add_ancillary_variable
 from esmvalcore.preprocessor import multi_model_statistics
 
 SPAN_OPTIONS = ('overlap', 'full')
@@ -600,3 +601,16 @@ def test_daily_inconsistent_calendars():
     result = multi_model_statistics(cubes, span="overlap", statistics=['mean'])
     result_cube = result['mean']
     assert result_cube[59].data == 2
+
+def test_remove_fx_variables():
+    """Test fx variables are removed from cubes."""
+    cube1 = generate_cube_from_dates("monthly")
+    fx_cube = generate_cube_from_dates("monthly")
+    fx_cube.standard_name = "land_area_fraction"
+    add_ancillary_variable(cube1, fx_cube)
+
+    cube2 = generate_cube_from_dates("monthly", fill_val=9)
+    result = mm.multi_model_statistics([cube1, cube2],
+                                       statistics=['mean'],
+                                       span='full')
+    assert result['mean'].ancillary_variables() == []

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -602,6 +602,7 @@ def test_daily_inconsistent_calendars():
     result_cube = result['mean']
     assert result_cube[59].data == 2
 
+
 def test_remove_fx_variables():
     """Test fx variables are removed from cubes."""
     cube1 = generate_cube_from_dates("monthly")


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

The fx variables are removed before computing multimodel statistics, in order to avoid issues when merging cubes with iris. 

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1213

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] ~[🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available~
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
