### PR TITLE
Added bias preprocessor

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1758,7 +1758,10 @@ The ``bias`` preprocessor supports 3 optional arguments:
      reference dataset) during the calculation of relative biases. All values
      in the reference dataset with absolute value less than the given threshold
      are masked out. This setting is ignored when ``bias_type`` is set to
-     ``'absolute'``.
+     ``'absolute'``. Please note that for some variables with very small
+     absolute values (e.g., carbon cycle fluxes, which are usually :math:`<
+     10^{-6} kg m^{-2} s^{-1}`) it is absolutely essential to adapt the default
+     value in order to get reasonable results.
    * ``keep_reference_dataset`` (:obj:`bool`, default: ``False``): If
      ``True``, keep the reference dataset in the output. If ``False``, drop the
      reference dataset.

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1761,7 +1761,7 @@ The ``bias`` preprocessor supports 4 optional arguments:
      ``'absolute'``. Please note that for some variables with very small
      absolute values (e.g., carbon cycle fluxes, which are usually :math:`<
      10^{-6}` kg m :math:`^{-2}` s :math:`^{-1}`) it is absolutely essential to
-     adapt the default value in order to get reasonable results.
+     change the default value in order to get reasonable results.
    * ``keep_reference_dataset`` (:obj:`bool`, default: ``False``): If
      ``True``, keep the reference dataset in the output. If ``False``, drop the
      reference dataset.

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -23,6 +23,7 @@ roughly following the default order in which preprocessor functions are applied:
 * :ref:`Trend`
 * :ref:`Detrend`
 * :ref:`Unit conversion`
+* :ref:`Bias`
 * :ref:`Other`
 
 See :ref:`preprocessor_functions` for implementation details and the exact default order.
@@ -1712,6 +1713,54 @@ will guarantee homogeneous input for the diagnostics.
    amount based unit is not supported at the moment.
 
 See also :func:`esmvalcore.preprocessor.convert_units`.
+
+
+.. _bias:
+
+Bias
+====
+
+The bias module contains the following preprocessor functions:
+
+* ``bias``: Calculate absolute or relative biases with respect to a reference
+  dataset
+
+``bias``
+--------
+
+This function calculates biases with respect to a given reference dataset. For
+this, exactly one input dataset needs to be declared as ``reference_for_bias:
+true`` in the recipe, e.g.,
+
+.. code-block:: yaml
+
+  datasets:
+    - {dataset: CanESM5, project: CMIP6, ensemble: r1i1p1f1, grid: gn}
+    - {dataset: CESM2,   project: CMIP6, ensemble: r1i1p1f1, grid: gn}
+    - {dataset: MIROC6,  project: CMIP6, ensemble: r1i1p1f1, grid: gn}
+    - {dataset: ERA-Interim, project: OBS6, tier: 3, type: reanaly, version: 1,
+       reference_for_bias: true}
+
+In the example above, ERA-Interim is used as reference dataset for the bias
+calculation.
+
+The ``bias`` preprocessor supports 3 optional arguments:
+
+   * ``bias_type`` (:obj:`str`, default: ``'absolute'``): Bias type that is
+     calculated. Can be ``'absolute'`` (i.e., calculate bias for dataset
+     :math:`X` and reference :math:`R` as :math:`X - R`) or ``relative`` (i.e,
+     calculate bias as :math:`\frac{X - R}{R}`).
+   * ``denominator_mask_threshold`` (:obj:`float`, default: ``1e-3``):
+     Threshold to mask values close to zero in the denominator (i.e., the
+     reference dataset) during the calculation of relative biases. All values
+     in the reference dataset with absolute value less than the given threshold
+     are masked out. This setting is ignored when ``bias_type`` is set to
+     ``'absolute'``.
+   * ``keep_reference_dataset`` (:obj:`bool`, default: ``False``): If
+     ``True``, keep the reference dataset in the output. If ``False``, drop the
+     reference dataset.
+
+See also :func:`esmvalcore.preprocessor.bias`.
 
 
 .. _Memory use:

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1742,7 +1742,10 @@ true`` in the recipe, e.g.,
        reference_for_bias: true}
 
 In the example above, ERA-Interim is used as reference dataset for the bias
