### PR TITLE
Fix numpy deprecation warnings

### DIFF
--- a/tests/integration/preprocessor/_regrid/test_extract_point.py
+++ b/tests/integration/preprocessor/_regrid/test_extract_point.py
@@ -19,7 +19,7 @@ class Test(tests.Test):
         """Prepare tests."""
         shape = (3, 4, 4)
         data = np.arange(np.prod(shape)).reshape(shape)
-        self.cube = _make_cube(data, dtype=np.float)
+        self.cube = _make_cube(data, dtype=np.float64)
         self.cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
 
     def test_extract_point__single_linear(self):
@@ -65,7 +65,7 @@ class Test(tests.Test):
         # Test two points outside the valid area
         point = extract_point(self.cube, -1, -1, scheme='nearest')
         self.assertEqual(point.shape, (3,))
-        masked = np.ma.array(np.empty(3, dtype=np.float), mask=True)
+        masked = np.ma.array(np.empty(3, dtype=np.float64), mask=True)
         self.assert_array_equal(point.data, masked)
 
         point = extract_point(self.cube, 30, 30, scheme='nearest')
@@ -105,7 +105,7 @@ class Test(tests.Test):
         point = extract_point(self.cube, [0, 10], 3,
                               scheme='linear')
         self.assertEqual(point.shape, (3, 2))
-        masked = np.ma.array(np.empty((3, 2), dtype=np.float), mask=True)
+        masked = np.ma.array(np.empty((3, 2), dtype=np.float64), mask=True)
         self.assert_array_equal(point.data, masked)
         coords = self.cube.coords(dim_coords=True)
         point = extract_point(self.cube, 2, [0, 10],
@@ -135,7 +135,7 @@ class Test(tests.Test):
                                                 [44, 44, 44, 45, 45, 47]])
         point = extract_point(self.cube, [0, 10], 3,
                               scheme='nearest')
-        masked = np.ma.array(np.empty((3, 2), dtype=np.float), mask=True)
+        masked = np.ma.array(np.empty((3, 2), dtype=np.float64), mask=True)
         self.assertEqual(point.shape, (3, 2))
         self.assert_array_equal(point.data, masked)
         point = extract_point(self.cube, 2, [0, 10],
@@ -150,7 +150,7 @@ class Test(tests.Test):
                               [0, 1.1, 1.5, 1.51, 4, 5], scheme='linear')
         self.assertEqual(point.data.shape, (3, 6, 6))
 
-        result = np.ma.array(np.empty((3, 6, 6), dtype=np.float), mask=True)
+        result = np.ma.array(np.empty((3, 6, 6), dtype=np.float64), mask=True)
         result[0, 1, 1:5] = [0.5, 0.9, 0.91, 3.4]
         result[0, 2, 1:5] = [2.1, 2.5, 2.51, 5.0]
         result[0, 3, 1:5] = [2.14, 2.54, 2.55, 5.04]
@@ -178,7 +178,7 @@ class Test(tests.Test):
                               [0, 1.1, 1.5, 1.51, 4, 5], scheme='nearest')
         self.assertEqual(point.data.shape, (3, 6, 6))
 
-        result = np.ma.array(np.empty((3, 6, 6), dtype=np.float), mask=True)
+        result = np.ma.array(np.empty((3, 6, 6), dtype=np.float64), mask=True)
         result[0, 1, 1:5] = [0.0, 0.0, 1.0, 3.0]
         result[0, 2, 1:5] = [0.0, 0.0, 1.0, 3.0]
         result[0, 3, 1:5] = [4.0, 4.0, 5.0, 7.0]


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->
Fix the numpy deprecation warnings coming from tests/integration/preprocessor/_regrid/test_extract_point.py:

```
tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__multiple_both_linear
tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__multiple_both_nearest
tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__multiple_linear
tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__multiple_nearest
tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__single_linear
tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__single_nearest
  /develop/tests/integration/preprocessor/_regrid/test_extract_point.py:22: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__multiple_both_linear
  /develop/tests/integration/preprocessor/_regrid/test_extract_point.py:153: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__multiple_both_nearest
  /develop/tests/integration/preprocessor/_regrid/test_extract_point.py:181: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__multiple_linear
  /develop/tests/integration/preprocessor/_regrid/test_extract_point.py:108: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__multiple_nearest
  /develop/tests/integration/preprocessor/_regrid/test_extract_point.py:138: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

tests/integration/preprocessor/_regrid/test_extract_point.py::Test::test_extract_point__single_nearest
  /develop/tests/integration/preprocessor/_regrid/test_extract_point.py:68: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ x [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
