### PR TITLE
Adding standard names to the custom tables of the `rlns` and `rsns` variables

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_rlns.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_rlns.dat
@@ -6,7 +6,7 @@ modeling_realm:    atmos
 !----------------------------------
 ! Variable attributes:
 !----------------------------------
-standard_name:
+standard_name:     surface_net_downward_longwave_flux
 units:             W m-2
 cell_methods:      time: mean
 cell_measures:     area: areacella

--- a/esmvalcore/cmor/tables/custom/CMOR_rlns.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_rlns.dat
@@ -11,7 +11,7 @@ units:             W m-2
 cell_methods:      time: mean
 cell_measures:     area: areacella
 long_name:         Surface Net downward Longwave Radiation
-comment:           at the top of the atmosphere (to be compared with satellite measurements)
+comment:           difference between downward and upward thermal radiation at the surface of the Earth
 !----------------------------------
 ! Additional variable information:
 !----------------------------------

--- a/esmvalcore/cmor/tables/custom/CMOR_rsns.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_rsns.dat
@@ -11,7 +11,7 @@ units:             W m-2
 cell_methods:      time: mean
 cell_measures:     area: areacella
 long_name:         Surface Net downward Shortwave Radiation
-comment:           at the top of the atmosphere (to be compared with satellite measurements)
+comment:           amount of solar radiation that reaches the surface of the Earth minus the amount reflected by the Earth's surface
 !----------------------------------
 ! Additional variable information:
 !----------------------------------

--- a/esmvalcore/cmor/tables/custom/CMOR_rsns.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_rsns.dat
@@ -6,7 +6,7 @@ modeling_realm:    atmos
 !----------------------------------
 ! Variable attributes:
 !----------------------------------
-standard_name:
+standard_name:     surface_net_downward_shortwave_flux
 units:             W m-2
 cell_methods:      time: mean
 cell_measures:     area: areacella


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->
This PR adds `standard_name` to the custom tables for the variables `rlns` and `rsns`. This is necessary for the derivation of the `rlus` and `rsus` variables in ERA5 otherwise a wrong standard name containing "upward" is used and the derivation fails (see [comment](https://github.com/ESMValGroup/ESMValTool/issues/2396#issuecomment-960826885)).

Related to https://github.com/ESMValGroup/ESMValTool/issues/2396

Link to documentation:
- https://github.com/ESMValGroup/ESMValCore/blob/main/esmvalcore/cmor/tables/custom/CMOR_rlns.dat
- https://github.com/ESMValGroup/ESMValCore/blob/main/esmvalcore/cmor/tables/custom/CMOR_rsns.dat

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- ~~[ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added~~
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- ~~[ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~~
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