-calculation.
+calculation. For this preprocessor, all input datasets need to have identical
+dimensional coordinates. This can for example be ensured with the preprocessors
+:func:`esmvalcore.preprocessor.regrid` and/or
+:func:`esmvalcore.preprocessor.regrid_time`.
 
 The ``bias`` preprocessor supports 3 optional arguments:
 

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1747,7 +1747,7 @@ dimensional coordinates. This can for example be ensured with the preprocessors
 :func:`esmvalcore.preprocessor.regrid` and/or
 :func:`esmvalcore.preprocessor.regrid_time`.
 
-The ``bias`` preprocessor supports 3 optional arguments:
+The ``bias`` preprocessor supports 4 optional arguments:
 
    * ``bias_type`` (:obj:`str`, default: ``'absolute'``): Bias type that is
      calculated. Can be ``'absolute'`` (i.e., calculate bias for dataset
@@ -1760,11 +1760,28 @@ The ``bias`` preprocessor supports 3 optional arguments:
      are masked out. This setting is ignored when ``bias_type`` is set to
      ``'absolute'``. Please note that for some variables with very small
      absolute values (e.g., carbon cycle fluxes, which are usually :math:`<
-     10^{-6} kg m^{-2} s^{-1}`) it is absolutely essential to adapt the default
-     value in order to get reasonable results.
+     10^{-6}` kg m :math:`^{-2}` s :math:`^{-1}`) it is absolutely essential to
+     adapt the default value in order to get reasonable results.
    * ``keep_reference_dataset`` (:obj:`bool`, default: ``False``): If
      ``True``, keep the reference dataset in the output. If ``False``, drop the
      reference dataset.
+   * ``exclude`` (:obj:`list` of :obj:`str`): Exclude specific datasets from
+     this preprocessor. Note that this option is only available in the recipe,
+     not when using :func:`esmvalcore.preprocessor.bias` directly (e.g., in
+     another python script). If the reference dataset has been excluded, an
+     error is raised.
+
+Example:
+
+.. code-block:: yaml
+
+    preprocessors:
+      preproc_bias:
+        bias:
+          bias_type: relative
+          denominator_mask_threshold: 1e-8
+          keep_reference_dataset: true
+          exclude: [CanESM2]
 
 See also :func:`esmvalcore.preprocessor.bias`.
 

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -820,6 +820,7 @@ def _get_preprocessor_products(variables, profile, order, ancestor_products,
             f'{separator.join(sorted(missing_vars))}')
 
     _update_statistic_settings(products, order, config_user['preproc_dir'])
+    check.reference_for_bias_preproc(products)
 
     for product in products:
         product.check()

--- a/esmvalcore/_recipe_checks.py
+++ b/esmvalcore/_recipe_checks.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import subprocess
+from pprint import pformat
 from shutil import which
 
 import yamale
@@ -227,3 +228,31 @@ def valid_multimodel_statistic(statistic):
             "Invalid value encountered for `statistic` in preprocessor "
             f"`multi_model_statistics`. Valid values are {valid_names} "
             f"or patterns matching {valid_patterns}. Got '{statistic}.'")
+
+
+def reference_for_bias_preproc(products):
+    """Check that exactly one reference dataset for bias preproc is given."""
+    step = 'bias'
+    products = {p for p in products if step in p.settings}
+    if not products:
+        return
+
+    # Check that exactly one dataset contains the facet ``reference_for_bias:
+    # true``
+    reference_products = []
+    for product in products:
+        if product.attributes.get('reference_for_bias', False):
+            reference_products.append(product)
+    if len(reference_products) != 1:
+        products_str = [p.filename for p in products]
+        if not reference_products:
+            ref_products_str = ". "
+        else:
+            ref_products_str = [p.filename for p in reference_products]
+            ref_products_str = f":\n{pformat(ref_products_str)}.\n"
+        raise RecipeError(
+            f"Expected exactly 1 dataset with 'reference_for_bias: true' in "
+            f"products\n{pformat(products_str)},\nfound "
+            f"{len(reference_products):d}{ref_products_str}Please also "
+            f"ensure that the reference dataset is not excluded with the "
+            f"'exclude' option")

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -19,6 +19,7 @@ from ._area import (
     meridional_statistics,
     zonal_statistics,
 )
+from ._bias import bias
 from ._cycles import amplitude
 from ._derive import derive
 from ._detrend import detrend
@@ -159,6 +160,8 @@ __all__ = [
     'convert_units',
     # Multi model statistics
     'multi_model_statistics',
+    # Bias calculation
+    'bias',
     # Remove fx_variables from cube
     'remove_fx_variables',
     # Save to file
@@ -191,6 +194,7 @@ INITIAL_STEPS = DEFAULT_ORDER[:DEFAULT_ORDER.index('add_fx_variables') + 1]
 FINAL_STEPS = DEFAULT_ORDER[DEFAULT_ORDER.index('remove_fx_variables'):]
 
 MULTI_MODEL_FUNCTIONS = {
+    'bias',
     'multi_model_statistics',
     'mask_multimodel',
     'mask_fillvalues',

--- a/esmvalcore/preprocessor/_bias.py
+++ b/esmvalcore/preprocessor/_bias.py
@@ -35,7 +35,10 @@ def bias(products, bias_type='absolute', denominator_mask_threshold=1e-3,
         reference dataset) during the calculation of relative biases. All
         values in the reference dataset with absolute value less than the given
         threshold are masked out. This setting is ignored when ``bias_type`` is
-        set to ``'absolute'``.
+        set to ``'absolute'``. Please note that for some variables with very
+        small absolute values (e.g., carbon cycle fluxes, which are usually
+        :math:`< 10^{-6} kg m^{-2} s^{-1}`) it is absolutely essential to adapt
+        the default value in order to get reasonable results.
     keep_reference_dataset: bool, optional (default: False)
         If ``True``, keep the reference dataset in the output. If ``False``,
         drop the reference dataset.

--- a/esmvalcore/preprocessor/_bias.py
+++ b/esmvalcore/preprocessor/_bias.py
@@ -1,0 +1,114 @@
+"""Preprocessor functions to calculate biases from data."""
+import logging
+
+import dask.array as da
+import iris.cube
+
+from ._io import concatenate
+
+logger = logging.getLogger(__name__)
+
+
+def bias(products, bias_type='absolute', denominator_mask_threshold=1e-3,
+         keep_reference_dataset=False):
+    """Calculate biases.
+
+    Notes
+    -----
+    This preprocessor requires a reference dataset. For this, exactly one input
+    dataset needs to have the facet ``reference_for_bias: true`` defined in the
+    recipe. In addition, all input datasets need to have similar dimensional
+    coordinates. This can for example be ensured with the preprocessors
+    :func:`esmvalcore.preprocessor.regrid` and/or
+    :func:`esmvalcore.preprocessor.regrid_time`.
+
+    Parameters
+    ----------
+    products: set of esmvalcore.preprocessor.PreprocessorFile
+        Input datasets. Exactly one datasets needs the facet
+        ``reference_for_bias: true``.
+    bias_type: str, optional (default: 'absolute')
+        Bias type that is calculated. Must be one of ``'absolute'`` (dataset -
+        ref) or ``'relative'`` ((dataset - ref) / ref).
+    denominator_mask_threshold: float, optional (default: 1e-3)
+        Threshold to mask values close to zero in the denominator (i.e., the
+        reference dataset) during the calculation of relative biases. All
+        values in the reference dataset with absolute value less than the given
+        threshold are masked out. This setting is ignored when ``bias_type`` is
+        set to ``'absolute'``.
+    keep_reference_dataset: bool, optional (default: False)
+        If ``True``, keep the reference dataset in the output. If ``False``,
+        drop the reference dataset.
+
+    Returns
+    -------
+    set of esmvalcore.preprocessor.PreprocessorFile
+        Output datasets.
+
+    Raises
+    ------
+    ValueError
+        Not exactly one input datasets contains the facet
+        ``reference_for_bias: true``; ``bias_type`` is not one of
+        ``'absolute'`` or ``'relative'``.
+
+    """
+    # Get reference product
+    reference_product = []
+    for product in products:
+        if product.attributes.get('reference_for_bias', False):
+            reference_product.append(product)
+    if len(reference_product) != 1:
+        raise ValueError(
+            f"Expected exactly 1 dataset with 'reference_for_bias: true', "
+            f"found {len(reference_product):d}")
+    reference_product = reference_product[0]
+
+    # Extract reference cube
+    # Note: For technical reasons, product objects contain the member
+    # ``cubes``, which is a list of cubes. However, this is expected to be a
+    # list with exactly one element due to the call of concatenate earlier in
+    # the preprocessing chain of ESMValTool. To make sure that this
+    # preprocessor can also be used outside the ESMValTool preprocessing chain,
+    # an additional concatenate call is added here.
+    ref_cube = concatenate(reference_product.cubes)
+    if bias_type == 'relative':
+        ref_cube = ref_cube.copy()
+        ref_cube.data = da.ma.masked_inside(ref_cube.core_data(),
+                                            -denominator_mask_threshold,
+                                            denominator_mask_threshold)
+
+    # Iterate over all input datasets and calculate bias
+    output_products = set()
+    for product in products:
+        if product == reference_product:
+            continue
+        cube = concatenate(product.cubes)
+        cube_metadata = cube.metadata
+
+        # Calculate bias
+        if bias_type == 'absolute':
+            cube = cube - ref_cube
+            new_units = str(cube.units)
+        elif bias_type == 'relative':
+            cube = (cube - ref_cube) / ref_cube
+            new_units = '1'
+        else:
+            raise ValueError(
+                f"Expected one of ['absolute', 'relative'] for bias_type, got "
+                f"'{bias_type}'")
+
+        # Adapt cube metadata and provenancen information
+        cube.metadata = cube_metadata
+        cube.units = new_units
+        product.attributes['units'] = new_units
+        product.wasderivedfrom(reference_product)
+
+        product.cubes = iris.cube.CubeList([cube])
+        output_products.add(product)
+
+    # Add reference dataset to output if desired
+    if keep_reference_dataset:
+        output_products.add(reference_product)
+
+    return output_products

--- a/esmvalcore/preprocessor/_bias.py
+++ b/esmvalcore/preprocessor/_bias.py
@@ -17,7 +17,7 @@ def bias(products, bias_type='absolute', denominator_mask_threshold=1e-3,
     -----
     This preprocessor requires a reference dataset. For this, exactly one input
     dataset needs to have the facet ``reference_for_bias: true`` defined in the
-    recipe. In addition, all input datasets need to have similar dimensional
+    recipe. In addition, all input datasets need to have identical dimensional
     coordinates. This can for example be ensured with the preprocessors
     :func:`esmvalcore.preprocessor.regrid` and/or
     :func:`esmvalcore.preprocessor.regrid_time`.
@@ -98,7 +98,7 @@ def bias(products, bias_type='absolute', denominator_mask_threshold=1e-3,
                 f"Expected one of ['absolute', 'relative'] for bias_type, got "
                 f"'{bias_type}'")
 
-        # Adapt cube metadata and provenancen information
+        # Adapt cube metadata and provenance information
         cube.metadata = cube_metadata
         cube.units = new_units
         product.attributes['units'] = new_units

--- a/esmvalcore/preprocessor/_bias.py
+++ b/esmvalcore/preprocessor/_bias.py
@@ -38,7 +38,7 @@ def bias(products, bias_type='absolute', denominator_mask_threshold=1e-3,
         set to ``'absolute'``. Please note that for some variables with very
         small absolute values (e.g., carbon cycle fluxes, which are usually
         :math:`< 10^{-6}` kg m :math:`^{-2}` s :math:`^{-1}`) it is absolutely
-        essential to adapt the default value in order to get reasonable
+        essential to change the default value in order to get reasonable
         results.
     keep_reference_dataset: bool, optional (default: False)
         If ``True``, keep the reference dataset in the output. If ``False``,

--- a/esmvalcore/preprocessor/_bias.py
+++ b/esmvalcore/preprocessor/_bias.py
@@ -37,8 +37,9 @@ def bias(products, bias_type='absolute', denominator_mask_threshold=1e-3,
         threshold are masked out. This setting is ignored when ``bias_type`` is
         set to ``'absolute'``. Please note that for some variables with very
         small absolute values (e.g., carbon cycle fluxes, which are usually
-        :math:`< 10^{-6} kg m^{-2} s^{-1}`) it is absolutely essential to adapt
-        the default value in order to get reasonable results.
+        :math:`< 10^{-6}` kg m :math:`^{-2}` s :math:`^{-1}`) it is absolutely
+        essential to adapt the default value in order to get reasonable
+        results.
     keep_reference_dataset: bool, optional (default: False)
         If ``True``, keep the reference dataset in the output. If ``False``,
         drop the reference dataset.

--- a/tests/unit/preprocessor/_bias/test_bias.py
+++ b/tests/unit/preprocessor/_bias/test_bias.py
@@ -1,0 +1,276 @@
+"""Unit tests for :mod:`esmvalcore.preprocessor._bias`."""
+
+from unittest import mock
+
+import iris
+import iris.cube
+import numpy as np
+import pytest
+from cf_units import Unit
+
+from esmvalcore.preprocessor import PreprocessorFile as PreprocessorFileBase
+from esmvalcore.preprocessor._bias import bias
+
+
+class PreprocessorFile(mock.Mock):
+    """Mocked PreprocessorFile."""
+
+    def __init__(self, cubes, filename, attributes, **kwargs):
+        """Initialize with cubes."""
+        super().__init__(spec=PreprocessorFileBase, **kwargs)
+        self.cubes = cubes
+        self.filename = filename
+        self.attributes = attributes
+        self.mock_ancestors = set()
+        self.wasderivedfrom = mock.Mock(side_effect=self.mock_ancestors.add)
+
+
+def assert_array_equal(array_1, array_2):
+    """Assert that (masked) array 1 equals (masked) array 2."""
+    if np.ma.is_masked(array_1) or np.ma.is_masked(array_2):
+        np.testing.assert_array_equal(np.ma.getmaskarray(array_1),
+                                      np.ma.getmaskarray(array_2))
+        mask = np.ma.getmaskarray(array_1)
+        np.testing.assert_array_equal(array_1[~mask], array_2[~mask])
+    else:
+        np.testing.assert_array_equal(array_1, array_2)
+
+
+def products_set_to_dict(products):
+    """Convert :obj:`set` of products to :obj:`dict`."""
+    new_dict = {}
+    for product in products:
+        new_dict[product.filename] = product
+    return new_dict
+
+
+def get_3d_cube(data, **cube_kwargs):
+    """Create 3D cube."""
+    time_units = Unit('days since 1850-01-01 00:00:00')
+    times = iris.coords.DimCoord([0.0, 1.0], standard_name='time',
+                                 var_name='time', long_name='time',
+                                 units=time_units)
+    lats = iris.coords.DimCoord([0.0, 10.0], standard_name='latitude',
+                                var_name='lat', long_name='latitude',
+                                units='degrees_north')
+    lons = iris.coords.DimCoord([20.0, 30.0], standard_name='longitude',
+                                var_name='lon', long_name='longitude',
+                                units='degrees_east')
+    coord_specs = [(times, 0), (lats, 1), (lons, 2)]
+    cube = iris.cube.Cube(data.astype('float32'),
+                          dim_coords_and_dims=coord_specs, **cube_kwargs)
+    return cube
+
+
+@pytest.fixture
+def regular_cubes():
+    """Regular cube."""
+    cube_data = np.arange(8.0).reshape(2, 2, 2)
+    cube = get_3d_cube(cube_data, standard_name='air_temperature',
+                       var_name='tas', units='K')
+    return iris.cube.CubeList([cube])
+
+
+@pytest.fixture
+def ref_cubes():
+    """Reference cube."""
+    cube_data = np.full((2, 2, 2), 2.0)
+    cube_data[1, 1, 1] = 4.0
+    cube = get_3d_cube(cube_data, standard_name='air_temperature',
+                       var_name='tas', units='K')
+    return iris.cube.CubeList([cube])
+
+
+def test_no_reference_for_bias(regular_cubes, ref_cubes):
+    """Test fail when no reference_for_bias is given."""
+    products = {
+        PreprocessorFile(regular_cubes, 'A', {}),
+        PreprocessorFile(regular_cubes, 'B', {}),
+        PreprocessorFile(ref_cubes, 'REF', {}),
+    }
+    msg = "Expected exactly 1 dataset with 'reference_for_bias: true', found 0"
+    with pytest.raises(ValueError, match=msg):
+        bias(products)
+
+
+def test_two_reference_for_bias(regular_cubes, ref_cubes):
+    """Test fail when two reference_for_bias is given."""
+    products = {
+        PreprocessorFile(regular_cubes, 'A', {'reference_for_bias': False}),
+        PreprocessorFile(ref_cubes, 'REF1', {'reference_for_bias': True}),
+        PreprocessorFile(ref_cubes, 'REF2', {'reference_for_bias': True}),
+    }
+    msg = "Expected exactly 1 dataset with 'reference_for_bias: true', found 2"
+    with pytest.raises(ValueError, match=msg):
+        bias(products)
+
+
+def test_invalid_bias_type(regular_cubes, ref_cubes):
+    """Test fail when invalid bias_type is given."""
+    products = {
+        PreprocessorFile(regular_cubes, 'A', {}),
+        PreprocessorFile(regular_cubes, 'B', {}),
+        PreprocessorFile(ref_cubes, 'REF', {'reference_for_bias': True}),
+    }
+    msg = (r"Expected one of \['absolute', 'relative'\] for bias_type, got "
+           r"'invalid_bias_type'")
+    with pytest.raises(ValueError, match=msg):
+        bias(products, 'invalid_bias_type')
+
+
+def test_absolute_bias(regular_cubes, ref_cubes):
+    """Test calculation of absolute bias."""
+    ref_product = PreprocessorFile(ref_cubes, 'REF',
+                                   {'reference_for_bias': True})
+    products = {
+        PreprocessorFile(regular_cubes, 'A', {'dataset': 'a'}),
+        PreprocessorFile(regular_cubes, 'B', {'dataset': 'b'}),
+        ref_product,
+    }
+    out_products = bias(products)
+    out_dict = products_set_to_dict(out_products)
+    assert len(out_dict) == 2
+
+    product_a = out_dict['A']
+    assert product_a.filename == 'A'
+    assert product_a.attributes == {'units': 'K', 'dataset': 'a'}
+    assert len(product_a.cubes) == 1
+    out_cube = product_a.cubes[0]
+    expected_data = [[[-2.0, -1.0],
+                      [0.0, 1.0]],
+                     [[2.0, 3.0],
+                      [4.0, 3.0]]]
+    assert_array_equal(out_cube.data, expected_data)
+    assert out_cube.var_name == 'tas'
+    assert out_cube.standard_name == 'air_temperature'
+    assert out_cube.units == 'K'
+    assert out_cube.dim_coords == regular_cubes[0].dim_coords
+    assert out_cube.aux_coords == regular_cubes[0].aux_coords
+    product_a.wasderivedfrom.assert_called_once()
+    assert product_a.mock_ancestors == {ref_product}
+
+    product_b = out_dict['B']
+    assert product_b.filename == 'B'
+    assert product_b.attributes == {'units': 'K', 'dataset': 'b'}
+    assert len(product_b.cubes) == 1
+    out_cube = product_b.cubes[0]
+    expected_data = [[[-2.0, -1.0],
+                      [0.0, 1.0]],
+                     [[2.0, 3.0],
+                      [4.0, 3.0]]]
+    assert_array_equal(out_cube.data, expected_data)
+    assert out_cube.var_name == 'tas'
+    assert out_cube.standard_name == 'air_temperature'
+    assert out_cube.units == 'K'
+    assert out_cube.dim_coords == regular_cubes[0].dim_coords
+    assert out_cube.aux_coords == regular_cubes[0].aux_coords
+    product_b.wasderivedfrom.assert_called_once()
+    assert product_b.mock_ancestors == {ref_product}
+
+
+def test_relative_bias(regular_cubes, ref_cubes):
+    """Test calculation of relative bias."""
+    ref_product = PreprocessorFile(ref_cubes, 'REF',
+                                   {'reference_for_bias': True})
+    products = {
+        PreprocessorFile(regular_cubes, 'A', {'dataset': 'a'}),
+        PreprocessorFile(regular_cubes, 'B', {'dataset': 'b'}),
+        ref_product,
+    }
+    out_products = bias(products, 'relative')
+    out_dict = products_set_to_dict(out_products)
+    assert len(out_dict) == 2
+
+    product_a = out_dict['A']
+    assert product_a.filename == 'A'
+    assert product_a.attributes == {'units': '1', 'dataset': 'a'}
+    assert len(product_a.cubes) == 1
+    out_cube = product_a.cubes[0]
+    expected_data = [[[-1.0, -0.5],
+                      [0.0, 0.5]],
+                     [[1.0, 1.5],
+                      [2.0, 0.75]]]
+    assert_array_equal(out_cube.data, expected_data)
+    assert out_cube.var_name == 'tas'
+    assert out_cube.standard_name == 'air_temperature'
+    assert out_cube.units == '1'
+    assert out_cube.dim_coords == regular_cubes[0].dim_coords
+    assert out_cube.aux_coords == regular_cubes[0].aux_coords
+    product_a.wasderivedfrom.assert_called_once()
+    assert product_a.mock_ancestors == {ref_product}
+
+    product_b = out_dict['B']
+    assert product_b.filename == 'B'
+    assert product_b.attributes == {'units': '1', 'dataset': 'b'}
+    assert len(product_b.cubes) == 1
+    out_cube = product_b.cubes[0]
+    expected_data = [[[-1.0, -0.5],
+                      [0.0, 0.5]],
+                     [[1.0, 1.5],
+                      [2.0, 0.75]]]
+    assert_array_equal(out_cube.data, expected_data)
+    assert out_cube.var_name == 'tas'
+    assert out_cube.standard_name == 'air_temperature'
+    assert out_cube.units == '1'
+    assert out_cube.dim_coords == regular_cubes[0].dim_coords
+    assert out_cube.aux_coords == regular_cubes[0].aux_coords
+    product_b.wasderivedfrom.assert_called_once()
+    assert product_b.mock_ancestors == {ref_product}
+
+
+def test_denominator_mask_threshold(regular_cubes, ref_cubes):
+    """Test denominator_mask_threshold argument."""
+    ref_product = PreprocessorFile(ref_cubes, 'REF',
+                                   {'reference_for_bias': True})
+    products = {
+        PreprocessorFile(regular_cubes, 'A', {'dataset': 'a'}),
+        ref_product,
+    }
+    out_products = bias(products, 'relative', denominator_mask_threshold=3.0)
+    out_dict = products_set_to_dict(out_products)
+    assert len(out_dict) == 1
+
+    product_a = out_dict['A']
+    assert product_a.filename == 'A'
+    assert product_a.attributes == {'units': '1', 'dataset': 'a'}
+    assert len(product_a.cubes) == 1
+    out_cube = product_a.cubes[0]
+    expected_data = np.ma.masked_equal([[[42.0, 42.0],
+                                         [42.0, 42.0]],
+                                        [[42.0, 42.0],
+                                         [42.0, 0.75]]], 42.0)
+    assert_array_equal(out_cube.data, expected_data)
+    assert out_cube.var_name == 'tas'
+    assert out_cube.standard_name == 'air_temperature'
+    assert out_cube.units == '1'
+    assert out_cube.dim_coords == regular_cubes[0].dim_coords
+    assert out_cube.aux_coords == regular_cubes[0].aux_coords
+    product_a.wasderivedfrom.assert_called_once()
+    assert product_a.mock_ancestors == {ref_product}
+
+
+def test_keep_reference_dataset(regular_cubes, ref_cubes):
+    """Test denominator_mask_threshold argument."""
+    products = {
+        PreprocessorFile(regular_cubes, 'A', {'dataset': 'a'}),
+        PreprocessorFile(ref_cubes, 'REF', {'reference_for_bias': True})
+    }
+    out_products = bias(products, keep_reference_dataset=True)
+    out_dict = products_set_to_dict(out_products)
+    assert len(out_dict) == 2
+
+    product_ref = out_dict['REF']
+    assert product_ref.filename == 'REF'
+    assert product_ref.attributes == {'reference_for_bias': True}
+    assert len(product_ref.cubes) == 1
+    out_cube = product_ref.cubes[0]
+    expected_data = [[[2.0, 2.0],
+                      [2.0, 2.0]],
+                     [[2.0, 2.0],
+                      [2.0, 4.0]]]
+    assert_array_equal(out_cube.data, expected_data)
+    assert out_cube.var_name == 'tas'
+    assert out_cube.standard_name == 'air_temperature'
+    assert out_cube.units == 'K'
+    assert out_cube.dim_coords == ref_cubes[0].dim_coords
+    assert out_cube.aux_coords == ref_cubes[0].aux_coords


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR adds a `bias` preprocessor that is able to calculate absolute or relative biases relative to a predefined reference dataset.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #119 

Link to documentation: https://esmvaltool--1406.org.readthedocs.build/projects/ESMValCore/en/1406/recipe/preprocessor.html#bias

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
