### PR TITLE
No longer embed provenance in output files

### DIFF
--- a/esmvalcore/_provenance.py
+++ b/esmvalcore/_provenance.py
@@ -107,7 +107,7 @@ def get_task_provenance(task, recipe_entity):
     return activity
 
 
-class TrackedFile(object):
+class TrackedFile:
     """File with provenance tracking."""
 
     def __init__(self, filename, attributes, ancestors=None):
@@ -205,7 +205,6 @@ class TrackedFile(object):
 
     def _select_for_include(self):
         attributes = {
-            'provenance': self.provenance.serialize(format='xml'),
             'software': "Created with ESMValTool v{}".format(__version__),
         }
         if 'caption' in self.attributes:
@@ -222,7 +221,6 @@ class TrackedFile(object):
     def _include_provenance_png(filename, attributes):
         pnginfo = PngInfo()
         exif_tags = {
-            'provenance': 'ImageHistory',
             'caption': 'ImageDescription',
             'software': 'Software',
         }
@@ -235,17 +233,11 @@ class TrackedFile(object):
         """Include provenance information as metadata."""
         attributes = self._select_for_include()
 
-        # List of files to attach provenance to
-        files = [self.filename]
-        if 'plot_file' in self.attributes:
-            files.append(self.attributes['plot_file'])
-
         # Attach provenance to supported file types
-        for filename in files:
-            ext = os.path.splitext(filename)[1].lstrip('.').lower()
-            write = getattr(self, '_include_provenance_' + ext, None)
-            if write:
-                write(filename, attributes)
+        ext = os.path.splitext(self.filename)[1].lstrip('.').lower()
+        write = getattr(self, '_include_provenance_' + ext, None)
+        if write:
+            write(self.filename, attributes)
 
     def save_provenance(self):
         """Export provenance information."""

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -257,6 +257,7 @@ def _get_filenames(root_path, filenames, tracking_id):
 
 @pytest.fixture
 def patched_datafinder(tmp_path, monkeypatch):
+
     def tracking_ids(i=0):
         while True:
             yield i
@@ -276,6 +277,7 @@ def patched_datafinder(tmp_path, monkeypatch):
 
 @pytest.fixture
 def patched_failing_datafinder(tmp_path, monkeypatch):
+
     def tracking_ids(i=0):
         while True:
             yield i
@@ -306,6 +308,7 @@ def patched_failing_datafinder(tmp_path, monkeypatch):
 
 @pytest.fixture
 def patched_tas_derivation(monkeypatch):
+
     def get_required(short_name, _):
         if short_name != 'tas':
             assert False
@@ -1417,8 +1420,7 @@ def simulate_diagnostic_run(diagnostic_task):
         p.filename for a in diagnostic_task.ancestors for p in a.products
     ]
     record = {
-        'caption': 'Test plot',
-        'plot_file': create_test_image('test', cfg),
+        'caption': 'Test figure',
         'statistics': ['mean', 'var'],
         'domains': ['trop', 'et'],
         'plot_types': ['zonal'],
@@ -1429,10 +1431,11 @@ def simulate_diagnostic_run(diagnostic_task):
 
     diagnostic_file = get_diagnostic_filename('test', cfg)
     create_test_file(diagnostic_file)
+    plot_file = create_test_image('test', cfg)
     provenance = os.path.join(cfg['run_dir'], 'diagnostic_provenance.yml')
     os.makedirs(cfg['run_dir'])
     with open(provenance, 'w') as file:
-        yaml.safe_dump({diagnostic_file: record}, file)
+        yaml.safe_dump({diagnostic_file: record, plot_file: record}, file)
 
     diagnostic_task._collect_provenance()
     return record
@@ -1479,38 +1482,43 @@ def test_diagnostic_task_provenance(
     simulate_diagnostic_run(next(iter(diagnostic_task.ancestors)))
     record = simulate_diagnostic_run(diagnostic_task)
 
-    # Check resulting product
-    product = diagnostic_task.products.pop()
-    check_provenance(product)
-    for key in ('caption', 'plot_file'):
-        assert product.attributes[key] == record[key]
-        assert product.entity.get_attribute('attribute:' +
-                                            key).pop() == record[key]
+    # Check resulting products
+    assert len(diagnostic_task.products) == 2
+    for product in diagnostic_task.products:
+        check_provenance(product)
+        assert product.attributes['caption'] == record['caption']
+        assert product.entity.get_attribute(
+            'attribute:' + 'caption').pop() == record['caption']
 
-    # Check that diagnostic script tags have been added
-    for key in ('statistics', 'domains', 'authors'):
-        assert product.attributes[key] == tuple(TAGS[key][k]
-                                                for k in record[key])
+        # Check that diagnostic script tags have been added
+        for key in ('statistics', 'domains', 'authors'):
+            assert product.attributes[key] == tuple(TAGS[key][k]
+                                                    for k in record[key])
 
-    # Check that recipe diagnostic tags have been added
-    src = yaml.safe_load(DEFAULT_DOCUMENTATION + content)
-    for key in ('realms', 'themes'):
-        value = src['diagnostics']['diagnostic_name'][key]
-        assert product.attributes[key] == tuple(TAGS[key][k] for k in value)
+        # Check that recipe diagnostic tags have been added
+        src = yaml.safe_load(DEFAULT_DOCUMENTATION + content)
+        for key in ('realms', 'themes'):
+            value = src['diagnostics']['diagnostic_name'][key]
+            assert product.attributes[key] == tuple(TAGS[key][k]
+                                                    for k in value)
 
-    # Check that recipe tags have been added
-    recipe_record = product.provenance.get_record('recipe:recipe_test.yml')
-    assert len(recipe_record) == 1
-    for key in ('description', 'references'):
-        value = src['documentation'][key]
-        if key == 'references':
-            value = str(src['documentation'][key])
-        assert recipe_record[0].get_attribute('attribute:' +
-                                              key).pop() == value
+        # Check that recipe tags have been added
+        recipe_record = product.provenance.get_record('recipe:recipe_test.yml')
+        assert len(recipe_record) == 1
+        for key in ('description', 'references'):
+            value = src['documentation'][key]
+            if key == 'references':
+                value = str(src['documentation'][key])
+            assert recipe_record[0].get_attribute('attribute:' +
+                                                  key).pop() == value
 
     # Test that provenance was saved to netcdf, xml and svg plot
-    cube = iris.load(product.filename)[0]
-    assert 'provenance' in cube.attributes
+    product = next(
+        iter(p for p in diagnostic_task.products
+             if p.filename.endswith('.nc')))
+    cube = iris.load_cube(product.filename)
+    assert cube.attributes['software'].startswith("Created with ESMValTool v")
+    assert cube.attributes['caption'] == record['caption']
     prefix = os.path.splitext(product.filename)[0] + '_provenance'
     assert os.path.exists(prefix + '.xml')
     assert os.path.exists(prefix + '.svg')
@@ -2853,7 +2861,7 @@ def test_unique_fx_var_in_multiple_mips_cmip6(tmp_path,
     sftgif_files = fx_variables['sftgif']['filename']
     assert isinstance(sftgif_files, list)
     assert len(sftgif_files) == 1
-    assert'_LImon_' in sftgif_files[0]
+    assert '_LImon_' in sftgif_files[0]
 
 
 def test_multimodel_mask(tmp_path, patched_datafinder, config_user):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1148

No longer embed provenance in output files.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available -> in a separate pull request: #1305 
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] ~Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
