### PR TITLE
Run the multimodel statistics preprocessor last

### DIFF
--- a/doc/api/esmvalcore.preprocessor.rst
+++ b/doc/api/esmvalcore.preprocessor.rst
@@ -3,6 +3,5 @@
 Preprocessor functions
 ======================
 
-By default, preprocessor functions are applied in the order in which they are listed here.
-
+.. autodata:: esmvalcore.preprocessor.DEFAULT_ORDER
 .. automodule:: esmvalcore.preprocessor

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -134,7 +134,6 @@ __all__ = [
     # 'average_zone': average_zone,
     # 'cross_section': cross_section,
     'detrend',
-    'multi_model_statistics',
     # Grid-point operations
     'extract_named_regions',
     'depth_integration',
@@ -158,7 +157,10 @@ __all__ = [
     'timeseries_filter',
     'linear_trend',
     'linear_trend_stderr',
+    # Convert units
     'convert_units',
+    # Multi model statistics
+    'multi_model_statistics',
     # Remove fx_variables from cube
     'remove_fx_variables',
     # Save to file
@@ -182,6 +184,9 @@ TIME_PREPROCESSORS = [
 ]
 
 DEFAULT_ORDER = tuple(__all__)
+"""
+By default, preprocessor functions are applied in this order.
+"""
 
 # The order of initial and final steps cannot be configured
 INITIAL_STEPS = DEFAULT_ORDER[:DEFAULT_ORDER.index('add_fx_variables') + 1]
@@ -231,7 +236,8 @@ def check_preprocessor_settings(settings):
                 "function {}".format(missing_args, step))
         # Final sanity check in case the above fails to catch a mistake
         try:
-            inspect.getcallargs(function, None, **settings[step])
+            signature = inspect.Signature.from_callable(function)
+            signature.bind_partial(**settings[step])
         except TypeError:
             logger.error(
                 "Wrong preprocessor function arguments in "
@@ -249,7 +255,7 @@ def _check_multi_model_settings(products):
             settings = product.settings.get(step)
             if settings is None:
                 continue
-            elif reference is None:
+            if reference is None:
                 reference = product
             elif reference.settings[step] != settings:
                 raise ValueError(
@@ -324,6 +330,7 @@ def get_step_blocks(steps, order):
 
 class PreprocessorFile(TrackedFile):
     """Preprocessor output file."""
+
     def __init__(self, attributes, settings, ancestors=None):
         super(PreprocessorFile, self).__init__(attributes['filename'],
                                                attributes, ancestors)
@@ -429,6 +436,7 @@ def _apply_multimodel(products, step, debug):
 
 class PreprocessingTask(BaseTask):
     """Task for running the preprocessor."""
+
     def __init__(
         self,
         products,

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -237,7 +237,7 @@ def check_preprocessor_settings(settings):
         # Final sanity check in case the above fails to catch a mistake
         try:
             signature = inspect.Signature.from_callable(function)
-            signature.bind_partial(**settings[step])
+            signature.bind(None, **settings[step])
         except TypeError:
             logger.error(
                 "Wrong preprocessor function arguments in "

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1038,11 +1038,11 @@ def test_custom_preproc_order(tmp_path, patched_datafinder, config_user):
     content = dedent("""
         preprocessors:
           default: &default
-            area_statistics:
-              operator: mean
             multi_model_statistics:
               span: overlap
               statistics: [mean ]
+            area_statistics:
+              operator: mean
           custom:
             custom_order: true
             <<: *default
@@ -1090,10 +1090,10 @@ def test_custom_preproc_order(tmp_path, patched_datafinder, config_user):
 
     for task in recipe.tasks:
         if task.name == 'diagnostic_name/chl_default':
-            assert task.order.index('area_statistics') > task.order.index(
+            assert task.order.index('area_statistics') < task.order.index(
                 'multi_model_statistics')
         elif task.name == 'diagnostic_name/chl_custom':
-            assert task.order.index('area_statistics') < task.order.index(
+            assert task.order.index('area_statistics') > task.order.index(
                 'multi_model_statistics')
         elif task.name == 'diagnostic_name/chl_empty_custom':
             assert len(task.products) == 1


### PR DESCRIPTION
 Move multimodel statistics preprocessor function to the end of the default order.

Some formatting issues and the use of a deprecated Python standard library function are also fixed in this pull request.

<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1221

Link to documentation: https://esmvaltool--1299.org.readthedocs.build/projects/ESMValCore/en/1299/api/esmvalcore.preprocessor.html

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] ~Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
