### PR TITLE
Improve error messages when a preprocessor is failing

### DIFF
--- a/esmvalcore/_provenance.py
+++ b/esmvalcore/_provenance.py
@@ -138,6 +138,10 @@ class TrackedFile:
         """Return summary string."""
         return "{}: {}".format(self.__class__.__name__, self.filename)
 
+    def __repr__(self):
+        """Return representation string (e.g., used by ``pformat``)."""
+        return f"{self.__class__.__name__}: {self.filename}"
+
     def copy_provenance(self):
         """Create a copy with identical provenance information."""
         if self.provenance is None:

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -291,7 +291,7 @@ def _run_preproc_function(function, items, kwargs, input_files=None):
         # To avoid very long error messages, we truncate the arguments and
         # input files here at a given threshold
         n_shown_args = 4
-        if len(input_files) > n_shown_args:
+        if input_files is not None and len(input_files) > n_shown_args:
             n_not_shown_files = len(input_files) - n_shown_args
             file_msg = (f"\nOriginal input file(s):\n"
                         f"{pformat(input_files[:n_shown_args])}\n(and "

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -291,11 +291,7 @@ def _run_preproc_function(function, items, kwargs, input_files=None):
         # To avoid very long error messages, we truncate the arguments and
         # input files here at a given threshold
         n_shown_args = 4
-        if input_files is None:
-            file_msg = ""
-        elif len(input_files) <= n_shown_args:
-            file_msg = f"\nOriginal input file(s):\n{pformat(input_files)}"
-        else:
+        if len(input_files) > n_shown_args:
             n_not_shown_files = len(input_files) - n_shown_args
             file_msg = (f"\nOriginal input file(s):\n"
                         f"{pformat(input_files[:n_shown_args])}\n(and "

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -282,9 +282,12 @@ def _run_preproc_function(function, items, kwargs, input_files=None):
     if input_files is None:
         file_msg = ""
     else:
-        file_msg = f"\nOriginal input file(s):\n{pformat(input_files)}"
-    logger.debug("Running %s with option(s)\n%s\non argument(s)\n%s%s",
-                 function.__name__, pformat(kwargs), pformat(items), file_msg)
+        file_msg = (f"\nloaded from original input file(s)\n"
+                    f"{pformat(input_files)}")
+    logger.debug(
+        "Running preprocessor function '%s' on the data\n%s%s\nwith function "
+        "argument(s)\n%s", function.__name__, pformat(items), file_msg,
+        pformat(kwargs))
     try:
         return function(items, **kwargs)
     except Exception:
@@ -293,7 +296,7 @@ def _run_preproc_function(function, items, kwargs, input_files=None):
         n_shown_args = 4
         if input_files is not None and len(input_files) > n_shown_args:
             n_not_shown_files = len(input_files) - n_shown_args
-            file_msg = (f"\nOriginal input file(s):\n"
+            file_msg = (f"\nloaded from original input file(s)\n"
                         f"{pformat(input_files[:n_shown_args])}\n(and "
                         f"{n_not_shown_files:d} further file(s) not shown "
                         f"here; refer to the debug log for a full list)")
@@ -305,15 +308,16 @@ def _run_preproc_function(function, items, kwargs, input_files=None):
             items = list(items)
 
         if len(items) <= n_shown_args:
-            msg = (f"{function.__name__} with option(s)\n{pformat(kwargs)}\n"
-                   f"on argument(s)\n{pformat(items)}{file_msg}")
+            data_msg = pformat(items)
         else:
             n_not_shown_args = len(items) - n_shown_args
-            msg = (f"{function.__name__} with option(s)\n{pformat(kwargs)}\n"
-                   f"on argument(s)\n{pformat(items[:n_shown_args])}\n(and "
-                   f"{n_not_shown_args:d} further argument(s) not shown here; "
-                   f"refer to the debug log for a full list){file_msg}")
-        logger.error("Failed to run %s", msg)
+            data_msg = (f"{pformat(items[:n_shown_args])}\n(and "
+                        f"{n_not_shown_args:d} further argument(s) not shown "
+                        f"here; refer to the debug log for a full list)")
+        logger.error(
+            "Failed to run preprocessor function '%s' on the data\n%s%s\nwith "
+            "function argument(s)\n%s", function.__name__, data_msg, file_msg,
+            pformat(kwargs))
         raise
 
 

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -279,6 +279,8 @@ def _get_multi_model_settings(products, step):
 
 def _run_preproc_function(function, items, kwargs, input_files=None):
     """Run preprocessor function."""
+    kwargs_str = ",\n".join(
+        [f"{k} = {pformat(v)}" for (k, v) in kwargs.items()])
     if input_files is None:
         file_msg = ""
     else:
@@ -287,7 +289,7 @@ def _run_preproc_function(function, items, kwargs, input_files=None):
     logger.debug(
         "Running preprocessor function '%s' on the data\n%s%s\nwith function "
         "argument(s)\n%s", function.__name__, pformat(items), file_msg,
-        pformat(kwargs))
+        kwargs_str)
     try:
         return function(items, **kwargs)
     except Exception:
@@ -317,7 +319,7 @@ def _run_preproc_function(function, items, kwargs, input_files=None):
         logger.error(
             "Failed to run preprocessor function '%s' on the data\n%s%s\nwith "
             "function argument(s)\n%s", function.__name__, data_msg, file_msg,
-            pformat(kwargs))
+            kwargs_str)
         raise
 
 

--- a/tests/unit/preprocessor/test_error_logging.py
+++ b/tests/unit/preprocessor/test_error_logging.py
@@ -29,7 +29,7 @@ def assert_debug_call_ok(mock_logger, items):
     else:
         for item in items:
             assert repr(item) in debug_call_args[2]
-    assert debug_call_args[4] == "{'test': 42}"
+    assert debug_call_args[4] == "test = 42,\nlist = ['a', 'b']"
 
 
 def assert_error_call_ok(mock_logger):
@@ -41,10 +41,10 @@ def assert_error_call_ok(mock_logger):
         "Failed to run preprocessor function '%s' on the data\n%s%s\nwith "
         "function argument(s)\n%s")
     assert error_call_args[1] == "failing_function"
