### PR TITLE
Fx files finding: CMIP6: look in experiment=`piControl` as a last measure if fx data is not found

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -437,12 +437,10 @@ def _get_fx_files(variable, fx_info, config_user):
     # Before completely giving up, try looking for fx files in piControl:
     # a lot of CMIP6 models have fx data only in piControl
     if not fx_files:
-        logger.warning("Missing data for fx variable '%s'",
-                       fx_info['short_name'])
         if fx_info['project'] == 'CMIP6':
-            logger.debug(
+            logger.warning(
                 "Missing data for fx variable %s "
-                "and experiment %s; since CMIP6, "
+                "and experiment %s; since data is CMIP6, "
                 "will try experiment piControl, most fx "
                 "stuff is there.", fx_info['short_name'], fx_info['exp'])
             fx_info = dict(fx_info)
@@ -453,6 +451,9 @@ def _get_fx_files(variable, fx_info, config_user):
                     "Failed to find data for CMIP6 fx variable "
                     "%s with experiment "
                     "piControl as well.", fx_info['short_name'])
+        else:
+            logger.warning("Missing data for fx variable '%s'",
+                           fx_info['short_name'])
 
     # If frequency = fx, only allow a single file
     if fx_files:

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -441,16 +441,17 @@ def _get_fx_files(variable, fx_info, config_user):
                        fx_info['short_name'])
         if fx_info['project'] == 'CMIP6':
             logger.debug(
-                f"Missing data for fx variable {fx_info['short_name']} "
-                f"and experiment {fx_info['exp']}; since CMIP6, "
-                f"will try experiment piControl, most fx stuff is there.")
+                "Missing data for fx variable %s "
+                "and experiment %s; since CMIP6, "
+                "will try experiment piControl, most fx "
+                "stuff is there.", fx_info['short_name'], fx_info['exp'])
             fx_info['exp'] = 'piControl'
             fx_files = _get_input_files(fx_info, config_user)[0]
             if not fx_files:
                 logger.warning(
-                    f"Failed to find data for CMIP6 fx variable "
-                    f"{fx_info['short_name']} with experiment "
-                    f"piControl as well.")
+                    "Failed to find data for CMIP6 fx variable "
+                    "%s with experiment "
+                    "piControl as well.", fx_info['short_name'])
 
     # If frequency = fx, only allow a single file
     if fx_files:

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -433,9 +433,23 @@ def _get_fx_files(variable, fx_info, config_user):
         fx_files = _get_input_files(fx_info, config_user)[0]
 
     # Flag a warning if no files are found
+    # CMIP6 special case:
+    # Before completely giving up, try looking for fx files in piControl:
+    # a lot of CMIP6 models have fx data only in piControl 
     if not fx_files:
         logger.warning("Missing data for fx variable '%s'",
                        fx_info['short_name'])
+        if fx_info['project'] == 'CMIP6':
+            logger.warning(
+                f"Missing data for fx variable {fx_info['short_name']} "
+                f"and experiment {fx_info['exp']}; "
+                f"will try experiment piControl")
+            fx_info['exp'] = 'piControl'
+            fx_files = _get_input_files(fx_info, config_user)[0]
+            if not fx_files:
+                logger.warning(
+                    f"Failed to find data for fx variable "
+                    f"{fx_info['short_name']} with experiment piControl as well.")
 
     # If frequency = fx, only allow a single file
     if fx_files:

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -440,15 +440,15 @@ def _get_fx_files(variable, fx_info, config_user):
         logger.warning("Missing data for fx variable '%s'",
                        fx_info['short_name'])
         if fx_info['project'] == 'CMIP6':
-            logger.warning(
+            logger.debug(
                 f"Missing data for fx variable {fx_info['short_name']} "
-                f"and experiment {fx_info['exp']}; "
-                f"will try experiment piControl")
+                f"and experiment {fx_info['exp']}; since CMIP6, "
+                f"will try experiment piControl, most fx stuff is there.")
             fx_info['exp'] = 'piControl'
             fx_files = _get_input_files(fx_info, config_user)[0]
             if not fx_files:
                 logger.warning(
-                    f"Failed to find data for fx variable "
+                    f"Failed to find data for CMIP6 fx variable "
                     f"{fx_info['short_name']} with experiment piControl as well.")
 
     # If frequency = fx, only allow a single file

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -435,7 +435,7 @@ def _get_fx_files(variable, fx_info, config_user):
     # Flag a warning if no files are found
     # CMIP6 special case:
     # Before completely giving up, try looking for fx files in piControl:
