### PR TITLE
Correctly use masked arrays after `unstructured_nearest` regridding

### DIFF
--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -18,7 +18,7 @@ from ..cmor._fixes.shared import add_altitude_from_plev, add_plev_from_altitude
 from ..cmor.fix import fix_file, fix_metadata
 from ..cmor.table import CMOR_TABLES
 from ._ancillary_vars import add_ancillary_variable, add_cell_measure
-from ._io import concatenate_callback, load
+from ._io import GLOBAL_FILL_VALUE, concatenate_callback, load
 from ._regrid_esmpy import ESMF_REGRID_METHODS
 from ._regrid_esmpy import regrid as esmpy_regrid
 

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -481,7 +481,8 @@ def regrid(cube, target_grid, scheme, lat_offset=True, lon_offset=True):
         else:
             cube = cube.regrid(target_grid, HORIZONTAL_SCHEMES[scheme])
 
-        # Preserve dtype for 'unstructured_nearest' scheme
+        # Preserve dtype and use masked arrays for 'unstructured_nearest'
+        # scheme
         if scheme == 'unstructured_nearest':
             try:
                 cube.data = cube.core_data().astype(original_dtype,

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -491,6 +491,7 @@ def regrid(cube, target_grid, scheme, lat_offset=True, lon_offset=True):
                     "dtype of data changed during regridding from '%s' to "
                     "'%s': %s", original_dtype, cube.core_data().dtype,
                     str(exc))
+            cube.data = da.ma.masked_equal(cube.core_data(), GLOBAL_FILL_VALUE)
 
     return cube
 

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -481,7 +481,11 @@ def regrid(cube, target_grid, scheme, lat_offset=True, lon_offset=True):
         # Note: da.ma.set_fill_value() works with any kind of input data
         # (masked and unmasked, numpy and dask)
         if scheme == 'unstructured_nearest':
-            da.ma.set_fill_value(cube.core_data(), GLOBAL_FILL_VALUE)
+            if np.issubdtype(cube.dtype, np.integer):
+                fill_value = np.iinfo(cube.dtype).max
+            else:
+                fill_value = GLOBAL_FILL_VALUE
+            da.ma.set_fill_value(cube.core_data(), fill_value)
 
         # Perform the horizontal regridding
         if _attempt_irregular_regridding(cube, scheme):
@@ -500,7 +504,7 @@ def regrid(cube, target_grid, scheme, lat_offset=True, lon_offset=True):
                     "dtype of data changed during regridding from '%s' to "
                     "'%s': %s", original_dtype, cube.core_data().dtype,
                     str(exc))
-            cube.data = da.ma.masked_equal(cube.core_data(), GLOBAL_FILL_VALUE)
+            cube.data = da.ma.masked_equal(cube.core_data(), fill_value)
 
     return cube
 

--- a/tests/integration/preprocessor/_regrid/test_regrid.py
+++ b/tests/integration/preprocessor/_regrid/test_regrid.py
@@ -10,6 +10,7 @@ from numpy import ma
 
 import tests
 from esmvalcore.preprocessor import regrid
+from esmvalcore.preprocessor._io import GLOBAL_FILL_VALUE
 from tests.unit.preprocessor._regrid import _make_cube
 
 
@@ -210,6 +211,10 @@ class Test(tests.Test):
         assert self.unstructured_grid_cube.dtype == np.float32
         assert result.dtype == np.float32
 
+        # Make sure that output is a masked array with correct fill value
+        # (= GLOBAL_FILL_VALUE)
+        np.testing.assert_allclose(result.data.fill_value, GLOBAL_FILL_VALUE)
+
     def test_regrid__unstructured_nearest_int(self):
         """Test unstructured_nearest regridding with cube of ints."""
         self.unstructured_grid_cube.data = np.full((3, 2, 2), 1, dtype=int)
@@ -220,6 +225,11 @@ class Test(tests.Test):
         np.testing.assert_array_equal(result.data, expected)
 
         # Make sure that dtype is not preserved (since conversion from float to
-        # float would be necessary)
+        # int would be necessary)
         assert np.issubdtype(self.unstructured_grid_cube.dtype, np.integer)
         assert result.dtype == np.float64
+
+        # Make sure that output is a masked array with correct fill value
+        # (= maximum int)
+        np.testing.assert_allclose(result.data.fill_value,
+                                   float(np.iinfo(int).max))

--- a/tests/unit/preprocessor/_regrid/test_regrid.py
+++ b/tests/unit/preprocessor/_regrid/test_regrid.py
@@ -63,7 +63,9 @@ class Test(tests.Test):
             coord_system=self.coord_system,
             coords=self.coords,
             remove_coord=self.remove_coord,
-            regrid=self.regrid)
+            regrid=self.regrid,
+            dtype=float,
+        )
         self.tgt_grid_coord = mock.Mock()
         self.tgt_grid = mock.Mock(
             spec=iris.cube.Cube, coord=self.tgt_grid_coord)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Right now, `unstructured_nearest` regridding does not return masked arrays. This PR fixes this.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1413

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
