### PR TITLE
ESMValCore Preprocessor: fixing unmatching attributes in pairwise concatenation.

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -146,7 +146,16 @@ def _by_two_concatenation(cubes):
     concatenated = iris.cube.CubeList(cubes).concatenate()
     if len(concatenated) == 1:
         return concatenated[0]
+    
+    logger.debug("Found unmatching attributes in cubes during pairwise concatenation. I'm trying to equalise them!")
+    cubes_adj = _equalise_attributes(cubes)
+    concatenated = iris.cube.CubeList(cubes_adj).concatenate()
 
+    if len(concatenated) == 1:
+        return concatenated[0]
+
+    logger.debug("Found unmatching attributes in cubes during pairwise concatenation. I'm trying to concatenate it as overlapping cubes.")
+    
     concatenated = _concatenate_overlapping_cubes(concatenated)
     if len(concatenated) == 2:
         _get_concatenation_error(concatenated)
@@ -460,4 +469,85 @@ def _concatenate_overlapping_cubes(cubes):
                     logger.error(cube)
                 raise ex
 
+    return cubes
+
+def _equalise_attributes(cubes_list):
+    """
+    Equalise the attributes of a given cubes_list. It sets up the same value 
+    for common attributes and remove the attributes which don't match.
+    The first cube is taken as reference
+
+    Arguments:
+
+    * cubes_list (iterable of :class:`iris.cube.Cube`):
+        A collection of cubes to compare and adjust.
+    
+    Return:
+    
+    * cubes (iterable of :class:`iris.cube.Cube`):
+        A collection of adjusted cubes.
+    """
+    
+    # create a deepcopy of original data
+    cubes = copy.deepcopy(cubes_list)
+    # Work out which attributes are identical across all the cubes.
+    common_keys = cubes[0].attributes.keys()
+    dtype = cubes[0].dtype
+    for cube in cubes[1:]:
+        cube_keys = cube.attributes.keys()
+        common_keys = [
+            key for key in common_keys
+            if key in cube_keys
+            and np.all(cube.attributes[key] == cubes[0].attributes[key])]
+        # Match data type and fill value to those of first cube.
+        if cube.dtype != dtype:
+            cube.data = cube.data.astype(dtype)
+
+    # Remove all the other attributes.
+    for cube in cubes:
+        for key in cube.attributes.keys():
+            if key not in common_keys:
+                del cube.attributes[key]
+
+    # Iterate for each co-ordinate in first cube.
+    for coord0 in cubes[0].coords():
+        coord_name = coord0.standard_name
+        if coord_name is not None:
+            dtype_points = coord0.points.dtype
+            dtype_bounds = getattr(coord0.bounds, 'dtype', None)
+            long_name = coord0.long_name
+            var_name = coord0.var_name
+            circular = getattr(coord0, 'circular', None)
+            # Work out which attributes are identical (for this co-ordinate)
+            # across all the cubes.
+            common_coord_keys = coord0.attributes.keys()
+            for cube in cubes[1:]:
+                coord = cube.coord(coord_name)
+                cube_coord_keys = coord.attributes.keys()
+                common_coord_keys = [key for key in common_coord_keys if key in
+                                     cube_coord_keys and
+                                     np.all(coord.attributes[key] ==
+                                            coord0.attributes[key])]
+                # Match names and data types to those of coord in first cube.
+                if coord.points.dtype != dtype_points:
+                    coord.points = coord.points.astype(dtype_points,
+                                                       copy=False)
+                d = getattr(coord.bounds, 'dtype', None)
+                if d != dtype_bounds and d is not None:
+                    coord.bounds = coord.bounds.astype(dtype_bounds,
+                                                       copy=False)
+                if coord.long_name != long_name:
+                    coord.long_name = long_name
+                if coord.var_name != var_name:
+                    coord.var_name = var_name
+                if circular is not None and \
+                        getattr(coord, 'circular', None) != circular:
+                    coord.circular = circular
+
+            # Remove all the other attributes (for this co-ordinate).
+            for cube in cubes:
+                coord = cube.coord(coord_name)
+                for key in coord.attributes.keys():
+                    if key not in common_coord_keys:
+                        del coord.attributes[key]
     return cubes


### PR DESCRIPTION
Hi everybody.
I'm submitting this pull request to solve an issue encountered in regional dataset preprocessing.
When a dataset is composed by multiple files, the esmvalcore's preprocessor concatenates the netcdfs by a pairwise concatenation (`_by_two_contatenation` in `esmvalcore/preprocessor/_io.py`). 
For instance if our dataset is splitted in 3 files `file_1994.nc`, `file_1995.nc` and` file_1996.nc`, the preprocessor concatenates the dataset in 2 steps:

1. Concatenate  `file_1994.nc` and `file_1995.nc` into `file_1994_1995.nc`
2. Concatenate `file_1994_1995.nc` and `file_1996.nc` into `file_1994_1995_1996.nc`

Sometimes an attribute (or type) unmatching between `file_1994_1995.nc` and `file_1996.nc` could happen. This could be due to several reasons either iris backend or an error in a dataset. To fix this potential issue I added an `_equalize_attributes` fuction wich tries to equalize the attributes (and types) between each pair of cubes taking the first cube as reference.

I encountered this issue in EUROCORDEX preprocessing. If found a type unmatching in CCLM EUROCORDEX datasets. This issue is still being discussed in this pull request #1068, here the problem seems to be solved in a more accurate way. Anyway I decided  to share the code by this pull requests beacause my solution could be more generic.

Cheers
Francesco 

<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #issue_number

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
