### PR TITLE
Fix `extract_shape` when fx vars are present

### DIFF
--- a/tests/unit/preprocessor/_area/test_area.py
+++ b/tests/unit/preprocessor/_area/test_area.py
@@ -725,8 +725,8 @@ def test_extract_shape_fx(make_testcube, ne_ocean_shapefile):
         standard_name='land_ice_area_fraction',
         var_name='sftgif',
         units='%')
-    cube.add_cell_measure(measure, (1, 2))
-    cube.add_ancillary_variable(ancillary_var, (1, 2))
+    cube.add_cell_measure(measure, (0, 1))
+    cube.add_ancillary_variable(ancillary_var, (0, 1))
     result = extract_shape(
         cube,
         shp_file,

--- a/tests/unit/preprocessor/_area/test_area.py
+++ b/tests/unit/preprocessor/_area/test_area.py
@@ -735,11 +735,11 @@ def test_extract_shape_fx(make_testcube, ne_ocean_shapefile):
     np.testing.assert_array_equal(result.data.data, expected)
     
     assert result.cell_measures()
-    result_measure = result.cell_measure('areacello').data
+    result_measure = result.cell_measure('cell_area').data
     np.testing.assert_array_equal(measure.data, result_measure)
 
     assert result.ancillary_variables()
-    result_ancillary_var = result.ancillary_variable('sftgif').data
+    result_ancillary_var = result.ancillary_variable('land_ice_area_fraction').data
     np.testing.assert_array_equal(ancillary_var.data, result_ancillary_var)
 
 

--- a/tests/unit/preprocessor/_area/test_area.py
+++ b/tests/unit/preprocessor/_area/test_area.py
@@ -71,9 +71,10 @@ class Test(tests.Test):
         self.assert_array_equal(result.data, expected)
 
     def test_area_statistics_cell_measure_mean(self):
+        """Test for area average of a 2D field.
+
+        The area measure is pre-loaded in the cube
         """
-        Test for area average of a 2D field.
-        The area measure is pre-loaded in the cube"""
         cube = guess_bounds(self.grid, ['longitude', 'latitude'])
         grid_areas = iris.analysis.cartography.area_weights(cube)
         measure = iris.coords.CellMeasure(
@@ -143,10 +144,8 @@ class Test(tests.Test):
         self.assert_array_equal(result.data, expected)
 
     def test_extract_region_mean(self):
-        """
-        Test for extracting a region and performing
-        the area mean of a 2D field.
-        """
+        """Test for extracting a region and performing the area mean of a 2D
+        field."""
         cube = guess_bounds(self.grid, ['longitude', 'latitude'])
         grid_areas = iris.analysis.cartography.area_weights(cube)
         measure = iris.coords.CellMeasure(
@@ -733,13 +732,14 @@ def test_extract_shape_fx(make_testcube, ne_ocean_shapefile):
         crop=False,
     )
     np.testing.assert_array_equal(result.data.data, expected)
-    
+
     assert result.cell_measures()
     result_measure = result.cell_measure('cell_area').data
     np.testing.assert_array_equal(measure.data, result_measure)
 
     assert result.ancillary_variables()
-    result_ancillary_var = result.ancillary_variable('land_ice_area_fraction').data
+    result_ancillary_var = result.ancillary_variable(
+        'land_ice_area_fraction').data
     np.testing.assert_array_equal(ancillary_var.data, result_ancillary_var)
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description
This pull request adds support to handle fx variables without crashing in the `extract_shape` preprocessor. It removes them before the shape extraction, and re-adds them after the data has been masked.
<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1394

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