-    # a lot of CMIP6 models have fx data only in piControl 
+    # a lot of CMIP6 models have fx data only in piControl
     if not fx_files:
         logger.warning("Missing data for fx variable '%s'",
                        fx_info['short_name'])
@@ -449,7 +449,8 @@ def _get_fx_files(variable, fx_info, config_user):
             if not fx_files:
                 logger.warning(
                     f"Failed to find data for CMIP6 fx variable "
-                    f"{fx_info['short_name']} with experiment piControl as well.")
+                    f"{fx_info['short_name']} with experiment "
+                    f"piControl as well.")
 
     # If frequency = fx, only allow a single file
     if fx_files:

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -445,6 +445,7 @@ def _get_fx_files(variable, fx_info, config_user):
                 "and experiment %s; since CMIP6, "
                 "will try experiment piControl, most fx "
                 "stuff is there.", fx_info['short_name'], fx_info['exp'])
+            fx_info = dict(fx_info)
             fx_info['exp'] = 'piControl'
             fx_files = _get_input_files(fx_info, config_user)[0]
             if not fx_files:

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -2199,7 +2199,13 @@ def test_landmask_no_fx(tmp_path, patched_failing_datafinder, config_user):
         fx_variables = product.settings['add_fx_variables']['fx_variables']
         assert isinstance(fx_variables, dict)
         fx_variables = fx_variables.values()
-        assert not any(fx_variables)
+        # usable fx data is found for CMIP6 in piControl
+        # the test is to check if all those found instances are only CMIP6's
+        if fx_variables:
+            count_cmip6 = [
+                p for p in fx_variables if p.get('project', None) == 'CMIP6'
+            ]
+            assert len(fx_variables) == len(count_cmip6)
 
 
 def test_fx_vars_fixed_mip_cmip6(tmp_path, patched_datafinder, config_user):

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -2199,13 +2199,7 @@ def test_landmask_no_fx(tmp_path, patched_failing_datafinder, config_user):
         fx_variables = product.settings['add_fx_variables']['fx_variables']
         assert isinstance(fx_variables, dict)
         fx_variables = fx_variables.values()
-        # usable fx data is found for CMIP6 in piControl
-        # the test is to check if all those found instances are only CMIP6's
-        if fx_variables:
-            count_cmip6 = [
-                p for p in fx_variables if p.get('project', None) == 'CMIP6'
-            ]
-            assert len(fx_variables) == len(count_cmip6)
+        assert not any(fx_variables)
 
 
 def test_fx_vars_fixed_mip_cmip6(tmp_path, patched_datafinder, config_user):
@@ -2403,14 +2397,42 @@ def test_fx_vars_mip_search_cmip6(tmp_path, patched_datafinder, config_user):
     assert '_Ofx_' in fx_variables['sftof']['filename']
 
 
-def test_fx_vars_exp_search_cmip6(tmp_path,
-                                  patched_failing_datafinder, config_user):
+def test_fx_fail_cmip5(tmp_path, config_user):
+    content = dedent("""
+        preprocessors:
+          landmask:
+            mask_landsea:
+              mask_out: sea
+              always_use_ne_mask: false
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              gpp:
+                preprocessor: landmask
+                project: CMIP5
+                mip: Lmon
+                exp: historical
+                start_year: 2000
+                end_year: 2005
+                ensemble: r1i1p1
+                additional_datasets:
+                  - {dataset: CanESM2}
+                  - {dataset: CanESM5, project: CMIP6, grid: gn,
+                     ensemble: r1i1p1f1}
+                  - {dataset: TEST, project: obs4mips, level: 1, version: 1,
+                     tier: 1}
+            scripts: null
+        """)
+    with pytest.raises(RecipeError) as exc:
+        get_recipe(tmp_path, content, config_user)
+    exc_message = "Could not create all tasks"
+    assert str(exc.value) == exc_message
+
+
+def test_fx_fail_cmip6(tmp_path, config_user):
     """Test mip tables search for different fx variables."""
     TAGS.set_tag_values(TAGS_FOR_TESTING)
-
-    # pass an invalid experiment, that will have no fx files
-    # so we can test the lookup in exp=piControl when no fx data
-    # is found in given experiment
     content = dedent("""
         preprocessors:
           preproc:
@@ -2418,8 +2440,6 @@ def test_fx_vars_exp_search_cmip6(tmp_path,
              operator: mean
              fx_variables:
                areacella:
-               areacello:
-               clayfrac:
            mask_landsea:
              mask_out: sea
 
@@ -2439,35 +2459,10 @@ def test_fx_vars_exp_search_cmip6(tmp_path,
                   - {dataset: CanESM5}
             scripts: null
         """)
