### PR TITLE
Better logging for package versions

### DIFF
--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -46,13 +46,12 @@ ______________________________________________________________________
 """ + __doc__
 
 
-def process_recipe(recipe_file, config_user):
+def process_recipe(recipe_file, config_user, packages):
     """Process recipe."""
     import datetime
     import os
     import shutil
 
-    from . import __version__
     from ._recipe import read_recipe_file
     if not os.path.isfile(recipe_file):
         import errno
@@ -63,8 +62,8 @@ def process_recipe(recipe_file, config_user):
     timestamp_format = "%Y-%m-%d %H:%M:%S"
 
     logger.info(
-        "Starting the Earth System Model Evaluation Tool v%s at time: %s UTC",
-        __version__, timestamp1.strftime(timestamp_format))
+        "Starting the Earth System Model Evaluation Tool at time: %s UTC",
+        timestamp1.strftime(timestamp_format))
 
     logger.info(70 * "-")
     logger.info("RECIPE   = %s", recipe_file)
@@ -107,8 +106,8 @@ def process_recipe(recipe_file, config_user):
     # End time timing
     timestamp2 = datetime.datetime.utcnow()
     logger.info(
-        "Ending the Earth System Model Evaluation Tool v%s at time: %s UTC",
-        __version__, timestamp2.strftime(timestamp_format))
+        "Ending the Earth System Model Evaluation Tool at time: %s UTC",
+        timestamp2.strftime(timestamp_format))
     logger.info("Time for running the recipe was: %s", timestamp2 - timestamp1)
 
 
@@ -118,7 +117,6 @@ class Config():
     This group contains utilities to manage ESMValTool configuration
     files.
     """
-
     @staticmethod
     def _copy_config_file(filename, overwrite, path):
         import os
@@ -189,7 +187,6 @@ class Recipes():
     Documentation for recipes included with ESMValTool is available at
     https://docs.esmvaltool.org/en/latest/recipes/index.html.
     """
-
     @staticmethod
     def list():
         """List all installed recipes.
@@ -277,7 +274,6 @@ class ESMValTool():
     To report issues or ask for improvements, please visit
     https://github.com/ESMValGroup/ESMValTool.
     """
-
     def __init__(self):
         self.recipes = Recipes()
         self.config = Config()
@@ -303,8 +299,8 @@ class ESMValTool():
         for project, version in self._extra_packages.items():
             print(f'{project}: {version}')
 
-    @staticmethod
-    def run(recipe,
+    def run(self,
+            recipe,
             config_file=None,
             max_datasets=None,
             max_years=None,
@@ -349,6 +345,7 @@ class ESMValTool():
         import os
         import shutil
 
+        from . import __version__
         from ._config import (
             DIAGNOSTICS,
             configure_logging,
@@ -380,6 +377,12 @@ class ESMValTool():
 
         # log header
         logger.info(HEADER)
+        logger.info('Package versions')
+        logger.info('----------------')
+        logger.info(f'ESMValCore: {__version__}')
+        for project, version in self._extra_packages.items():
+            logger.info('%s: %s', project, version)
+        logger.info('----------------')
         logger.info("Using config file %s", cfg['config_file'])
         logger.info("Writing program log files to:\n%s", "\n".join(log_files))
 
@@ -406,7 +409,9 @@ class ESMValTool():
         resource_log = os.path.join(cfg['run_dir'], 'resource_usage.txt')
         from ._task import resource_usage_logger
         with resource_usage_logger(pid=os.getpid(), filename=resource_log):
-            process_recipe(recipe_file=recipe, config_user=cfg)
+            process_recipe(recipe_file=recipe,
+                           config_user=cfg,
+                           packages=self._extra_packages)
 
         if os.path.exists(cfg["preproc_dir"]) and cfg["remove_preproc_dir"]:
             logger.info("Removing preproc containing preprocessed data")

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -77,7 +77,8 @@ def test_empty_run(tmp_path):
     recipe_file.write_text(content)
     Config.get_config_user(path=tmp_path)
     with pytest.raises(check.RecipeError) as exc:
-        ESMValTool.run(recipe_file, config_file=f"{tmp_path}/config-user.yml")
+        ESMValTool().run(recipe_file,
+                         config_file=f"{tmp_path}/config-user.yml")
     assert str(exc.value) == 'The given recipe does not have any diagnostic.'
     log_dir = './esmvaltool_output'
     log_file = os.path.join(log_dir,


### PR DESCRIPTION
This PR changes the way the version of the tool is displayed on the log to show versions for both ESMValCore and ESMValTool (and any potential new packages). It also displays them more prominently.

A sample:
```

For further help, please read the documentation at
http://docs.esmvaltool.org. Have fun!

2021-08-03 10:33:00,711 UTC [22022] INFO    Package versions
2021-08-03 10:33:00,712 UTC [22022] INFO    ----------------
2021-08-03 10:33:00,712 UTC [22022] INFO    ESMValCore: 2.3.1
2021-08-03 10:33:00,712 UTC [22022] INFO    ESMValTool: 2.3.0
2021-08-03 10:33:00,712 UTC [22022] INFO    ----------------
2021-08-03 10:33:00,712 UTC [22022] INFO    Using config file /home/jvegas/.esmvaltool/config-user.yml
2021-08-03 10:33:00,713 UTC [22022] INFO    Writing program log files to:
```


Closes #1260 

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
