### PR TITLE
Add a more friendly and useful message when using default config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
           # Install curl for codecov upload
           command: apt update && apt install -y curl
       - codecov/upload:
+          when: always
           file: 'test-reports/coverage.xml'
       - coverage-reporter/send_report:
           coverage-reports: 'test-reports/coverage.xml'

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,7 @@ coverage:
     project: off
     patch:
       default:
+        informational: true
         target: 100%
+comment:
+  require_changes: true  # comment only if the coverage changes

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,4 @@ coverage:
     project: off
     patch:
       default:
-        informational: true
         target: 100%
-comment:
-  require_changes: true  # comment only if the coverage changes

--- a/esmvalcore/_config/_config.py
+++ b/esmvalcore/_config/_config.py
@@ -61,8 +61,7 @@ def read_config_user_file(config_file, folder_name, options=None):
     """Read config user file and store settings in a dictionary."""
     if not config_file:
         config_file = '~/.esmvaltool/config-user.yml'
-    config_file = os.path.abspath(
-        os.path.expandvars(os.path.expanduser(config_file)))
+    config_file = _normalize_path(config_file)
     # Read user config file
     if not os.path.exists(config_file):
         print(f"ERROR: Config file {config_file} does not exist")
@@ -135,6 +134,7 @@ def read_config_user_file(config_file, folder_name, options=None):
 
     cfg['config_developer_file'] = _normalize_path(
         cfg['config_developer_file'])
+    cfg['config_user_file'] = config_file
 
     for key in cfg['rootpath']:
         root = cfg['rootpath'][key]

--- a/esmvalcore/_config/_config.py
+++ b/esmvalcore/_config/_config.py
@@ -134,7 +134,7 @@ def read_config_user_file(config_file, folder_name, options=None):
 
     cfg['config_developer_file'] = _normalize_path(
         cfg['config_developer_file'])
-    cfg['config_user_file'] = config_file
+    cfg['config_file'] = config_file
 
     for key in cfg['rootpath']:
         root = cfg['rootpath'][key]

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -380,7 +380,7 @@ class ESMValTool():
 
         # log header
         logger.info(HEADER)
-        logger.info("Using config file %s", cfg['config_user_file'])
+        logger.info("Using config file %s", cfg['config_file'])
         logger.info("Writing program log files to:\n%s", "\n".join(log_files))
 
         cfg['skip-nonexistent'] = skip_nonexistent

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -380,12 +380,7 @@ class ESMValTool():
 
         # log header
         logger.info(HEADER)
-
-        if config_file is not None:
-            logger.info("Using config file %s", config_file)
-        else:
-            logger.info("Attempting to use default config file from "
-                        "$HOME/.esmvaltool/config-user.yml")
+        logger.info("Using config file %s", cfg['config_user_file'])
         logger.info("Writing program log files to:\n%s", "\n".join(log_files))
 
         cfg['skip-nonexistent'] = skip_nonexistent

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -381,7 +381,11 @@ class ESMValTool():
         # log header
         logger.info(HEADER)
 
-        logger.info("Using config file %s", config_file)
+        if config_file is not None:
+            logger.info("Using config file %s", config_file)
+        else:
+            logger.info("Attempting to use default config file from "
+                        "$HOME/.esmvaltool/config-user.yml")
         logger.info("Writing program log files to:\n%s", "\n".join(log_files))
 
         cfg['skip-nonexistent'] = skip_nonexistent

--- a/esmvalcore/_recipe_checks.py
+++ b/esmvalcore/_recipe_checks.py
@@ -61,6 +61,8 @@ def recipe_with_schema(filename):
 
 def diagnostics(diags):
     """Check diagnostics in recipe."""
