### PR TITLE
Machine-specific directories for auxiliary data in the `config-user.yml` file

### DIFF
--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -128,7 +128,12 @@ Python toolkits, such as cartopy, will attempt to download data files at run
 time, typically geographic data files such as coastlines or land surface maps.
 This can fail if the machine does not have access to the wider internet. This
 location allows the user to specify where to find such files if they can not be
-downloaded at runtime.
+downloaded at runtime. The example user configuration file already contains two valid
+locations for ``auxiliary_data_dir`` directories on CEDA-JASMIN and DKRZ, and a number
+of such maps and shapefiles (used by current diagnostics) are already there. You will
+need ``esmeval`` group workspace membership to access the JASMIN one (see
+`instructions <https://help.jasmin.ac.uk/article/199-introduction-to-group-workspaces>`_
+how to gain access to the group workspace.
 
 .. warning::
 

--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -54,7 +54,7 @@ drs:
 
 # Site-specific entries: Jasmin
 # Uncomment the lines below to locate data on JASMIN
-# auxiliary_data_dir: /gws/nopw/j04/esmeval/aux_data/AUX
+#auxiliary_data_dir: /gws/nopw/j04/esmeval/aux_data/AUX
 #rootpath:
 #  CMIP6: /badc/cmip6/data/CMIP6
 #  CMIP5: /badc/cmip5/data/cmip5/output1
@@ -76,7 +76,7 @@ drs:
 
 # Site-specific entries: DKRZ
 # Uncomment the lines below to locate data on Mistral at DKRZ
-# auxiliary_data_dir: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/AUX
+#auxiliary_data_dir: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/AUX
 #rootpath:
 #  CMIP6: /mnt/lustre02/work/ik1017/CMIP6/data/CMIP6
 #  CMIP5: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/CMIP5_DKRZ

--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -11,11 +11,6 @@ output_file_type: png
 # Destination directory
 output_dir: ./esmvaltool_output
 # Auxiliary data directory (used for some additional datasets)
-# Jasmin
-# auxiliary_data_dir: /gws/nopw/j04/esmeval/aux_data/AUX
-# Mistral
-# auxiliary_data_dir: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/AUX
-# default
 auxiliary_data_dir: ./auxiliary_data
 # Use netCDF compression true/[false]
 compress_netcdf: false
@@ -59,6 +54,7 @@ drs:
 
 # Site-specific entries: Jasmin
 # Uncomment the lines below to locate data on JASMIN
+# auxiliary_data_dir: /gws/nopw/j04/esmeval/aux_data/AUX
 #rootpath:
 #  CMIP6: /badc/cmip6/data/CMIP6
 #  CMIP5: /badc/cmip5/data/cmip5/output1
@@ -80,6 +76,7 @@ drs:
 
 # Site-specific entries: DKRZ
 # Uncomment the lines below to locate data on Mistral at DKRZ
+# auxiliary_data_dir: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/AUX
 #rootpath:
 #  CMIP6: /mnt/lustre02/work/ik1017/CMIP6/data/CMIP6
 #  CMIP5: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/CMIP5_DKRZ

--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -11,6 +11,11 @@ output_file_type: png
 # Destination directory
 output_dir: ./esmvaltool_output
 # Auxiliary data directory (used for some additional datasets)
+# Jasmin
+# auxiliary_data_dir: /gws/nopw/j04/esmeval/aux_data/AUX
+# Mistral
+# auxiliary_data_dir: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/AUX
+# default
 auxiliary_data_dir: ./auxiliary_data
 # Use netCDF compression true/[false]
 compress_netcdf: false


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description
This PR adds a path for the `auxiliary_data_dir` on Jasmin and Mistral. These are included in the "lines to uncomment" for each of the two machines. Not sure if these paths would be better placed below 
```yaml
# Auxiliary data directory (used for some additional datasets)
auxiliary_data_dir: ./auxiliary_data
```
<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1266 

Link to documentation: [https://docs.esmvaltool.org/projects/ESMValCore/en/latest/quickstart/configure.html?highlight=auxiliary#user-configuration-file](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/quickstart/configure.html?highlight=auxiliary#user-configuration-file)

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- ~~[ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added~~
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- ~~[ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~~
- ~~[ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date~~
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
