### PR TITLE
Synda query for cordex regional datasets

### DIFF
--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -236,7 +236,7 @@ CORDEX:
     spec: '{domain}/{institute}/{driver}/{exp}/{ensemble}/{dataset}/{rcm_version}/{mip}/{short_name}'
     BADC: '{domain}/{institute}/{driver}/{exp}/{ensemble}/{dataset}/{rcm_version}/{mip}/{short_name}/{latestversion}'
   input_file: '{short_name}_{domain}_{driver}_{exp}_{ensemble}_{dataset}_{rcm_version}_{mip}*.nc'
-  output_file: '{short_name}_{dataset}_{exp}_{ensemble}_{rcm_version}_{mip}'
+  output_file: '{short_name}_{domain}_{driver}_{dataset}_{exp}_{ensemble}_{rcm_version}_{frequency}'
   cmor_type: 'CMIP5'
   cmor_path: 'cordex'
 

--- a/esmvalcore/preprocessor/_download.py
+++ b/esmvalcore/preprocessor/_download.py
@@ -37,7 +37,7 @@ def _synda_search_cmd(variable):
             'rcm_name' :  variable.get('rcm_name'),
             'rcm_version' : variable.get('rcm_version'),
             'project': variable.get('project'),
-            'frequency': variable.get('frequency'),
+            'frequency': variable.get('mip'),
             'ensemble': variable.get('ensemble'),
             'experiment': variable.get('exp'),
             'variable': variable.get('short_name'),

--- a/esmvalcore/preprocessor/_download.py
+++ b/esmvalcore/preprocessor/_download.py
@@ -31,6 +31,19 @@ def _synda_search_cmd(variable):
             'variant_label': variable.get('ensemble'),
             'grid_label': variable.get('grid'),
         }
+    elif project == "CORDEX":
+        query = {
+            'institute':  variable.get('institute'),
+            'rcm_name' :  variable.get('rcm_name'),
+            'rcm_version' : variable.get('rcm_version'),
+            'project': variable.get('project'),
+            'frequency': variable.get('frequency'),
+            'ensemble': variable.get('ensemble'),
+            'experiment': variable.get('exp'),
+            'variable': variable.get('short_name'),
+            'domain' : variable.get('domain'),
+            'driving_model' : variable.get('driver')
+        }
     else:
         raise NotImplementedError(
             f"Unknown project {project}, unable to download data.")


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description
Hi everybody with this new PR I'm going to propose an enhancement for preprocessor module. In order to make ESMValtool able to retrieve Euro-Cordex datasets from ESGF nodes by Synda,  I have added an `elif` block to implement this feature. I tested this implementation to retrieve 13 Euro-Cordex datasets, it works fine.  
This is an example of query to include in a recipe:
```yaml
datasets:
    - { project: CORDEX,
        variable : pr ,
        domain: EUR-11,
        driver: ICHEC-EC-EARTH,
        exp: historical,
        ensemble: r12i1p1,
        institute: CLMcom,
        rcm_name: CCLM4-8-17,
        dataset: CLMcom-CCLM4-8-17,
        rcm_version: v1,
        mip: day,
        start_year: 1949,
        end_year: 1955
        }
```

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
