### PR TITLE
Pin esmpy to anything but 8.1.0 since that particular one changes the CPU affinity

### DIFF
--- a/.github/workflows/action-install-from-source.yml
+++ b/.github/workflows/action-install-from-source.yml
@@ -22,7 +22,7 @@ on:
   push:
     branches:
     - main
-    - unpin_iris
+    - pin_esmpy_affinity
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/action-pypi-build-and-deploy.yml
+++ b/.github/workflows/action-pypi-build-and-deploy.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - pin_esmpy_affinity
 
 jobs:
   build-n-publish:

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - cf-units>=3.0.0
   - compilers
   - fiona  # 1.8.18/py39, they seem weary to build manylinux wheels and pypi ver built with older gdal
-  - esmpy
+  - esmpy!=8.1.0  # see github.com/ESMValGroup/ESMValCore/issues/1208
   - iris>=3.0.2
   - python>=3.7
   - python-stratify

--- a/package/meta.yaml
+++ b/package/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - cftime
     - cf-units>=3.0.0
     - cython  # required by cf-units but not automatically installed
-    - esmpy
+    - esmpy!=8.1.0  # see github.com/ESMValGroup/ESMValCore/issues/1208
     - fiona
     - fire
     - jinja2

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ REQUIREMENTS = {
     'install': [
         'cf-units>=3.0.0',
         'dask[array]',
+        'esmpy!=8.1.0',  # see github.com/ESMValGroup/ESMValCore/issues/1208
         'fiona',
         'fire',
         "importlib_resources;python_version<'3.9'",


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

See the issue and [comment](https://github.com/ESMValGroup/ESMValCore/issues/1208#issuecomment-915175795) for more details, in a nutshell - for some reason `esmf/esmpy=8.1.0` reduces cpu affinity to 0 when running esmvalcore; thanks to @SarahAlidoost for noticing this; 8.1.1 is fine but is yet to be solved for in the conda/mamba environment; 8.0.1 is fine too and it's what esmvaltool currently ingests in the environment 

Closes #1208 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful
**Nope** because the test docker container is prebuilt with `esmpy=8.1.0` actually, but all else passes fine as it should be :+1: 

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
