### PR TITLE
Remove history attribute from coords

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -100,10 +100,10 @@ def concatenate_callback(raw_cube, field, _):
         _delete_attributes(coord, ('history', ))
 
 
-def _delete_attributes(object, attrs):
-    for attr in attrs:
-        if attr in object.attributes:
-            del object.attributes[attr]
+def _delete_attributes(iris_object, atts):
+    for att in atts:
+        if att in iris_object.attributes:
+            del iris_object.attributes[att]
 
 
 def load(file, callback=None):
@@ -231,6 +231,9 @@ def save(cubes,
 
     compress: bool, optional
         Use NetCDF internal compression.
+
+    alias: str, optional
+        Var name to use when saving instead of the one in the cube.
 
     Returns
     -------

--- a/tests/integration/preprocessor/_io/test_load.py
+++ b/tests/integration/preprocessor/_io/test_load.py
@@ -20,7 +20,6 @@ def _create_sample_cube():
 
 class TestLoad(unittest.TestCase):
     """Tests for :func:`esmvalcore.preprocessor.load`."""
-
     def setUp(self):
         """Start tests."""
         self.temp_files = []
@@ -67,6 +66,26 @@ class TestLoad(unittest.TestCase):
                 (cube.coord('latitude').points == np.array([1, 2])).all())
             for attr in attributes:
                 self.assertTrue(attr not in cube.attributes)
+
+    def test_callback_remove_attributes_from_coords(self):
+        """Test callback remove unwanted attributes from coords."""
+        attributes = ('history', )
+        for _ in range(2):
+            cube = _create_sample_cube()
+            for coord in cube.coords():
+                for attr in attributes:
+                    coord.attributes[attr] = attr
+            self._save_cube(cube)
+        for temp_file in self.temp_files:
+            cubes = load(temp_file, callback=concatenate_callback)
+            cube = cubes[0]
+            self.assertEqual(1, len(cubes))
+            self.assertTrue((cube.data == np.array([1, 2])).all())
+            self.assertTrue(
+                (cube.coord('latitude').points == np.array([1, 2])).all())
+            for coord in cube.coords():
+                for attr in attributes:
+                    self.assertTrue(attr not in cube.attributes)
 
     def test_callback_fix_lat_units(self):
         """Test callback for fixing units."""


### PR DESCRIPTION
I found an EC-Earth experiment at BSC that has the `history` attribute at the coords and not only in the cube. It was added in the CMORization process to keep track of the changes done to that coordinate. I am not sure if this is something particular of ec2cmor or if this is coming directly from the cmor library.

I extended the automatic removal of the history attribute to the coordinates to automatically fix it

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
