### PR TITLE
Correct brackets in preprocessor documentation for list of seasons

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1056,8 +1056,8 @@ See also :func:`esmvalcore.preprocessor.monthly_statistics`.
 ``seasonal_statistics``
 -----------------------
 
-This function produces statistics for each season (default: "(DJF, MAM, JJA,
-SON)" or custom seasons e.g. "(JJAS, ONDJFMAM)" ) in the dataset. Note that
+This function produces statistics for each season (default: ``[DJF, MAM, JJA,
+SON]`` or custom seasons e.g. ``[JJAS, ONDJFMAM]``) in the dataset. Note that
 this function will not check for missing time points. For instance, if you are
 looking at the DJF field, but your datasets starts on January 1st, the first
 DJF field will only contain data from January and February.
@@ -1070,9 +1070,9 @@ Parameters:
       'median', 'std_dev', 'min', 'max', 'sum' and 'rms'. Default is 'mean'
 
     * seasons: seasons to build statistics.
-      Default is '(DJF, MAM, JJA, SON)'
+      Default is '[DJF, MAM, JJA, SON]'
 
-See also :func:`esmvalcore.preprocessor.seasonal_mean`.
+See also :func:`esmvalcore.preprocessor.seasonal_statistics`.
 
 .. _annual_statistics:
 
@@ -1118,7 +1118,7 @@ Parameters:
       'mon', 'daily', 'day'. Default is 'full'
 
     * seasons: if period 'seasonal' or 'season' allows to set custom seasons.
-      Default is '(DJF, MAM, JJA, SON)'
+      Default is '[DJF, MAM, JJA, SON]'
 
 Examples:
     * Monthly climatology:
@@ -1240,7 +1240,7 @@ Parameters:
       parameters from extract_time_. Default is null
     * standardize: if true calculate standardized anomalies (default: false)
     * seasons: if period 'seasonal' or 'season' allows to set custom seasons.
-      Default is '(DJF, MAM, JJA, SON)'
+      Default is '[DJF, MAM, JJA, SON]'
 Examples:
     * Anomalies from the full period climatology:
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

The brackets used in the documentation of the `seasons` argument to several preprocessor functions were not a valid way to create a list in YAML. This pull request fixes the problem.

Link to documentation: https://esmvaltool--1420.org.readthedocs.build/projects/ESMValCore/en/1420/recipe/preprocessor.html#seasonal-statistics

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
