### PR TITLE
Renamed vertical regridding schemes

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -334,7 +334,7 @@ extract the levels and vertically regrid onto the vertical levels of
           levels: ERA-Interim
           # This also works, but allows specifying the pressure coordinate name
           # levels: {dataset: ERA-Interim, coordinate: air_pressure}
-          scheme: linear_horizontal_extrapolate_vertical
+          scheme: linear_extrapolate
 
 By default, vertical interpolation is performed in the dimension coordinate of
 the z axis. If you want to explicitly declare the z axis coordinate to use
@@ -348,7 +348,7 @@ the name of the desired coordinate:
       preproc_select_levels_from_dataset:
         extract_levels:
           levels: ERA-Interim
-          scheme: linear_horizontal_extrapolate_vertical
+          scheme: linear_extrapolate
           coordinate: air_pressure
 
 If ``coordinate`` is specified, pressure levels (if present) can be converted

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -377,7 +377,7 @@ The meaning of 'very close' can be changed by providing the parameters:
 Schemes for vertical interpolation and extrapolation
 ----------------------------------------------------
 
-The vertical interpolation current supports the following schemes:
+The vertical interpolation currently supports the following schemes:
 
 * ``linear``: Linear interpolation without extrapolation, i.e., extrapolation
   points will be masked even if the source data is not a masked array.
@@ -392,12 +392,12 @@ The vertical interpolation current supports the following schemes:
   nearest source point.
 
 .. note::
-   Previous versions of ESMValCore (<2.5) supported the schemes
+   Previous versions of ESMValCore (<2.5.0) supported the schemes
    ``linear_horizontal_extrapolate_vertical`` and
    ``nearest_horizontal_extrapolate_vertical``. These schemes have been renamed
    to ``linear_extrapolate`` and ``nearest_extrapolate``, respectively, in
-   version 2.5 and are identical to the new schemes. Support for the old
-   schemes will be removed in version 2.7.
+   version 2.5.0 and are identical to the new schemes. Support for the old
+   names will be removed in version 2.7.0.
 
 * See also :func:`esmvalcore.preprocessor.extract_levels`.
 * See also :func:`esmvalcore.preprocessor.get_cmor_levels`.

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -374,29 +374,39 @@ The meaning of 'very close' can be changed by providing the parameters:
     By default, `atol` will be set to 10^-7 times the mean value of
     of the available levels.
 
+Schemes for vertical interpolation and extrapolation
+----------------------------------------------------
+
+The vertical interpolation current supports the following schemes:
+
+* ``linear``: Linear interpolation without extrapolation, i.e., extrapolation
+  points will be masked even if the source data is not a masked array.
+* ``linear_extrapolate``: Linear interpolation with **nearest-neighbour**
+  extrapolation, i.e., extrapolation points will take their value from the
+  nearest source point.
+* ``nearest``: Nearest-neighbour interpolation without extrapolation, i.e.,
+  extrapolation points will be masked even if the source data is not a masked
+  array.
+* ``nearest_extrapolate``: Nearest-neighbour interpolation with nearest-neighbour
+  extrapolation, i.e., extrapolation points will take their value from the
+  nearest source point.
+
+.. note::
+   Previous versions of ESMValCore (<2.5) supported the schemes
+   ``linear_horizontal_extrapolate_vertical`` and
+   ``nearest_horizontal_extrapolate_vertical``. These schemes have been renamed
+   to ``linear_extrapolate`` and ``nearest_extrapolate``, respectively, in
+   version 2.5 and are identical to the new schemes. Support for the old
+   schemes will be removed in version 2.7.
 
 * See also :func:`esmvalcore.preprocessor.extract_levels`.
 * See also :func:`esmvalcore.preprocessor.get_cmor_levels`.
 
 .. note::
 
