### PR TITLE
Sort missing years in "No input data available for years" message

### DIFF
--- a/esmvalcore/_recipe_checks.py
+++ b/esmvalcore/_recipe_checks.py
@@ -142,7 +142,7 @@ def data_availability(input_files, var, dirnames, filenames):
     if missing_years:
         raise RecipeError(
             "No input data available for years {} in files {}".format(
-                ", ".join(str(year) for year in missing_years), input_files))
+                ", ".join(str(year) for year in sorted(missing_years)), input_files))
 
 
 def tasks_valid(tasks):

--- a/esmvalcore/_recipe_checks.py
+++ b/esmvalcore/_recipe_checks.py
@@ -142,7 +142,8 @@ def data_availability(input_files, var, dirnames, filenames):
     if missing_years:
         raise RecipeError(
             "No input data available for years {} in files {}".format(
-                ", ".join(str(year) for year in sorted(missing_years)), input_files))
+                ", ".join(str(year) for year in sorted(missing_years)), 
+                input_files))
 
 
 def tasks_valid(tasks):

--- a/esmvalcore/_recipe_checks.py
+++ b/esmvalcore/_recipe_checks.py
@@ -142,7 +142,7 @@ def data_availability(input_files, var, dirnames, filenames):
     if missing_years:
         raise RecipeError(
             "No input data available for years {} in files {}".format(
-                ", ".join(str(year) for year in sorted(missing_years)), 
+                ", ".join(str(year) for year in sorted(missing_years)),
                 input_files))
 
 

--- a/tests/integration/test_recipe_checks.py
+++ b/tests/integration/test_recipe_checks.py
@@ -40,7 +40,7 @@ DATA_AVAILABILITY_DATA = [
     (FILES[:-1], dict(VAR), ERR_RANGE.format('2025', FILES[:-1])),
     (FILES[:-2], dict(VAR), ERR_RANGE.format('2024, 2025', FILES[:-2])),
     ([FILES[1]] + [FILES[3]], dict(VAR),
-     ERR_RANGE.format('2024, 2025, 2020, 2022', [FILES[1]] + [FILES[3]])),
+     ERR_RANGE.format('2020, 2022, 2024, 2025', [FILES[1]] + [FILES[3]])),
 ]
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1224

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