+    if diags is None:
+        raise RecipeError('The given recipe does not have any diagnostic.')
     for name, diagnostic in diags.items():
         if 'scripts' not in diagnostic:
             raise RecipeError(

--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -36,19 +36,21 @@ profile_diagnostic: false
 # Rootpaths to the data from different projects (lists are also possible)
 # these are generic entries to better allow you to enter your own
 # For site-specific entries, see below
-# rootpath:
-#   CMIP5: [~/cmip5_inputpath1, ~/cmip5_inputpath2]
-#   OBS: ~/obs_inputpath
-#   RAWOBS: ~/rawobs_inputpath
-#   default: ~/default_inputpath
-#   CORDEX: ~/default_inputpath
+# Comment out these when using a site-specific path
+rootpath:
+  CMIP5: [~/cmip5_inputpath1, ~/cmip5_inputpath2]
+  OBS: ~/obs_inputpath
+  RAWOBS: ~/rawobs_inputpath
+  default: ~/default_inputpath
+  CORDEX: ~/default_inputpath
 
 # Directory structure for input data: [default]/BADC/DKRZ/ETHZ/etc
 # See config-developer.yml for definitions.
-# drs:
-#   CMIP5: default
-#   CORDEX: default
-#   OBS: default
+# comment out/replace as per needed
+drs:
+  CMIP5: default
+  CORDEX: default
+  OBS: default
 
 # Site-specific entries: Jasmin
 # Uncomment the lines below to locate data on JASMIN

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -75,7 +75,7 @@ def test_actual_run(tmp_path):
     recipe_file.write_text(content)
     os.system(f'esmvaltool config get_config_user --path {tmp_path}')
     os.system(f"esmvaltool run {recipe_file} "
-              f"--config_file={tmp_path}/config_user.yml")
+              f"--config_file={tmp_path}/config-user.yml")
     log_dir = './esmvaltool_output'
     log_file = os.path.join(log_dir,
                             os.listdir(log_dir)[0], 'run', 'main_log.txt')

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -3,11 +3,12 @@ Tests for ESMValTool CLI
 
 Includes a context manager to temporarly modify sys.argv
 """
-
 import contextlib
 import copy
 import functools
+import os
 import sys
+from textwrap import dedent
 from unittest.mock import patch
 
 import pytest
@@ -58,8 +59,32 @@ def test_run():
         run()
 
 
+def test_actual_run(tmp_path):
+    """Test run from command line in full."""
+    recipe_file = tmp_path / "recipe.yml"
+    content = dedent("""
+        documentation:
+          description: This is a test recipe.
+          authors:
+            - andela_bouwe
+          references:
+            - contact_authors
+            - acknow_project
+          projects:
+            - c3s-magic
+    """)
+    recipe_file.write_text(content)
+    os.system("esmvaltool run %s" % recipe_file)
+    log_dir = './esmvaltool_output'
+    log_file = os.path.join(log_dir,
+                            os.listdir(log_dir)[0], 'run', 'main_log.txt')
+    os.system("rm -r esmvaltool_output")
+
+    assert log_file
+
+
 @patch('esmvalcore._main.ESMValTool.run', new=wrapper(ESMValTool.run))
-def test_tun_with_config():
+def test_run_with_config():
     with arguments('esmvaltool', 'run', 'recipe.yml', '--config_file',
                    'config.yml'):
         run()

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -74,6 +74,7 @@ def test_actual_run(tmp_path):
             - c3s-magic
     """)
     recipe_file.write_text(content)
+    os.system('esmvaltool config get_config_user')
     os.system("esmvaltool run %s" % recipe_file)
     log_dir = './esmvaltool_output'
     log_file = os.path.join(log_dir,

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,7 +1,6 @@
-"""
-Tests for ESMValTool CLI
+"""Tests for ESMValTool CLI.
 
-Includes a context manager to temporarly modify sys.argv
+Includes a context manager to temporarily modify sys.argv
 """
 import contextlib
 import copy
@@ -44,7 +43,7 @@ def test_setargs():
 
 @patch('esmvalcore._main.ESMValTool.version', new=wrapper(ESMValTool.version))
 def test_version():
-    """Test version command"""
+    """Test version command."""
     with arguments('esmvaltool', 'version'):
         run()
     with arguments('esmvaltool', 'version', '--extra_parameter=asterisk'):
@@ -54,7 +53,7 @@ def test_version():
 
 @patch('esmvalcore._main.ESMValTool.run', new=wrapper(ESMValTool.run))
 def test_run():
-    """Test version command"""
+    """Test version command."""
     with arguments('esmvaltool', 'run', 'recipe.yml'):
         run()
 
@@ -74,8 +73,9 @@ def test_actual_run(tmp_path):
             - c3s-magic
     """)
     recipe_file.write_text(content)
