### PR TITLE
Set long_name in lat and lon coordinates in regrid

### DIFF
--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -129,12 +129,14 @@ def _generate_cube_from_dimcoords(latdata, londata, circular: bool = False):
     """
     lats = iris.coords.DimCoord(latdata,
                                 standard_name='latitude',
+                                long_name='latitude',
                                 units='degrees_north',
                                 var_name='lat',
                                 circular=circular)
 
     lons = iris.coords.DimCoord(londata,
                                 standard_name='longitude',
+                                long_name='longitude',
                                 units='degrees_east',
                                 var_name='lon',
                                 circular=circular)

--- a/tests/unit/preprocessor/_regrid/test__stock_cube.py
+++ b/tests/unit/preprocessor/_regrid/test__stock_cube.py
@@ -1,8 +1,5 @@
-"""
-Unit tests for the :func:`esmvalcore.preprocessor.regrid._stock_cube`
-function.
-
-"""
+"""Unit tests for the :func:`esmvalcore.preprocessor.regrid._stock_cube`
+function."""
 
 import unittest
 from unittest import mock
@@ -11,9 +8,15 @@ import iris
 import numpy as np
 
 import tests
-from esmvalcore.preprocessor._regrid import (_LAT_MAX, _LAT_MIN, _LAT_RANGE,
-                                             _LON_MAX, _LON_MIN, _LON_RANGE)
-from esmvalcore.preprocessor._regrid import _global_stock_cube
+from esmvalcore.preprocessor._regrid import (
+    _LAT_MAX,
+    _LAT_MIN,
+    _LAT_RANGE,
+    _LON_MAX,
+    _LON_MIN,
+    _LON_RANGE,
+    _global_stock_cube,
+)
 
 
 class Test(tests.Test):
@@ -40,6 +43,7 @@ class Test(tests.Test):
         [args], kwargs = call_lats
         self.assert_array_equal(args, expected_lat_points)
         expected_lat_kwargs = dict(standard_name='latitude',
+                                   long_name='latitude',
                                    units='degrees_north',
                                    var_name='lat',
                                    circular=False)
@@ -49,6 +53,7 @@ class Test(tests.Test):
         [args], kwargs = call_lons
         self.assert_array_equal(args, expected_lon_points)
         expected_lon_kwargs = dict(standard_name='longitude',
+                                   long_name='longitude',
                                    units='degrees_east',
                                    var_name='lon',
                                    circular=False)

--- a/tests/unit/preprocessor/_regrid/test_regrid.py
+++ b/tests/unit/preprocessor/_regrid/test_regrid.py
@@ -245,5 +245,15 @@ def test_regrid_is_skipped_if_grids_are_the_same():
     assert expected_different_cube is not cube
 
 
+def test_lat_lon_long_names_are_set():
+    """Test that lat and lon long_names are set."""
+    cube = _make_cube(lat=LAT_SPEC1, lon=LON_SPEC1)
+    scheme = 'linear'
+
+    regridded = regrid(cube, target_grid='5x5', scheme=scheme)
+    assert regridded.coord('latitude').long_name == 'latitude'
+    assert regridded.coord('longitude').long_name == 'longitude'
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We discovered in ESMValGroup/ESMValTool#2398 that we were not setting the `long_name` attribute in lat and lon coordiantes when creating the reference cube for the regrid. This PR fixes that by setting it to its CMIP5 / OBS values of `latitude` and `longitude`. Bear in mind that this was changed in CMIP6 to `Latitude` and `Longitude` and that we may want to change it later when most of our recipes use CMIP6 / OBS6 datasets

Closes ESMValGroup/ESMValTool#2398


## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
