### PR TITLE
Removed scalar coordinates `p0` and `ptop` prior to merge in `multi_model_statistics`

### DIFF
--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -72,9 +72,7 @@ def add_plev_from_altitude(cube):
             pressure_bounds = altitude_to_pressure(height_coord.core_bounds())
         pressure_coord = iris.coords.AuxCoord(pressure_points,
                                               bounds=pressure_bounds,
-                                              var_name='plev',
                                               standard_name='air_pressure',
-                                              long_name='pressure',
                                               units='Pa')
         cube.add_aux_coord(pressure_coord, cube.coord_dims(height_coord))
         return
@@ -108,9 +106,7 @@ def add_altitude_from_plev(cube):
             altitude_bounds = pressure_to_altitude(plev_coord.core_bounds())
         altitude_coord = iris.coords.AuxCoord(altitude_points,
                                               bounds=altitude_bounds,
-                                              var_name='alt',
                                               standard_name='altitude',
-                                              long_name='altitude',
                                               units='m')
         cube.add_aux_coord(altitude_coord, cube.coord_dims(plev_coord))
         return

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -216,9 +216,11 @@ def _combine(cubes):
             coord.long_name = None
             coord.attributes = None
 
-        for auxcoord in cube.coords(dimensions=()):
-            if (auxcoord.var_name == 'p0' or auxcoord.var_name == 'ptop'):
-                cube.remove_coord(auxcoord)
+        # Remove specific scalar coordinates which are not expected to be equal
+        scalar_coords_to_remove = ['p0', 'ptop']
+        for scalar_coord in cube.coords(dimensions=()):
+            if scalar_coord.var_name in scalar_coords_to_remove:
+                cube.remove_coord(scalar_coord)
 
     cubes = iris.cube.CubeList(cubes)
 

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -216,7 +216,7 @@ def _combine(cubes):
             coord.long_name = None
             coord.attributes = None
 
-        for auxcoord in cube.aux_coords:
+        for auxcoord in cube.coords(dimensions=()):
             if (auxcoord.var_name == 'p0' or auxcoord.var_name == 'ptop'):
                 cube.remove_coord(auxcoord)
 

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -216,6 +216,10 @@ def _combine(cubes):
             coord.long_name = None
             coord.attributes = None
 
+        for auxcoord in cube.aux_coords:
+            if (auxcoord.var_name == 'p0' or auxcoord.var_name == 'ptop'):
+                cube.remove_coord(auxcoord)
+
     cubes = iris.cube.CubeList(cubes)
 
     merged_cube = cubes.merge_cube()

--- a/tests/integration/cmor/_fixes/test_common.py
+++ b/tests/integration/cmor/_fixes/test_common.py
@@ -156,9 +156,9 @@ def hybrid_height_coord_fix_metadata(nc_path, short_name, fix):
     air_pressure_coord = cube.coord('air_pressure')
     np.testing.assert_allclose(air_pressure_coord.points, PRESSURE_POINTS)
     np.testing.assert_allclose(air_pressure_coord.bounds, PRESSURE_BOUNDS)
-    assert air_pressure_coord.var_name == 'plev'
+    assert air_pressure_coord.var_name is None
     assert air_pressure_coord.standard_name == 'air_pressure'
-    assert air_pressure_coord.long_name == 'pressure'
+    assert air_pressure_coord.long_name is None
     assert air_pressure_coord.units == 'Pa'
 
 

--- a/tests/integration/cmor/_fixes/test_shared.py
+++ b/tests/integration/cmor/_fixes/test_shared.py
@@ -106,20 +106,15 @@ def test_add_aux_coords_from_cubes(coord_dict, output):
 
 
 ALT_COORD = iris.coords.AuxCoord([0.0], bounds=[[-100.0, 500.0]],
-                                 var_name='alt', long_name='altitude',
                                  standard_name='altitude', units='m')
-ALT_COORD_NB = iris.coords.AuxCoord([0.0], var_name='alt',
-                                    long_name='altitude',
-                                    standard_name='altitude', units='m')
+ALT_COORD_NB = iris.coords.AuxCoord([0.0], standard_name='altitude', units='m')
 ALT_COORD_KM = iris.coords.AuxCoord([0.0], bounds=[[-0.1, 0.5]],
                                     var_name='alt', long_name='altitude',
                                     standard_name='altitude', units='km')
 P_COORD = iris.coords.AuxCoord([101325.0], bounds=[[102532.0, 95460.8]],
-                               var_name='plev', standard_name='air_pressure',
-                               long_name='pressure', units='Pa')
-P_COORD_NB = iris.coords.AuxCoord([101325.0], var_name='plev',
-                                  standard_name='air_pressure',
-                                  long_name='pressure', units='Pa')
+                               standard_name='air_pressure', units='Pa')
+P_COORD_NB = iris.coords.AuxCoord([101325.0], standard_name='air_pressure',
+                                  units='Pa')
 CUBE_ALT = iris.cube.Cube([1.0], var_name='x',
                           aux_coords_and_dims=[(ALT_COORD, 0)])
 CUBE_ALT_NB = iris.cube.Cube([1.0], var_name='x',

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -8,8 +8,8 @@ import iris
 import numpy as np
 import pytest
 from cf_units import Unit
-from iris.cube import Cube
 from iris.coords import AuxCoord
+from iris.cube import Cube
 
 import esmvalcore.preprocessor._multimodel as mm
 from esmvalcore.iris_helpers import date2num

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from cf_units import Unit
 from iris.cube import Cube
+from iris.coords import AuxCoord
 
 import esmvalcore.preprocessor._multimodel as mm
 from esmvalcore.iris_helpers import date2num
@@ -369,6 +370,25 @@ def test_combine_inconsistent_var_names_fail():
 
     with pytest.raises(iris.exceptions.MergeError):
         _ = mm._combine(cubes)
+
+
+@pytest.mark.parametrize('scalar_coord', ['p0', 'ptop'])
+def test_combine_with_scalar_coords_to_remove(scalar_coord):
+    """Test _combine with scalar coordinates that should be removed."""
+    num_cubes = 5
+    cubes = []
+
+    for num in range(num_cubes):
+        cube = generate_cube_from_dates('monthly')
+        cubes.append(cube)
+
+    scalar_coord_0 = AuxCoord(0.0, var_name=scalar_coord)
+    scalar_coord_1 = AuxCoord(1.0, var_name=scalar_coord)
+    cubes[0].add_aux_coord(scalar_coord_0, ())
+    cubes[1].add_aux_coord(scalar_coord_1, ())
+
+    merged_cube = mm._combine(cubes)
+    assert merged_cube.shape == (5, 3)
 
 
 @pytest.mark.parametrize('span', SPAN_OPTIONS)


### PR DESCRIPTION
This is a solution for the issue described in https://github.com/ESMValGroup/ESMValCore/issues/1222.

## Description

Variables on hybrid vertical levels (e.g. clw) have to be converted to pressure or height levels to be able to be processed by some diagnostics and to be able to calculate meaningful multi-model statistics across different models. For this conversion, some models provide an auxiliary coordinate 'p0'. Calculating the multi-model mean over such datasets converted to pressure or height levels fails because 'p0' is kept after converting the vertical levels but (as expected) not identical in all models. This problem is solved by deleting the scalar auxiliary coordinates p0 and ptop (if present) after converting to pressure or altitude levels.

Closes #1222

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
