### PR TITLE
Fix DRS for IPSLCM : split attribute 'freq' into : 'out' and 'freq'

### DIFF
--- a/doc/develop/fixing_data.rst
+++ b/doc/develop/fixing_data.rst
@@ -381,10 +381,10 @@ formats) are supported, and should be configured in recipes as e.g.:
 .. code-block:: yaml
 
   datasets:
-    - {simulation: CM61-LR-hist-03.1950, exp: piControl, freq: Analyse/TS_MO,
+    - {simulation: CM61-LR-hist-03.1950, exp: piControl, out: Analyse, freq: TS_MO,
        account: p86caub,  status: PROD, dataset: IPSL-CM6, project: IPSLCM,
        root: /thredds/tgcc/store}
-    - {simulation: CM61-LR-hist-03.1950, exp: historical, freq: Output/MO,
+    - {simulation: CM61-LR-hist-03.1950, exp: historical, out: Output, freq: MO,
        account: p86caub,  status: PROD, dataset: IPSL-CM6, project: IPSLCM,
        root: /thredds/tgcc/store}
 

--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -243,7 +243,7 @@ CORDEX:
 IPSLCM:
   cmor_strict: false
   input_dir:
-    default: '{root}/{account}/{model}/{status}/{exp}/{simulation}/{dir}/{freq}'
+    default: '{root}/{account}/{model}/{status}/{exp}/{simulation}/{dir}/{out}/{freq}'
   input_file:
     default:
       - '{simulation}_*_{ipsl_varname}.nc'


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

    For datasets using project ISLCM, instead of writing e.g. :
      `out: Analyse/TS_MO'`
    one should now write :
      `out: Analyse, freq: TS_MO`

    This is mainly in order to avoid side effects when creating output
    directories based on attributes value

Link to documentation: https://esmvaltool--1304.org.readthedocs.build/projects/ESMValCore/en/1304/develop/fixing_data.html#ipsl-cm6

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do : Not done because assume interested individuals are very few

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance). 
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available : Yes,, applies to technical doc only, see https://esmvaltool--1304.org.readthedocs.build/projects/ESMValCore/en/1304/develop/fixing_data.html#ipsl-cm6
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added. No
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility). No (recipes have to be modified if they use project IPSLCM), but user base for this feature is still small and limited to IPSL, and the information will be forwarded 
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly. N/A
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
