### PR TITLE
Added earlier validation for command line arguments

### DIFF
--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -368,11 +368,34 @@ class ESMValTool():
             strict (fail if there are any warnings).
         """
         import os
+        import warnings
 
         from ._config import configure_logging, read_config_user_file
         from ._recipe import TASKSEP
         from .cmor.check import CheckLevels
         from .esgf._logon import logon
+
+        # Check validity of optional command line arguments with experimental
+        # API
+        with warnings.catch_warnings():
+            # ignore experimental API warning
+            warnings.simplefilter("ignore")
+            from .experimental.config._config_object import Config
+        explicit_optional_kwargs = {
+            'config_file': config_file,
+            'resume_from': resume_from,
+            'max_datasets': max_datasets,
+            'max_years': max_years,
+            'skip_nonexistent': skip_nonexistent,
+            'offline': offline,
+            'diagnostics': diagnostics,
+            'check_level': check_level,
+        }
+        all_optional_kwargs = dict(kwargs)
+        for (key, val) in explicit_optional_kwargs.items():
+            if val is not None:
+                all_optional_kwargs[key] = val
+        Config(all_optional_kwargs)
 
         recipe = self._get_recipe(recipe)
         cfg = read_config_user_file(config_file, recipe.stem, kwargs)
@@ -390,7 +413,7 @@ class ESMValTool():
         self._log_header(cfg['config_file'], log_files)
 
         cfg['resume_from'] = parse_resume(resume_from, recipe)
-        cfg['skip-nonexistent'] = skip_nonexistent
+        cfg['skip_nonexistent'] = skip_nonexistent
         if isinstance(diagnostics, str):
             diagnostics = diagnostics.split(' ')
         cfg['diagnostics'] = {

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -380,7 +380,7 @@ class ESMValTool():
         with warnings.catch_warnings():
             # ignore experimental API warning
             warnings.simplefilter("ignore")
-            from .experimental.config._config_object import Config
+            from .experimental.config._config_object import ExpConfig
         explicit_optional_kwargs = {
             'config_file': config_file,
             'resume_from': resume_from,
@@ -395,7 +395,7 @@ class ESMValTool():
         for (key, val) in explicit_optional_kwargs.items():
             if val is not None:
                 all_optional_kwargs[key] = val
-        Config(all_optional_kwargs)
+        ExpConfig(all_optional_kwargs)
 
         recipe = self._get_recipe(recipe)
         cfg = read_config_user_file(config_file, recipe.stem, kwargs)

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -380,7 +380,7 @@ class ESMValTool():
         with warnings.catch_warnings():
             # ignore experimental API warning
             warnings.simplefilter("ignore")
-            from .experimental.config._config_object import ExpConfig
+            from .experimental.config._config_object import Config as ExpConfig
         explicit_optional_kwargs = {
             'config_file': config_file,
             'resume_from': resume_from,

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -824,7 +824,7 @@ def _match_products(products, variables):
 def _allow_skipping(ancestors, variable, config_user):
     """Allow skipping of datasets."""
     allow_skipping = all([
-        config_user.get('skip-nonexistent'),
+        config_user.get('skip_nonexistent'),
         not ancestors,
         variable['dataset'] != variable.get('reference_dataset'),
     ])

--- a/esmvalcore/experimental/config/_config_validators.py
+++ b/esmvalcore/experimental/config/_config_validators.py
@@ -270,7 +270,7 @@ _validators = {
 
     # From CLI
     "resume_from": validate_pathlist,
-    "skip-nonexistent": validate_bool,
+    "skip_nonexistent": validate_bool,
     "diagnostics": validate_diagnostics,
     "check_level": validate_check_level,
     "offline": validate_bool,

--- a/esmvalcore/preprocessor/_derive/__init__.py
+++ b/esmvalcore/preprocessor/_derive/__init__.py
@@ -95,7 +95,7 @@ def derive(cubes, short_name, long_name, units, standard_name=None):
         cube = DerivedVariable().calculate(cubes)
     except Exception as exc:
         msg = (f"Derivation of variable '{short_name}' failed. If you used "
-               f"the option '--skip-nonexistent' for running your recipe, "
+               f"the option '--skip_nonexistent' for running your recipe, "
                f"this might be caused by missing input data for derivation")
         raise ValueError(msg) from exc
 

--- a/tests/unit/main/test_esmvaltool.py
+++ b/tests/unit/main/test_esmvaltool.py
@@ -42,7 +42,7 @@ def test_run(mocker, tmp_path, cmd_offline, cfg_offline):
         'diagnostics': set(),
         'offline': offline,
         'resume_from': [],
-        'skip-nonexistent': False,
+        'skip_nonexistent': False,
 
     })
 

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -94,45 +94,45 @@ VAR_A_REF_B = {'dataset': 'A', 'reference_dataset': 'B'}
 TEST_ALLOW_SKIPPING = [
     ([], VAR_A, {}, False),
     ([], VAR_A, {
-        'skip-nonexistent': False
+        'skip_nonexistent': False
     }, False),
     ([], VAR_A, {
-        'skip-nonexistent': True
+        'skip_nonexistent': True
     }, True),
     ([], VAR_A_REF_A, {}, False),
     ([], VAR_A_REF_A, {
-        'skip-nonexistent': False
+        'skip_nonexistent': False
     }, False),
     ([], VAR_A_REF_A, {
-        'skip-nonexistent': True
+        'skip_nonexistent': True
     }, False),
     ([], VAR_A_REF_B, {}, False),
     ([], VAR_A_REF_B, {
-        'skip-nonexistent': False
+        'skip_nonexistent': False
     }, False),
     ([], VAR_A_REF_B, {
-        'skip-nonexistent': True
+        'skip_nonexistent': True
     }, True),
     (['A'], VAR_A, {}, False),
     (['A'], VAR_A, {
-        'skip-nonexistent': False
+        'skip_nonexistent': False
     }, False),
     (['A'], VAR_A, {
-        'skip-nonexistent': True
+        'skip_nonexistent': True
     }, False),
     (['A'], VAR_A_REF_A, {}, False),
     (['A'], VAR_A_REF_A, {
-        'skip-nonexistent': False
+        'skip_nonexistent': False
     }, False),
     (['A'], VAR_A_REF_A, {
-        'skip-nonexistent': True
+        'skip_nonexistent': True
     }, False),
     (['A'], VAR_A_REF_B, {}, False),
     (['A'], VAR_A_REF_B, {
-        'skip-nonexistent': False
+        'skip_nonexistent': False
     }, False),
     (['A'], VAR_A_REF_B, {
-        'skip-nonexistent': True
+        'skip_nonexistent': True
     }, False),
 ]
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR adds additional validation for the validity of command line arguments before reading the configuration. This allows us to detect errors like


```
> esmvaltool run --config-usa ~/config-user.yml ~/tmp/recipes/recipe_cox18nature.yml
...
esmvalcore.experimental.config._validated_config.InvalidConfigParameter: `config-usa` is not a valid config parameter.
```

In addition, this also catches wrong types (this has also been caught previously, but later in the run):

```
> esmvaltool run --config-file ~/config/DKRZ_default.yml --offline=aaaa ~/ESMValTool/esmvaltool/recipes/examples/recipe_python.yml
...
esmvalcore.experimental.config._validated_config.InvalidConfigParameter: Key `offline`: Could not convert `aaaa` to `bool`
```

Moreover, I renamed the option `skip-nonexistent` to `skip_nonexistent` across the entire tool. This is now consistent with other options. `Fire` automatically renames `-` to `_` anyway, so both spelling options are (still) fine in the command line.



<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #797

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