-    recipe = get_recipe(tmp_path, content, config_user)
-
-    # Check generated tasks
-    assert len(recipe.tasks) == 1
-    task = recipe.tasks.pop()
-    assert task.name == 'diagnostic_name' + TASKSEP + 'tas'
-    assert len(task.products) == 1
-    product = task.products.pop()
-
-    # Check area_statistics
-    assert 'area_statistics' in product.settings
-    settings = product.settings['area_statistics']
-    assert len(settings) == 1
-    assert settings['operator'] == 'mean'
-
-    # Check mask_landsea
-    assert 'mask_landsea' in product.settings
-    settings = product.settings['mask_landsea']
-    assert len(settings) == 1
-    assert settings['mask_out'] == 'sea'
-
-    # Check add_fx_variables
-    fx_variables = product.settings['add_fx_variables']['fx_variables']
-    assert isinstance(fx_variables, dict)
-    assert len(fx_variables) == 4
-    assert '_fx_' and '_piControl_' in fx_variables['areacella']['filename']
-    assert '_Ofx_' and '_piControl_' in fx_variables['areacello']['filename']
-    assert '_Efx_' and '_piControl_' in fx_variables['clayfrac']['filename']
-    assert '_Ofx_' and '_piControl_' in fx_variables['sftof']['filename']
+    with pytest.raises(RecipeError) as exc:
+        get_recipe(tmp_path, content, config_user)
+    exc_message = "Could not create all tasks"
+    assert str(exc.value) == exc_message
 
 
 def test_fx_list_mip_search_cmip6(tmp_path, patched_datafinder, config_user):

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -2403,7 +2403,7 @@ def test_fx_vars_mip_search_cmip6(tmp_path, patched_datafinder, config_user):
     assert '_Ofx_' in fx_variables['sftof']['filename']
 
 
-def test_fx_vars_exp_search_cmip6(tmp_path, patched_datafinder, config_user):
+def test_fx_vars_exp_search_cmip6(tmp_path, patched_failing_datafinder, config_user):
     """Test mip tables search for different fx variables."""
     TAGS.set_tag_values(TAGS_FOR_TESTING)
 
@@ -2462,12 +2462,11 @@ def test_fx_vars_exp_search_cmip6(tmp_path, patched_datafinder, config_user):
     # Check add_fx_variables
     fx_variables = product.settings['add_fx_variables']['fx_variables']
     assert isinstance(fx_variables, dict)
-    assert len(fx_variables) == 5
-    assert '_fx_' in fx_variables['areacella']['filename']
-    assert '_Ofx_' in fx_variables['areacello']['filename']
-    assert '_Efx_' in fx_variables['clayfrac']['filename']
-    assert '_fx_' in fx_variables['sftlf']['filename']
-    assert '_Ofx_' in fx_variables['sftof']['filename']
+    assert len(fx_variables) == 4
+    assert '_fx_' and '_piControl_' in fx_variables['areacella']['filename']
+    assert '_Ofx_' and '_piControl_' in fx_variables['areacello']['filename']
+    assert '_Efx_' and '_piControl_' in fx_variables['clayfrac']['filename']
+    assert '_Ofx_' and '_piControl_' in fx_variables['sftof']['filename']
 
 
 def test_fx_list_mip_search_cmip6(tmp_path, patched_datafinder, config_user):

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -2403,7 +2403,8 @@ def test_fx_vars_mip_search_cmip6(tmp_path, patched_datafinder, config_user):
     assert '_Ofx_' in fx_variables['sftof']['filename']
 
 
-def test_fx_vars_exp_search_cmip6(tmp_path, patched_failing_datafinder, config_user):
+def test_fx_vars_exp_search_cmip6(tmp_path,
+                                  patched_failing_datafinder, config_user):
     """Test mip tables search for different fx variables."""
     TAGS.set_tag_values(TAGS_FOR_TESTING)
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

This is a sort of a lifeboat approach: many CMIP6 models don't have fx data in any other experiment BUT `piControl` - fx data is produced only once and is experiment-agnostic, so they don't bother producing multiple copies; also the ESGF data storing rules are a bit lax here so they don't ask the uploaders to provide multiple copies of fx data for multiple experiments. So if one wants `exp=historical, var: tas` and then asks for some fx var to go with it, ESMValTool will not find that var, hence the lifeboat search in `piControl` right before exiting and declaring fx data not found. This **helps** with #1314 but it don't close it by no means.


Link to documentation: Q: do you think we should add documentation for this?

***


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