-    assert error_call_args[4] == "{'test': 42}"
+    assert error_call_args[4] == "test = 42,\nlist = ['a', 'b']"
 
 
-KWARGS = {'test': 42}
+KWARGS = {'test': 42, 'list': ['a', 'b']}
 PREPROC_FILE = PreprocessorFile({'filename': 'a'}, {})
 TEST_ITEMS_SHORT = [
     # Scalars

--- a/tests/unit/preprocessor/test_error_logging.py
+++ b/tests/unit/preprocessor/test_error_logging.py
@@ -1,0 +1,242 @@
+"""Unit tests for error logging of :mod:`esmvalcore.preprocessor`."""
+
+from unittest import mock
+
+import pytest
+from iris.cube import Cube, CubeList
+
+from esmvalcore.preprocessor import PreprocessorFile, _run_preproc_function
+
+VALUE_ERROR_MSG = "This function is expected to fail with exactly this error"
+
+
+def failing_function(*_, **__):
+    """Raise ValueError."""
+    raise ValueError(VALUE_ERROR_MSG)
+
+
+def assert_debug_call_ok(mock_logger, items):
+    """Check debug call."""
+    mock_logger.debug.assert_called_once()
+    assert mock_logger.debug.call_args.kwargs == {}
+    debug_call_args = mock_logger.debug.call_args.args
+    assert debug_call_args[0] == ("Running %s with option(s)\n%s\non argument"
+                                  "(s)\n%s%s")
+    assert debug_call_args[1] == "failing_function"
+    assert debug_call_args[2] == "{'test': 42}"
+    if isinstance(items, (PreprocessorFile, Cube, str)):
+        assert debug_call_args[3] == repr(items)
+    else:
+        for item in items:
+            assert repr(item) in debug_call_args[3]
+
+
+def assert_error_call_ok(mock_logger):
+    """Check error call."""
+    mock_logger.error.assert_called_once()
+    assert mock_logger.error.call_args.kwargs == {}
+    error_call_args = mock_logger.error.call_args.args
+    assert error_call_args[0] == "Failed to run %s"
+    expected_str = ("failing_function with option(s)\n{'test': 42}\non "
+                    "argument(s)\n")
+    assert expected_str in error_call_args[1]
+
+
+KWARGS = {'test': 42}
+PREPROC_FILE = PreprocessorFile({'filename': 'a'}, {})
+TEST_ITEMS_SHORT = [
+    # Scalars
+    PREPROC_FILE,
+    Cube(0),
+    'a',
+    # 1-element lists
+    [PREPROC_FILE],
+    [Cube(0)],
+    ['a'],
+    # 1-element sets
+    set([PREPROC_FILE]),
+    set([Cube(0)]),
+    set(['a']),
+    # 1-element CubeList
+    CubeList([Cube(0)]),
+    # 4-element lists
+    [PREPROC_FILE] * 4,
+    [Cube(0)] * 4,
+    ['a'] * 4,
+    # 4-element sets
+    set(['a', 'b', 'c', 'd']),
+    # 4-element CubeList
+    CubeList([Cube(0), Cube(1), Cube(2), Cube(3)]),
+]
+TEST_ITEMS_LONG = [
+    # 6-element list
+    ['a', 'b', 'c', 'd', 'e', 'f'],
+    # 6-element set
+    set(['a', 'b', 'c', 'd', 'e', 'f']),
+]
+SHORT_INPUT_FILES = ['x', 'y', 'z', 'w']
+LONG_INPUT_FILES = ['x', 'y', 'z', 'w', 'v', 'u']
+
+
+@pytest.mark.parametrize('items', TEST_ITEMS_SHORT)
+@mock.patch('esmvalcore.preprocessor.logger', autospec=True)
+def test_short_items_no_input_files(mock_logger, items):
+    """Test short list of items and no input files."""
+    with pytest.raises(ValueError, match=VALUE_ERROR_MSG):
+        _run_preproc_function(failing_function, items, KWARGS)
+    assert len(mock_logger.mock_calls) == 2
+
+    # Debug call
+    assert_debug_call_ok(mock_logger, items)
+    assert mock_logger.debug.call_args.args[4] == ""
+
+    # Error call
+    assert_error_call_ok(mock_logger)
+    error_call_args = mock_logger.error.call_args.args
+    if isinstance(items, (PreprocessorFile, Cube, str)):
+        assert repr(items) in error_call_args[1]
+    else:
+        for item in items:
+            assert repr(item) in error_call_args[1]
+    assert "\nOriginal input file(s):\n" not in error_call_args[1]
+    assert "further file(s) not shown here;" not in error_call_args[1]
+    assert "further argument(s) not shown here;" not in error_call_args[1]
+
+
+@pytest.mark.parametrize('items', TEST_ITEMS_SHORT)
+@mock.patch('esmvalcore.preprocessor.logger', autospec=True)
+def test_short_items_short_input_files(mock_logger, items):
+    """Test short list of items and short list of input files."""
+    with pytest.raises(ValueError, match=VALUE_ERROR_MSG):
+        _run_preproc_function(failing_function, items, KWARGS,
+                              input_files=SHORT_INPUT_FILES)
+    assert len(mock_logger.mock_calls) == 2
+
+    # Debug call
+    assert_debug_call_ok(mock_logger, items)
+    assert mock_logger.debug.call_args.args[4] == (
+        "\nOriginal input file(s):\n['x', 'y', 'z', 'w']")
+
+    # Error call
+    assert_error_call_ok(mock_logger)
+    error_call_args = mock_logger.error.call_args.args
+    if isinstance(items, (PreprocessorFile, Cube, str)):
+        assert repr(items) in error_call_args[1]
+    else:
+        for item in items:
+            assert repr(item) in error_call_args[1]
+    assert ("\nOriginal input file(s):\n['x', 'y', 'z', 'w']" in
+            error_call_args[1])
+    assert "further file(s) not shown here;" not in error_call_args[1]
+    assert "further argument(s) not shown here;" not in error_call_args[1]
+
+
+@pytest.mark.parametrize('items', TEST_ITEMS_SHORT)
+@mock.patch('esmvalcore.preprocessor.logger', autospec=True)
+def test_short_items_long_input_files(mock_logger, items):
+    """Test short list of items and long list of input files."""
+    with pytest.raises(ValueError, match=VALUE_ERROR_MSG):
+        _run_preproc_function(failing_function, items, KWARGS,
+                              input_files=LONG_INPUT_FILES)
+    assert len(mock_logger.mock_calls) == 2
+
+    # Debug call
+    assert_debug_call_ok(mock_logger, items)
+    assert mock_logger.debug.call_args.args[4] == (
+        "\nOriginal input file(s):\n['x', 'y', 'z', 'w', 'v', 'u']")
+
+    # Error call
+    assert_error_call_ok(mock_logger)
+    error_call_args = mock_logger.error.call_args.args
+    if isinstance(items, (PreprocessorFile, Cube, str)):
+        assert repr(items) in error_call_args[1]
+    else:
+        for item in items:
+            assert repr(item) in error_call_args[1]
+    assert ("\nOriginal input file(s):\n['x', 'y', 'z', 'w']\n" in
+            error_call_args[1])
+    assert "['x', 'y', 'z', 'w', 'v', 'u']" not in error_call_args[1]
+    assert "\n(and 2 further file(s) not shown here;" in error_call_args[1]
+    assert "further argument(s) not shown here;" not in error_call_args[1]
+
+
+@pytest.mark.parametrize('items', TEST_ITEMS_LONG)
+@mock.patch('esmvalcore.preprocessor.logger', autospec=True)
+def test_long_items_no_input_files(mock_logger, items):
+    """Test long list of items and no input files."""
+    with pytest.raises(ValueError, match=VALUE_ERROR_MSG):
+        _run_preproc_function(failing_function, items, KWARGS)
+    assert len(mock_logger.mock_calls) == 2
+
+    # Debug call
+    assert_debug_call_ok(mock_logger, items)
+    assert mock_logger.debug.call_args.args[4] == ""
+
+    # Error call
+    assert_error_call_ok(mock_logger)
+    error_call_args = mock_logger.error.call_args.args
+    items = list(items)
+    for item in items[:4]:
+        assert repr(item) in error_call_args[1]
+    for item in items[4:]:
+        assert repr(item) not in error_call_args[1]
+    assert "\nOriginal input file(s):\n" not in error_call_args[1]
+    assert "further file(s) not shown here;" not in error_call_args[1]
+    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[1]
+
+
+@pytest.mark.parametrize('items', TEST_ITEMS_LONG)
+@mock.patch('esmvalcore.preprocessor.logger', autospec=True)
+def test_long_items_short_input_files(mock_logger, items):
+    """Test long list of items and short list of input files."""
+    with pytest.raises(ValueError, match=VALUE_ERROR_MSG):
+        _run_preproc_function(failing_function, items, KWARGS,
+                              input_files=SHORT_INPUT_FILES)
+    assert len(mock_logger.mock_calls) == 2
+
+    # Debug call
+    assert_debug_call_ok(mock_logger, items)
+    assert mock_logger.debug.call_args.args[4] == (
+        "\nOriginal input file(s):\n['x', 'y', 'z', 'w']")
+
+    # Error call
+    assert_error_call_ok(mock_logger)
+    error_call_args = mock_logger.error.call_args.args
+    items = list(items)
+    for item in items[:4]:
+        assert repr(item) in error_call_args[1]
+    for item in items[4:]:
+        assert repr(item) not in error_call_args[1]
+    assert ("\nOriginal input file(s):\n['x', 'y', 'z', 'w']" in
+            error_call_args[1])
+    assert "further file(s) not shown here;" not in error_call_args[1]
+    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[1]
+
+
+@pytest.mark.parametrize('items', TEST_ITEMS_LONG)
+@mock.patch('esmvalcore.preprocessor.logger', autospec=True)
+def test_long_items_long_input_files(mock_logger, items):
+    """Test long list of items and long list of input files."""
+    with pytest.raises(ValueError, match=VALUE_ERROR_MSG):
+        _run_preproc_function(failing_function, items, KWARGS,
+                              input_files=LONG_INPUT_FILES)
+    assert len(mock_logger.mock_calls) == 2
+
+    # Debug call
+    assert_debug_call_ok(mock_logger, items)
+    assert mock_logger.debug.call_args.args[4] == (
+        "\nOriginal input file(s):\n['x', 'y', 'z', 'w', 'v', 'u']")
+
+    # Error call
+    assert_error_call_ok(mock_logger)
+    error_call_args = mock_logger.error.call_args.args
+    items = list(items)
+    for item in items[:4]:
+        assert repr(item) in error_call_args[1]
+    for item in items[4:]:
+        assert repr(item) not in error_call_args[1]
+    assert ("\nOriginal input file(s):\n['x', 'y', 'z', 'w']\n" in
+            error_call_args[1])
+    assert "['x', 'y', 'z', 'w', 'v', 'u']" not in error_call_args[1]
+    assert "\n(and 2 further file(s) not shown here;" in error_call_args[1]
+    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[1]

--- a/tests/unit/preprocessor/test_error_logging.py
+++ b/tests/unit/preprocessor/test_error_logging.py
@@ -20,15 +20,16 @@ def assert_debug_call_ok(mock_logger, items):
     mock_logger.debug.assert_called_once()
     assert mock_logger.debug.call_args.kwargs == {}
     debug_call_args = mock_logger.debug.call_args.args
-    assert debug_call_args[0] == ("Running %s with option(s)\n%s\non argument"
-                                  "(s)\n%s%s")
+    assert debug_call_args[0] == (
+        "Running preprocessor function '%s' on the data\n%s%s\nwith function "
+        "argument(s)\n%s")
     assert debug_call_args[1] == "failing_function"
-    assert debug_call_args[2] == "{'test': 42}"
     if isinstance(items, (PreprocessorFile, Cube, str)):
-        assert debug_call_args[3] == repr(items)
+        assert debug_call_args[2] == repr(items)
     else:
         for item in items:
-            assert repr(item) in debug_call_args[3]
+            assert repr(item) in debug_call_args[2]
+    assert debug_call_args[4] == "{'test': 42}"
 
 
 def assert_error_call_ok(mock_logger):
@@ -36,10 +37,11 @@ def assert_error_call_ok(mock_logger):
     mock_logger.error.assert_called_once()
     assert mock_logger.error.call_args.kwargs == {}
     error_call_args = mock_logger.error.call_args.args
-    assert error_call_args[0] == "Failed to run %s"
-    expected_str = ("failing_function with option(s)\n{'test': 42}\non "
-                    "argument(s)\n")
-    assert expected_str in error_call_args[1]
+    assert error_call_args[0] == (
+        "Failed to run preprocessor function '%s' on the data\n%s%s\nwith "
+        "function argument(s)\n%s")
+    assert error_call_args[1] == "failing_function"
+    assert error_call_args[4] == "{'test': 42}"
 
 
 KWARGS = {'test': 42}
@@ -88,19 +90,18 @@ def test_short_items_no_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[4] == ""
+    assert mock_logger.debug.call_args.args[3] == ""
 
     # Error call
     assert_error_call_ok(mock_logger)
     error_call_args = mock_logger.error.call_args.args
     if isinstance(items, (PreprocessorFile, Cube, str)):
-        assert repr(items) in error_call_args[1]
+        assert repr(items) in error_call_args[2]
     else:
         for item in items:
-            assert repr(item) in error_call_args[1]
-    assert "\nOriginal input file(s):\n" not in error_call_args[1]
-    assert "further file(s) not shown here;" not in error_call_args[1]
-    assert "further argument(s) not shown here;" not in error_call_args[1]
+            assert repr(item) in error_call_args[2]
+    assert "further argument(s) not shown here;" not in error_call_args[2]
+    assert error_call_args[3] == ""
 
 
 @pytest.mark.parametrize('items', TEST_ITEMS_SHORT)
@@ -114,21 +115,20 @@ def test_short_items_short_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[4] == (
-        "\nOriginal input file(s):\n['x', 'y', 'z', 'w']")
+    assert mock_logger.debug.call_args.args[3] == (
+        "\nloaded from original input file(s)\n['x', 'y', 'z', 'w']")
 
     # Error call
     assert_error_call_ok(mock_logger)
     error_call_args = mock_logger.error.call_args.args
     if isinstance(items, (PreprocessorFile, Cube, str)):
-        assert repr(items) in error_call_args[1]
+        assert repr(items) in error_call_args[2]
     else:
         for item in items:
-            assert repr(item) in error_call_args[1]
-    assert ("\nOriginal input file(s):\n['x', 'y', 'z', 'w']" in
-            error_call_args[1])
-    assert "further file(s) not shown here;" not in error_call_args[1]
-    assert "further argument(s) not shown here;" not in error_call_args[1]
+            assert repr(item) in error_call_args[2]
+    assert "further argument(s) not shown here;" not in error_call_args[2]
+    assert error_call_args[3] == (
+        "\nloaded from original input file(s)\n['x', 'y', 'z', 'w']")
 
 
 @pytest.mark.parametrize('items', TEST_ITEMS_SHORT)
@@ -142,22 +142,22 @@ def test_short_items_long_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[4] == (
-        "\nOriginal input file(s):\n['x', 'y', 'z', 'w', 'v', 'u']")
+    assert mock_logger.debug.call_args.args[3] == (
+        "\nloaded from original input file(s)\n['x', 'y', 'z', 'w', 'v', 'u']")
 
     # Error call
     assert_error_call_ok(mock_logger)
     error_call_args = mock_logger.error.call_args.args
     if isinstance(items, (PreprocessorFile, Cube, str)):
-        assert repr(items) in error_call_args[1]
+        assert repr(items) in error_call_args[2]
     else:
         for item in items:
-            assert repr(item) in error_call_args[1]
-    assert ("\nOriginal input file(s):\n['x', 'y', 'z', 'w']\n" in
-            error_call_args[1])
-    assert "['x', 'y', 'z', 'w', 'v', 'u']" not in error_call_args[1]
-    assert "\n(and 2 further file(s) not shown here;" in error_call_args[1]
-    assert "further argument(s) not shown here;" not in error_call_args[1]
+            assert repr(item) in error_call_args[2]
+    assert "further argument(s) not shown here;" not in error_call_args[2]
+    assert error_call_args[3] == (
+        "\nloaded from original input file(s)\n['x', 'y', 'z', 'w']\n(and 2 "
+        "further file(s) not shown here; refer to the debug log for a full "
+        "list)")
 
 
 @pytest.mark.parametrize('items', TEST_ITEMS_LONG)
@@ -170,19 +170,18 @@ def test_long_items_no_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[4] == ""
+    assert mock_logger.debug.call_args.args[3] == ""
 
     # Error call
     assert_error_call_ok(mock_logger)
     error_call_args = mock_logger.error.call_args.args
     items = list(items)
     for item in items[:4]:
-        assert repr(item) in error_call_args[1]
+        assert repr(item) in error_call_args[2]
     for item in items[4:]:
-        assert repr(item) not in error_call_args[1]
-    assert "\nOriginal input file(s):\n" not in error_call_args[1]
-    assert "further file(s) not shown here;" not in error_call_args[1]
-    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[1]
+        assert repr(item) not in error_call_args[2]
+    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[2]
+    assert error_call_args[3] == ""
 
 
 @pytest.mark.parametrize('items', TEST_ITEMS_LONG)
@@ -196,21 +195,20 @@ def test_long_items_short_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[4] == (
-        "\nOriginal input file(s):\n['x', 'y', 'z', 'w']")
+    assert mock_logger.debug.call_args.args[3] == (
+        "\nloaded from original input file(s)\n['x', 'y', 'z', 'w']")
 
     # Error call
     assert_error_call_ok(mock_logger)
     error_call_args = mock_logger.error.call_args.args
     items = list(items)
     for item in items[:4]:
-        assert repr(item) in error_call_args[1]
+        assert repr(item) in error_call_args[2]
     for item in items[4:]:
-        assert repr(item) not in error_call_args[1]
-    assert ("\nOriginal input file(s):\n['x', 'y', 'z', 'w']" in
-            error_call_args[1])
-    assert "further file(s) not shown here;" not in error_call_args[1]
-    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[1]
+        assert repr(item) not in error_call_args[2]
+    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[2]
+    assert error_call_args[3] == (
+        "\nloaded from original input file(s)\n['x', 'y', 'z', 'w']")
 
 
 @pytest.mark.parametrize('items', TEST_ITEMS_LONG)
@@ -224,22 +222,22 @@ def test_long_items_long_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[4] == (
-        "\nOriginal input file(s):\n['x', 'y', 'z', 'w', 'v', 'u']")
+    assert mock_logger.debug.call_args.args[3] == (
+        "\nloaded from original input file(s)\n['x', 'y', 'z', 'w', 'v', 'u']")
 
     # Error call
     assert_error_call_ok(mock_logger)
     error_call_args = mock_logger.error.call_args.args
     items = list(items)
     for item in items[:4]:
-        assert repr(item) in error_call_args[1]
+        assert repr(item) in error_call_args[2]
     for item in items[4:]:
-        assert repr(item) not in error_call_args[1]
-    assert ("\nOriginal input file(s):\n['x', 'y', 'z', 'w']\n" in
-            error_call_args[1])
-    assert "['x', 'y', 'z', 'w', 'v', 'u']" not in error_call_args[1]
-    assert "\n(and 2 further file(s) not shown here;" in error_call_args[1]
-    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[1]
+        assert repr(item) not in error_call_args[2]
+    assert "\n(and 2 further argument(s) not shown here;" in error_call_args[2]
+    assert error_call_args[3] == (
+        "\nloaded from original input file(s)\n['x', 'y', 'z', 'w']\n(and 2 "
+        "further file(s) not shown here; refer to the debug log for a full "
+        "list)")
 
 
 class MockAncestor():

--- a/tests/unit/preprocessor/test_error_logging.py
+++ b/tests/unit/preprocessor/test_error_logging.py
@@ -240,3 +240,30 @@ def test_long_items_long_input_files(mock_logger, items):
     assert "['x', 'y', 'z', 'w', 'v', 'u']" not in error_call_args[1]
     assert "\n(and 2 further file(s) not shown here;" in error_call_args[1]
     assert "\n(and 2 further argument(s) not shown here;" in error_call_args[1]
+
+
+class MockAncestor():
+    """Mock class for ancestors."""
+
+    def __init__(self, filename):
+        """Initialize mock ancestor."""
+        self.filename = filename
+
+
+def test_input_files_for_log():
+    """Test :meth:`PreprocessorFile._input_files_for_log`."""
+    ancestors = [
+        MockAncestor('a.nc'),
+        MockAncestor('b.nc'),
+    ]
+    preproc_file = PreprocessorFile({'filename': 'p.nc'}, {},
+                                    ancestors=ancestors)
+
+    assert preproc_file._input_files == ['a.nc', 'b.nc']
+    assert preproc_file.files == ['a.nc', 'b.nc']
+    assert preproc_file._input_files_for_log() is None
+
+    preproc_file.files = ['c.nc', 'd.nc']
+    assert preproc_file._input_files == ['a.nc', 'b.nc']
+    assert preproc_file.files == ['c.nc', 'd.nc']
+    assert preproc_file._input_files_for_log() == ['a.nc', 'b.nc']


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

This PR improves the error messages when a preprocessor is failing. For example, this old message

```
 2021-12-08 12:41:02,140 UTC [44931] ERROR   Failed to run fix_metadata([<iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of 
minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- 
: 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, 
<iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 
'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 
81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc_rt / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vert. integr. heating by atm. gravity wave drag / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of meridional stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface albedo / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of latent heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of dissipation of orographic waves / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of meridional wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of zonal wind in 10m / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of v-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse visible radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of daylght_frc / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_shortwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 
81920)>, <iris 'Cube' of maximum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud ice / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of u-momentum flux at the surface / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of total cloud cover / (m2 m-2) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sea ice thickness / (m) (time: 1; -- : 81920)>, <iris 'Cube' of convection_type (0...3) / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of cosine of the zenith angle for rad. heating / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of fraction of ocean covered by sea ice / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of convective precipitation flux (snow) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of precipitation flux / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of zonal stress from subgrid scale orographic drag / (N m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface upwelling photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of evaporation / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo NIR diffuse / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>, <iris 'Cube' of large-scale precipitation flux (water) / (kg m-2 s-1) (time: 1; -- : 81920)>, <iris 'Cube' of sensible heat flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated cloud water / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of vertically integrated water vapour / (kg m-2) (time: 1; -- : 81920)>, <iris 'Cube' of toa_outgoing_longwave_flux_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface_air_pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of toa_incoming_shortwave_flux / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling diffuse near infrared radiation at radiation time / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of tropopause air pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of minimum 2m temperature / (K) (time: 1; -- : 81920)>, <iris 'Cube' of dew point temperature in 2m / (K) (time: 1; -- : 81920)>, <iris 'Cube' of surface_upwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of mean sea level pressure / (Pa) (time: 1; -- : 81920)>, <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>, <iris 'Cube' of albedo VIS direct / (unknown) (time: 1; -- : 81920)>, <iris 'Cube' of surface downwelling direct photosynthetically active radiation at radiation time / (W m-2) (time: 1; -- : 81920)>], {'preprocessor': 'clim', 'mip': 'Amon', 'project': 'ICON', 'exp': 'amip', 'start_year': 2006, 'end_year': 2006, 'derive': True, 'reference_dataset': 'ESACCI-CLOUD', 'variable_group': 'lwp_derive_input_lwp', 'short_name': 'lwp', 'diagnostic': 'maps2d', 'dataset': 'ICON', 'component': 'atm', 'grid': 'R2B5', 'ensemble': 'r1v1i1p1l1f1', 'var_type': 'atm_2d_ml', 'version': 'icon-2.6.1', 'recipe_dataset_index': 0, 'activity': 'CMIP', 'alias': 'ICON', 'original_short_name': 'lwp', 'standard_name': 'atmosphere_mass_content_of_cloud_liquid_water', 'long_name': 'Liquid Water Path', 'units': 'kg m-2', 'modeling_realm': ['aerosol'], 'frequency': 'mon', 'filename': '/scratch/b/b309141/work_v2/recipe_icon_eval_clouds_20211208_124051/preproc/maps2d/lwp_derive_input_lwp/ICON_icon-2.6.1_atm_R2B5_Amon_amip_r1v1i1p1l1f1_lwp_atm_2d_ml_2006-2006.nc', 'check_level': <CheckLevels.DEFAULT: 3>})
```

now reads

```
2021-12-08 15:49:50,621 UTC [13502] ERROR   Failed to run fix_metadata with option(s)
{'activity': 'CMIP',
 'alias': 'ICON',
 'check_level': <CheckLevels.DEFAULT: 3>,
 'component': 'atm',
 'dataset': 'ICON',
 'derive': True,
 'diagnostic': 'maps2d',
 'end_year': 2006,
 'ensemble': 'r1v1i1p1l1f1',
 'exp': 'amip',
 'filename': '/scratch/b/b309141/work_v2/recipe_icon_eval_clouds_20211208_154937/preproc/maps2d/lwp_derive_input_lwp/ICON_icon-2.6.1_atm_R2B5_Amon_amip_r1v1i1p1l1f1_lwp_atm_2d_ml_2006-2006.nc',
 'frequency': 'mon',
 'grid': 'R2B5',
 'long_name': 'Liquid Water Path',
 'mip': 'Amon',
 'modeling_realm': ['aerosol'],
 'original_short_name': 'lwp',
 'preprocessor': 'clim',
 'project': 'ICON',
 'recipe_dataset_index': 0,
 'reference_dataset': 'ESACCI-CLOUD',
 'short_name': 'lwp',
 'standard_name': 'atmosphere_mass_content_of_cloud_liquid_water',
 'start_year': 2006,
 'units': 'kg m-2',
 'var_type': 'atm_2d_ml',
 'variable_group': 'lwp_derive_input_lwp',
 'version': 'icon-2.6.1'}
on argument(s)
[<iris 'Cube' of 10m windspeed / (m s-1) (time: 1; -- : 81920)>,
 <iris 'Cube' of surface_downwelling_longwave_flux_in_air / (W m-2) (time: 1; -- : 81920)>,
 <iris 'Cube' of surface_downwelling_longwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>,
 <iris 'Cube' of surface_upwelling_shortwave_flux_in_air_assuming_clear_sky / (W m-2) (time: 1; -- : 81920)>]
(and 728 further argument(s) not shown here; refer to the debug log for a full list)
Original input file(s):
['/mnt/lustre02/work/bd1179/experiments/icon-2.6.1_atm_amip_R2B5_r1v1i1p1l1f1/icon-2.6.1_atm_amip_R2B5_r1v1i1p1l1f1_atm_2d_ml_20060101T000000Z.nc',
 '/mnt/lustre02/work/bd1179/experiments/icon-2.6.1_atm_amip_R2B5_r1v1i1p1l1f1/icon-2.6.1_atm_amip_R2B5_r1v1i1p1l1f1_atm_2d_ml_20060201T000000Z.nc',
 '/mnt/lustre02/work/bd1179/experiments/icon-2.6.1_atm_amip_R2B5_r1v1i1p1l1f1/icon-2.6.1_atm_amip_R2B5_r1v1i1p1l1f1_atm_2d_ml_20060301T000000Z.nc',
 '/mnt/lustre02/work/bd1179/experiments/icon-2.6.1_atm_amip_R2B5_r1v1i1p1l1f1/icon-2.6.1_atm_amip_R2B5_r1v1i1p1l1f1_atm_2d_ml_20060401T000000Z.nc']
(and 8 further file(s) not shown here; refer to the debug log for a full list)
```

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1407

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