-    os.system('esmvaltool config get_config_user')
-    os.system("esmvaltool run %s" % recipe_file)
+    os.system(f'esmvaltool config get_config_user --path {tmp_path}')
+    os.system(f"esmvaltool run {recipe_file} "
+              f"--config_file={tmp_path}/config_user.yml")
     log_dir = './esmvaltool_output'
     log_file = os.path.join(log_dir,
                             os.listdir(log_dir)[0], 'run', 'main_log.txt')
@@ -137,7 +137,7 @@ def test_run_fails_with_other_params():
 
 
 def test_recipes_get(tmp_path, monkeypatch):
-    """Test version command"""
+    """Test version command."""
     src_recipe = tmp_path / 'recipe.yml'
     src_recipe.touch()
     tgt_dir = tmp_path / 'test'
@@ -150,14 +150,14 @@ def test_recipes_get(tmp_path, monkeypatch):
 
 @patch('esmvalcore._main.Recipes.list', new=wrapper(Recipes.list))
 def test_recipes_list():
-    """Test version command"""
+    """Test version command."""
     with arguments('esmvaltool', 'recipes', 'list'):
         run()
 
 
 @patch('esmvalcore._main.Recipes.list', new=wrapper(Recipes.list))
 def test_recipes_list_do_not_admit_parameters():
-    """Test version command"""
+    """Test version command."""
     with arguments('esmvaltool', 'recipes', 'list', 'parameter'):
         with pytest.raises(FireExit):
             run()
@@ -166,7 +166,7 @@ def test_recipes_list_do_not_admit_parameters():
 @patch('esmvalcore._main.Config.get_config_developer',
        new=wrapper(Config.get_config_developer))
 def test_get_config_developer():
-    """Test version command"""
+    """Test version command."""
     with arguments('esmvaltool', 'config', 'get_config_developer'):
         run()
 
@@ -174,13 +174,13 @@ def test_get_config_developer():
 @patch('esmvalcore._main.Config.get_config_user',
        new=wrapper(Config.get_config_user))
 def test_get_config_user():
-    """Test version command"""
+    """Test version command."""
     with arguments('esmvaltool', 'config', 'get_config_user'):
         run()
 
 
 def test_get_config_user_path(tmp_path):
-    """Test version command"""
+    """Test version command."""
     with arguments('esmvaltool', 'config', 'get_config_user',
                    f'--path={tmp_path}'):
         run()
@@ -188,7 +188,7 @@ def test_get_config_user_path(tmp_path):
 
 
 def test_get_config_user_overwrite(tmp_path):
-    """Test version command"""
+    """Test version command."""
     config_user = tmp_path / 'config-user.yml'
     config_user.touch()
     with arguments('esmvaltool', 'config', 'get_config_user',
@@ -199,7 +199,7 @@ def test_get_config_user_overwrite(tmp_path):
 @patch('esmvalcore._main.Config.get_config_user',
        new=wrapper(Config.get_config_user))
 def test_get_config_user_bad_option_fails():
-    """Test version command"""
+    """Test version command."""
     with arguments('esmvaltool', 'config', 'get_config_user',
                    '--bad_option=path'):
         with pytest.raises(FireExit):

--- a/tests/unit/experimental/test_config.py
+++ b/tests/unit/experimental/test_config.py
@@ -237,6 +237,14 @@ def test_config_update():
         config.update(fail_dict)
 
 
+def test_set_bad_item():
+    config = Config({'output_dir': 'config'})
+    with pytest.raises(InvalidConfigParameter) as err_exc:
+        config['bad_item'] = 47
+
+    assert str(err_exc.value) == '`bad_item` is not a valid config parameter.'
+
+
 def test_config_init():
     config = Config()
     assert isinstance(config, MutableMapping)
@@ -249,4 +257,4 @@ def test_session():
     assert session == config
 
     session['output_dir'] = 'session'
-    session != config
+    assert session != config


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

When there is no user-specified config-user file, the info stdout says Using config file None, which is both untrue and user confusing, even though the actual value is indeed `None`

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValTool/issues/2235

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
