### PR TITLE
Fixed bug that caused automatic download to fail in rare cases

### DIFF
--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -95,6 +95,7 @@ drs:
 
 # Site-specific entries: DKRZ
 # Uncomment the lines below to locate data on Mistral at DKRZ
+# Note: Use offline: false only on login and prepost nodes
 #auxiliary_data_dir: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/AUX
 #rootpath:
 #  CMIP6: /mnt/lustre02/work/ik1017/CMIP6/data/CMIP6

--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -95,7 +95,7 @@ drs:
 
 # Site-specific entries: DKRZ
 # Uncomment the lines below to locate data on Mistral at DKRZ
-# Note: Use offline: false only on login and prepost nodes
+# Note: Use "offline: false" only on login and prepost nodes
 #auxiliary_data_dir: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/AUX
 #rootpath:
 #  CMIP6: /mnt/lustre02/work/ik1017/CMIP6/data/CMIP6

--- a/esmvalcore/esgf/_download.py
+++ b/esmvalcore/esgf/_download.py
@@ -109,9 +109,14 @@ def get_preferred_hosts():
     for entry in speeds.values():
         entry[SPEED] = compute_speed(entry[SIZE], entry[DURATION])
 
-    # Hosts from which no data has been downloaded yet get median speed
-    median_speed = median(speeds[h][SPEED] for h in speeds
-                          if speeds[h][SPEED] != 0)
+    # Hosts from which no data has been downloaded yet get median speed; if no
+    # host with non-zero entries is found assign a value of 0.0
+    speeds_list = [speeds[h][SPEED] for h in speeds if
+                   speeds[h][SPEED] != 0.0]
+    if not speeds_list:
+        median_speed = 0.0
+    else:
+        median_speed = median(speeds_list)
     for host in speeds:
         if speeds[host][SIZE] == 0:
             speeds[host][SPEED] = median_speed

--- a/tests/unit/esgf/test_download.py
+++ b/tests/unit/esgf/test_download.py
@@ -126,6 +126,33 @@ def test_get_preferred_hosts(monkeypatch, tmp_path, age_in_hours):
     assert preferred_hosts == expected
 
 
+def test_get_preferred_hosts_only_zeros(monkeypatch, tmp_path):
+    """Test ``get_preferred_hosts`` when speed is zero for all entries."""
+    hosts_file = tmp_path / 'esgf-hosts.yml'
+    content = textwrap.dedent("""
+    aims3.llnl.gov:
+      duration (s): 0
+      error: false
+      size (bytes): 0
+      speed (MB/s): 0
+    esg.lasg.ac.cn:
+      duration (s): 0.0
+      error: false
+      size (bytes): 0.0
+      speed (MB/s): 0.0
+    """).lstrip()
+    hosts_file.write_text(content)
+    monkeypatch.setattr(_download, 'HOSTS_FILE', hosts_file)
+
+    preferred_hosts = _download.get_preferred_hosts()
+
+    # The following assert is safe since "the built-in sorted() function is
+    # guaranteed to be stable"
+    # (https://docs.python.org/3/library/functions.html)
+    expected = ['aims3.llnl.gov', 'esg.lasg.ac.cn']
+    assert preferred_hosts == expected
+
+
 def test_sort_hosts(mocker):
     """Test that hosts are sorted according to priority by sort_hosts."""
     urls = [


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR fixes a bug in the automatic download feature that led to weird error messages. It assigns `median_speed = 0.0` if no non-zero values for the download speed can be found from past runs. This avoids cryptic error messages that result from using the download feature on a node without internet connection.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1440

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] ~~[🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available~~
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] ~~[🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~~
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