-   For both vertical and horizontal regridding one can control the
-   extrapolation mode when defining the interpolation scheme. Controlling the
-   extrapolation mode allows us to avoid situations where extrapolating values
-   makes little physical sense (e.g. extrapolating beyond the last data point).
-   The extrapolation mode is controlled by the `extrapolation_mode`
-   keyword. For the available interpolation schemes available in Iris, the
-   extrapolation_mode keyword must be one of:
-
-        * ``extrapolate``: the extrapolation points will be calculated by
-	  extending the gradient of the closest two points;
-        * ``error``: a ``ValueError`` exception will be raised, notifying an
-	  attempt to extrapolate;
-        * ``nan``: the extrapolation points will be be set to NaN;
-        * ``mask``: the extrapolation points will always be masked, even if the
-	  source data is not a ``MaskedArray``; or
-        * ``nanmask``: if the source data is a MaskedArray the extrapolation
-	  points will be masked, otherwise they will be set to NaN.
+   Controlling the extrapolation mode allows us to avoid situations where
+   extrapolating values makes little physical sense (e.g. extrapolating beyond
+   the last data point).
 
 
 .. _weighting:
@@ -818,35 +828,32 @@ Regridding (interpolation, extrapolation) schemes
 
 The schemes used for the interpolation and extrapolation operations needed by
 the horizontal regridding functionality directly map to their corresponding
-implementations in Iris:
+implementations in :mod:`iris`:
 
-* ``linear``: ``Linear(extrapolation_mode='mask')``, see :obj:`iris.analysis.Linear`.
-* ``linear_extrapolate``: ``Linear(extrapolation_mode='extrapolate')``, see :obj:`iris.analysis.Linear`.
-* ``nearest``: ``Nearest(extrapolation_mode='mask')``, see :obj:`iris.analysis.Nearest`.
-* ``area_weighted``: ``AreaWeighted()``, see :obj:`iris.analysis.AreaWeighted`.
-* ``unstructured_nearest``: ``UnstructuredNearest()``, see :obj:`iris.analysis.UnstructuredNearest`.
+* ``linear``: Linear interpolation without extrapolation, i.e., extrapolation
+  points will be masked even if the source data is not a masked array (uses
+  ``Linear(extrapolation_mode='mask')``, see :obj:`iris.analysis.Linear`).
+* ``linear_extrapolate``: Linear interpolation with extrapolation, i.e.,
+  extrapolation points will be calculated by extending the gradient of the
+  closest two points (uses ``Linear(extrapolation_mode='extrapolate')``, see
+  :obj:`iris.analysis.Linear`).
+* ``nearest``: Nearest-neighbour interpolation without extrapolation, i.e.,
+  extrapolation points will be masked even if the source data is not a masked
+  array (uses ``Nearest(extrapolation_mode='mask')``, see
+  :obj:`iris.analysis.Nearest`).
+* ``area_weighted``: Area-weighted regridding (uses ``AreaWeighted()``, see
+  :obj:`iris.analysis.AreaWeighted`).
+* ``unstructured_nearest``: Nearest-neighbour interpolation for unstructured
+  grids (uses ``UnstructuredNearest()``, see
+  :obj:`iris.analysis.UnstructuredNearest`).
 
 See also :func:`esmvalcore.preprocessor.regrid`
 
 .. note::
 
