### PR TITLE
Fixed tests for python 3.7

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
     - main
-    - fix_py37_tests
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
     - main
+    - fix_py37_tests
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/tests/unit/preprocessor/test_error_logging.py
+++ b/tests/unit/preprocessor/test_error_logging.py
@@ -18,8 +18,8 @@ def failing_function(*_, **__):
 def assert_debug_call_ok(mock_logger, items):
     """Check debug call."""
     mock_logger.debug.assert_called_once()
-    assert mock_logger.debug.call_args.kwargs == {}
-    debug_call_args = mock_logger.debug.call_args.args
+    assert mock_logger.debug.call_args[1] == {}
+    debug_call_args = mock_logger.debug.call_args[0]
     assert debug_call_args[0] == (
         "Running preprocessor function '%s' on the data\n%s%s\nwith function "
         "argument(s)\n%s")
@@ -35,8 +35,8 @@ def assert_debug_call_ok(mock_logger, items):
 def assert_error_call_ok(mock_logger):
     """Check error call."""
     mock_logger.error.assert_called_once()
-    assert mock_logger.error.call_args.kwargs == {}
-    error_call_args = mock_logger.error.call_args.args
+    assert mock_logger.error.call_args[1] == {}
+    error_call_args = mock_logger.error.call_args[0]
     assert error_call_args[0] == (
         "Failed to run preprocessor function '%s' on the data\n%s%s\nwith "
         "function argument(s)\n%s")
@@ -90,11 +90,11 @@ def test_short_items_no_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[3] == ""
+    assert mock_logger.debug.call_args[0][3] == ""
 
     # Error call
     assert_error_call_ok(mock_logger)
-    error_call_args = mock_logger.error.call_args.args
+    error_call_args = mock_logger.error.call_args[0]
     if isinstance(items, (PreprocessorFile, Cube, str)):
         assert repr(items) in error_call_args[2]
     else:
@@ -115,12 +115,12 @@ def test_short_items_short_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[3] == (
+    assert mock_logger.debug.call_args[0][3] == (
         "\nloaded from original input file(s)\n['x', 'y', 'z', 'w']")
 
     # Error call
     assert_error_call_ok(mock_logger)
-    error_call_args = mock_logger.error.call_args.args
+    error_call_args = mock_logger.error.call_args[0]
     if isinstance(items, (PreprocessorFile, Cube, str)):
         assert repr(items) in error_call_args[2]
     else:
@@ -142,12 +142,12 @@ def test_short_items_long_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[3] == (
+    assert mock_logger.debug.call_args[0][3] == (
         "\nloaded from original input file(s)\n['x', 'y', 'z', 'w', 'v', 'u']")
 
     # Error call
     assert_error_call_ok(mock_logger)
-    error_call_args = mock_logger.error.call_args.args
+    error_call_args = mock_logger.error.call_args[0]
     if isinstance(items, (PreprocessorFile, Cube, str)):
         assert repr(items) in error_call_args[2]
     else:
@@ -170,11 +170,11 @@ def test_long_items_no_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[3] == ""
+    assert mock_logger.debug.call_args[0][3] == ""
 
     # Error call
     assert_error_call_ok(mock_logger)
-    error_call_args = mock_logger.error.call_args.args
+    error_call_args = mock_logger.error.call_args[0]
     items = list(items)
     for item in items[:4]:
         assert repr(item) in error_call_args[2]
@@ -195,12 +195,12 @@ def test_long_items_short_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[3] == (
+    assert mock_logger.debug.call_args[0][3] == (
         "\nloaded from original input file(s)\n['x', 'y', 'z', 'w']")
 
     # Error call
     assert_error_call_ok(mock_logger)
-    error_call_args = mock_logger.error.call_args.args
+    error_call_args = mock_logger.error.call_args[0]
     items = list(items)
     for item in items[:4]:
         assert repr(item) in error_call_args[2]
@@ -222,12 +222,12 @@ def test_long_items_long_input_files(mock_logger, items):
 
     # Debug call
     assert_debug_call_ok(mock_logger, items)
-    assert mock_logger.debug.call_args.args[3] == (
+    assert mock_logger.debug.call_args[0][3] == (
         "\nloaded from original input file(s)\n['x', 'y', 'z', 'w', 'v', 'u']")
 
     # Error call
     assert_error_call_ok(mock_logger)
-    error_call_args = mock_logger.error.call_args.args
+    error_call_args = mock_logger.error.call_args[0]
     items = list(items)
     for item in items[:4]:
         assert repr(item) in error_call_args[2]


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

#1408 broke the tests for python 3.7, which are only tested for `main`. This should fix it.

@ESMValGroup/esmvaltool-coreteam would it maybe be possible to also run these tests on the feature branches so we immediately see that those fail and not only after the merge to `main`?


***


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
