### PR TITLE
explicitly imports of iris submodules instead of using iris attributes (`iris=3.1.0` incompatibility change)

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
@@ -1,5 +1,6 @@
 """Fixes for EC-Earth model."""
 import iris
+import iris.cube
 import numpy as np
 from dask import array as da
 

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
@@ -1,5 +1,6 @@
 """Fixes for CNRM-CM6-1 model."""
 import iris
+import iris.cube
 
 from ..common import ClFixHybridPressureCoord
 from ..fix import Fix

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -3,6 +3,8 @@ import datetime
 import logging
 
 import iris
+import iris.cube
+
 import numpy as np
 
 from ..fix import Fix

--- a/esmvalcore/preprocessor/_ancillary_vars.py
+++ b/esmvalcore/preprocessor/_ancillary_vars.py
@@ -4,6 +4,7 @@ import logging
 
 import dask.array as da
 import iris
+import iris.cube
 
 from esmvalcore.cmor.check import cmor_check_data, cmor_check_metadata
 from esmvalcore.cmor.fix import fix_data, fix_metadata

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -7,6 +7,7 @@ import logging
 
 import fiona
 import iris
+import iris.cube
 import numpy as np
 import shapely
 import shapely.ops

--- a/esmvalcore/preprocessor/_derive/__init__.py
+++ b/esmvalcore/preprocessor/_derive/__init__.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import iris
+import iris.cube
 
 logger = logging.getLogger(__name__)
 

--- a/esmvalcore/preprocessor/_derive/uajet.py
+++ b/esmvalcore/preprocessor/_derive/uajet.py
@@ -2,6 +2,7 @@
 
 import cf_units
 import iris
+import iris.cube
 import numpy as np
 
 from ._baseclass import DerivedVariableBase

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -7,6 +7,7 @@ from itertools import groupby
 from warnings import catch_warnings, filterwarnings
 
 import iris
+import iris.cube
 import iris.exceptions
 import numpy as np
 import yaml

--- a/esmvalcore/preprocessor/_mapping.py
+++ b/esmvalcore/preprocessor/_mapping.py
@@ -4,6 +4,7 @@
 import collections
 
 import iris
+import iris.cube
 import numpy as np
 
 

--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -13,6 +13,7 @@ import os
 import cartopy.io.shapereader as shpreader
 import dask.array as da
 import iris
+import iris.cube
 import numpy as np
 import shapely.vectorized as shp_vect
 from iris.analysis import Aggregator

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -8,6 +8,7 @@ from functools import reduce
 
 import cf_units
 import iris
+import iris.cube
 import numpy as np
 from iris.util import equalise_attributes
 

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import Dict
 
 import iris
+import iris.cube
 import numpy as np
 import stratify
 from dask import array as da

--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -3,6 +3,7 @@
 
 import ESMF
 import iris
+import iris.cube
 import numpy as np
 
 from ._mapping import get_empty_data, map_slices, ref_to_dims_index

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 import logging
 
 import iris
+import iris.cube
 import numpy as np
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Due to [this note](https://scitools-iris.readthedocs.io/en/v3.1.0/whatsnew/3.1.html#minimised-imports) in the iris=3.1.0 release notes, it looks like it's not safe to use `iris.cube.Cube` or `iris.cube.CubeList` any more without the explicit import of `iris.cube` - ie use it as imported submodule and not as attribute. There may be more instances that I missed, also @bouweandela @bjlittle do we need to change all calls to `iris` attributes to explicit imports (eg `iris.Constraint` etc)?

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #issue_number

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