-   For both vertical and horizontal regridding one can control the
-   extrapolation mode when defining the interpolation scheme. Controlling the
-   extrapolation mode allows us to avoid situations where extrapolating values
-   makes little physical sense (e.g. extrapolating beyond the last data
-   point). The extrapolation mode is controlled by the `extrapolation_mode`
-   keyword. For the available interpolation schemes available in Iris, the
-   extrapolation_mode keyword must be one of:
-
-        * ``extrapolate`` – the extrapolation points will be calculated by
-	  extending the gradient of the closest two points;
-        * ``error`` – a ``ValueError`` exception will be raised, notifying an
-	  attempt to extrapolate;
-        * ``nan`` – the extrapolation points will be be set to NaN;
-        * ``mask`` – the extrapolation points will always be masked, even if
-	  the source data is not a ``MaskedArray``; or
-        * ``nanmask`` – if the source data is a MaskedArray the extrapolation
-	  points will be masked, otherwise they will be set to NaN.
+   Controlling the extrapolation mode allows us to avoid situations where
+   extrapolating values makes little physical sense (e.g. extrapolating beyond
+   the last data point).
 
 .. note::
 

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -729,8 +729,8 @@ def parse_vertical_scheme(scheme):
         deprecation_msg = (
             f"The vertical regridding scheme ``{scheme}`` has been deprecated "
             f"in ESMValCore version 2.5 and is scheduled for removal in "
-            f"version 2.7. It has been renamed to ``{new_scheme}`` without "
-            f"any change in functionality.")
+            f"version 2.7. It has been renamed to the identical scheme "
+            f"``{new_scheme}`` without any change in functionality.")
         warnings.warn(deprecation_msg, ESMValCoreDeprecationWarning)
         scheme = new_scheme
 

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import re
+import warnings
 from copy import deepcopy
 from decimal import Decimal
 from typing import Dict
@@ -13,6 +14,8 @@ import stratify
 from dask import array as da
 from iris.analysis import AreaWeighted, Linear, Nearest, UnstructuredNearest
 from iris.util import broadcast_to_shape
+
+from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 
 from ..cmor._fixes.shared import add_altitude_from_plev, add_plev_from_altitude
 from ..cmor.fix import fix_file, fix_metadata
@@ -63,9 +66,12 @@ HORIZONTAL_SCHEMES = {
 }
 
 # Supported vertical interpolation schemes.
-VERTICAL_SCHEMES = ('linear', 'nearest',
-                    'linear_horizontal_extrapolate_vertical',
-                    'nearest_horizontal_extrapolate_vertical')
+VERTICAL_SCHEMES = (
+    'linear',
+    'nearest',
+    'linear_extrapolate',
+    'nearest_extrapolate',
+)
 
 
 def parse_cell_spec(spec):
@@ -705,27 +711,44 @@ def parse_vertical_scheme(scheme):
         The vertical interpolation scheme to use. Choose from
         'linear',
         'nearest',
-        'nearest_horizontal_extrapolate_vertical',
-        'linear_horizontal_extrapolate_vertical'.
+        'linear_extrapolate',
+        'nearest_extrapolate'.
 
     Returns
     -------
     (str, str)
         A tuple containing the interpolation and extrapolation scheme.
     """
+    # Issue warning when deprecated schemes are used
+    deprecated_schemes = {
+        'linear_horizontal_extrapolate_vertical': 'linear_extrapolate',
+        'nearest_horizontal_extrapolate_vertical': 'nearest_extrapolate',
+    }
+    if scheme in deprecated_schemes:
+        new_scheme = deprecated_schemes[scheme]
+        deprecation_msg = (
+            f"The vertical regridding scheme ``{scheme}`` has been deprecated "
+            f"in ESMValCore version 2.5 and is scheduled for removal in "
+            f"version 2.7. It has been replaced with the scheme "
+            f"``{new_scheme}``.")
+        warnings.warn(deprecation_msg, ESMValCoreDeprecationWarning)
+        scheme = new_scheme
+
+    # Check if valid scheme is given
     if scheme not in VERTICAL_SCHEMES:
-        emsg = 'Unknown vertical interpolation scheme, got {!r}. '
-        emsg += 'Possible schemes: {!r}'
-        raise ValueError(emsg.format(scheme, VERTICAL_SCHEMES))
+        raise ValueError(
+            f"Unknown vertical interpolation scheme, got '{scheme}', possible "
+            f"schemes are {VERTICAL_SCHEMES}")
 
     # This allows us to put level 0. to load the ocean surface.
     extrap_scheme = 'nan'
-    if scheme == 'nearest_horizontal_extrapolate_vertical':
-        scheme = 'nearest'
+
+    if scheme == 'linear_extrapolate':
+        scheme = 'linear'
         extrap_scheme = 'nearest'
 
-    if scheme == 'linear_horizontal_extrapolate_vertical':
-        scheme = 'linear'
+    if scheme == 'nearest_extrapolate':
+        scheme = 'nearest'
         extrap_scheme = 'nearest'
 
     return scheme, extrap_scheme
@@ -753,8 +776,8 @@ def extract_levels(cube,
         The vertical interpolation scheme to use. Choose from
         'linear',
         'nearest',
-        'nearest_horizontal_extrapolate_vertical',
-        'linear_horizontal_extrapolate_vertical'.
+        'linear_extrapolate',
+        'nearest_extrapolate'.
     coordinate :  optional str
         The coordinate to interpolate. If specified, pressure levels
         (if present) can be converted to height levels and vice versa using

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -728,8 +728,8 @@ def parse_vertical_scheme(scheme):
         new_scheme = deprecated_schemes[scheme]
         deprecation_msg = (
             f"The vertical regridding scheme ``{scheme}`` has been deprecated "
-            f"in ESMValCore version 2.5 and is scheduled for removal in "
-            f"version 2.7. It has been renamed to the identical scheme "
+            f"in ESMValCore version 2.5.0 and is scheduled for removal in "
+            f"version 2.7.0. It has been renamed to the identical scheme "
             f"``{new_scheme}`` without any change in functionality.")
         warnings.warn(deprecation_msg, ESMValCoreDeprecationWarning)
         scheme = new_scheme

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -729,8 +729,8 @@ def parse_vertical_scheme(scheme):
         deprecation_msg = (
             f"The vertical regridding scheme ``{scheme}`` has been deprecated "
             f"in ESMValCore version 2.5 and is scheduled for removal in "
-            f"version 2.7. It has been replaced with the scheme "
-            f"``{new_scheme}``.")
+            f"version 2.7. It has been renamed to ``{new_scheme}`` without "
+            f"any change in functionality.")
         warnings.warn(deprecation_msg, ESMValCoreDeprecationWarning)
         scheme = new_scheme
 

--- a/tests/integration/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/integration/preprocessor/_regrid/test_extract_levels.py
@@ -113,7 +113,7 @@ class Test(tests.Test):
         assert self.cube.coords('air_pressure')
         assert not self.cube.coords('altitude')
         result = extract_levels(self.cube, [1, 2],
-                                'linear_horizontal_extrapolate_vertical',
+                                'linear_extrapolate',
                                 coordinate='altitude')
         assert not result.coords('air_pressure')
         assert result.coords('altitude')
@@ -129,7 +129,7 @@ class Test(tests.Test):
         assert not self.cube.coords('air_pressure')
         assert self.cube.coords('altitude')
         result = extract_levels(self.cube, [1, 2],
-                                'linear_horizontal_extrapolate_vertical',
+                                'linear_extrapolate',
                                 coordinate='air_pressure')
         assert result.coords('air_pressure')
         assert not result.coords('altitude')

--- a/tests/unit/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_levels.py
@@ -69,8 +69,7 @@ class Test(tests.Test):
         for scheme in deprecated_references:
             warn_msg = (
                 "has been deprecated in ESMValCore version 2.5 and is "
-                "scheduled for removal in version 2.7. It has been replaced "
-                "with the scheme")
+                "scheduled for removal in version 2.7. It has been renamed to")
             with pytest.warns(ESMValCoreDeprecationWarning, match=warn_msg):
                 interp, extrap = parse_vertical_scheme(scheme)
             assert interp, extrap == deprecated_references[scheme]

--- a/tests/unit/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_levels.py
@@ -68,8 +68,9 @@ class Test(tests.Test):
         }
         for scheme in deprecated_references:
             warn_msg = (
-                "has been deprecated in ESMValCore version 2.5 and is "
-                "scheduled for removal in version 2.7. It has been renamed to")
+                "`` has been deprecated in ESMValCore version 2.5 and is "
+                "scheduled for removal in version 2.7. It has been renamed to "
+                "the identical scheme ``")
             with pytest.warns(ESMValCoreDeprecationWarning, match=warn_msg):
                 interp, extrap = parse_vertical_scheme(scheme)
             assert interp, extrap == deprecated_references[scheme]

--- a/tests/unit/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_levels.py
@@ -6,15 +6,17 @@ from unittest import mock
 
 import iris
 import numpy as np
+import pytest
 from numpy import ma
 
 import tests
+from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 from esmvalcore.preprocessor._regrid import (
     _MDI,
     VERTICAL_SCHEMES,
+    _preserve_fx_vars,
     extract_levels,
     parse_vertical_scheme,
-    _preserve_fx_vars,
 )
 from tests.unit.preprocessor._regrid import _make_cube, _make_vcoord
 
@@ -33,8 +35,7 @@ class Test(tests.Test):
             'esmvalcore.preprocessor._regrid._create_cube',
             return_value=self.created_cube)
         self.schemes = [
-            'linear', 'nearest', 'linear_horizontal_extrapolate_vertical',
-            'nearest_horizontal_extrapolate_vertical'
+            'linear', 'nearest', 'linear_extrapolate', 'nearest_extrapolate',
         ]
         descriptor, self.filename = tempfile.mkstemp('.nc')
         os.close(descriptor)
@@ -53,12 +54,26 @@ class Test(tests.Test):
         reference = {
             'linear': ('linear', 'nan'),
             'nearest': ('nearest', 'nan'),
-            'linear_horizontal_extrapolate_vertical': ('linear', 'nearest'),
-            'nearest_horizontal_extrapolate_vertical': ('nearest', 'nearest'),
+            'linear_extrapolate': ('linear', 'nearest'),
+            'nearest_extrapolate': ('nearest', 'nearest'),
         }
         for scheme in self.schemes:
             interpolation, extrapolation = parse_vertical_scheme(scheme)
             assert interpolation, extrapolation == reference[scheme]
+
+        # Deprecated schemes (remove in v2.7)
+        deprecated_references = {
+            'linear_horizontal_extrapolate_vertical': ('linear', 'nearest'),
+            'nearest_horizontal_extrapolate_vertical': ('nearest', 'nearest'),
+        }
+        for scheme in deprecated_references:
+            warn_msg = (
+                "has been deprecated in ESMValCore version 2.5 and is "
+                "scheduled for removal in version 2.7. It has been replaced "
+                "with the scheme")
+            with pytest.warns(ESMValCoreDeprecationWarning, match=warn_msg):
+                interp, extrap = parse_vertical_scheme(scheme)
+            assert interp, extrap == deprecated_references[scheme]
 
     def test_nop__levels_match(self):
         vcoord = _make_vcoord(self.z, dtype=self.dtype)

--- a/tests/unit/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_levels.py
@@ -68,9 +68,9 @@ class Test(tests.Test):
         }
         for scheme in deprecated_references:
             warn_msg = (
-                "`` has been deprecated in ESMValCore version 2.5 and is "
-                "scheduled for removal in version 2.7. It has been renamed to "
-                "the identical scheme ``")
+                "`` has been deprecated in ESMValCore version 2.5.0 and is "
+                "scheduled for removal in version 2.7.0. It has been renamed "
+                "to the identical scheme ``")
             with pytest.warns(ESMValCoreDeprecationWarning, match=warn_msg):
                 interp, extrap = parse_vertical_scheme(scheme)
             assert interp, extrap == deprecated_references[scheme]


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR deprecates the vertical regridding schemes `nearest_horizontal_extrapolate_vertical` and `linear_horizontal_extrapolate_vertical` in favor of `nearest_extrapolate` and `linear_extrapolate`.

I changed all affected recipes and tested them successfully (see ESMValGroup/ESMValTool#2487).

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1170

Link to documentation: https://esmvaltool--1429.org.readthedocs.build/projects/ESMValCore/en/1429/recipe/preprocessor.html#vertical-interpolation

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- ~~[ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~~
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
