### PR TITLE
Added `dataset` and `alias` attributes to `multi_model_statistics` output

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -754,11 +754,16 @@ def _update_multiproduct(input_products, order, preproc_dir, step):
         common_attributes = _get_common_attributes(products)
 
         for statistic in settings.get('statistics'):
-            common_attributes[step] = _get_tag(step, identifier, statistic)
-            filename = get_multiproduct_filename(common_attributes,
+            statistic_attributes = dict(common_attributes)
+            statistic_attributes[step] = _get_tag(step, identifier, statistic)
+            statistic_attributes.setdefault('alias',
+                                            statistic_attributes[step])
+            statistic_attributes.setdefault('dataset',
+                                            statistic_attributes[step])
+            filename = get_multiproduct_filename(statistic_attributes,
                                                  preproc_dir)
-            common_attributes['filename'] = filename
-            statistic_product = PreprocessorFile(common_attributes,
+            statistic_attributes['filename'] = filename
+            statistic_product = PreprocessorFile(statistic_attributes,
                                                  downstream_settings)
             output_products.add(statistic_product)
             relevant_settings['output_products'][identifier][

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -73,12 +73,17 @@ class Test(unittest.TestCase):
 class PreprocessorFile(mock.Mock):
     """Mocked PreprocessorFile."""
 
-    def __init__(self, cubes, filename, attributes, **kwargs):
+    def __init__(self, cubes, filename, attributes, settings=None, **kwargs):
         """Initialize with cubes."""
         super().__init__(spec=PreprocessorFileBase, **kwargs)
         self.cubes = cubes
         self.filename = filename
         self.attributes = attributes
-        self.settings = {}
+        if settings is None:
+            self.settings = {}
+        else:
+            self.settings = settings
         self.mock_ancestors = set()
         self.wasderivedfrom = mock.Mock(side_effect=self.mock_ancestors.add)
+
+    group = PreprocessorFileBase.group

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -434,16 +434,16 @@ def test_update_multiproduct_ensemble_statistics():
     cube = iris.cube.Cube(np.array([1]))
     products = [
         PreprocessorFile(cube, 'A',
-                         attributes={'dataset': 'a', **common_attributes},
+                         attributes=common_attributes,
                          settings=settings),
         PreprocessorFile(cube, 'B',
-                         attributes={'dataset': 'b', **common_attributes},
+                         attributes=common_attributes,
                          settings=settings),
         PreprocessorFile(cube, 'C',
-                         attributes={'dataset': 'c', **common_attributes},
+                         attributes=common_attributes,
                          settings=settings),
         PreprocessorFile(cube, 'D',
-                         attributes={'dataset': 'd', **common_attributes},
+                         attributes=common_attributes,
                          settings=settings),
     ]
     order = ('load', 'ensemble_statistics', 'save')

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -356,6 +356,127 @@ def test_multi_model_filename():
     assert attributes['timerange'] == '1989/1992'
 
 
+def test_update_multiproduct_multi_model_statistics():
+    """Test ``_update_multiproduct``."""
+    settings = {'multi_model_statistics': {'statistics': ['mean', 'std_dev']}}
+    common_attributes = {
+        'project': 'CMIP6',
+        'timerange': '2000/2000',
+        'diagnostic': 'd',
+        'variable_group': 'var',
+    }
+    cube = iris.cube.Cube(np.array([1]))
+    products = [
+        PreprocessorFile(cube, 'A',
+                         attributes={'dataset': 'a', **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'B',
+                         attributes={'dataset': 'b', **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'C',
+                         attributes={'dataset': 'c', **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'D',
+                         attributes={'dataset': 'd', **common_attributes},
+                         settings=settings),
+    ]
+    order = ('load', 'multi_model_statistics', 'save')
+    preproc_dir = '/preproc'
+    step = 'multi_model_statistics'
+    output, settings = _recipe._update_multiproduct(
+        products, order, preproc_dir, step)
+
+    assert len(output) == 2
+
+    filenames = [p.filename for p in output]
+    assert '/preproc/d/var/CMIP6_MultiModelMean_2000-2000.nc' in filenames
+    assert '/preproc/d/var/CMIP6_MultiModelStd_Dev_2000-2000.nc' in filenames
+
+    for product in output:
+        for attr in common_attributes:
+            assert attr in product.attributes
+            assert product.attributes[attr] == common_attributes[attr]
+            assert 'alias' in product.attributes
+            assert 'dataset' in product.attributes
+            assert 'multi_model_statistics' in product.attributes
+        if 'MultiModelStd_Dev' in product.filename:
+            assert product.attributes['alias'] == 'MultiModelStd_Dev'
+            assert product.attributes['dataset'] == 'MultiModelStd_Dev'
+            assert (product.attributes['multi_model_statistics'] ==
+                    'MultiModelStd_Dev')
+        elif 'MultiModelMean' in product.filename:
+            assert product.attributes['alias'] == 'MultiModelMean'
+            assert product.attributes['dataset'] == 'MultiModelMean'
+            assert (product.attributes['multi_model_statistics'] ==
+                    'MultiModelMean')
+
+    assert len(settings) == 1
+    output_products = settings['output_products']
+    assert len(output_products) == 1
+    stats = output_products['']
+    assert len(stats) == 2
+    assert 'mean' in stats
+    assert 'std_dev' in stats
+    assert 'MultiModelMean' in stats['mean'].filename
+    assert 'MultiModelStd_Dev' in stats['std_dev'].filename
+
+
+def test_update_multiproduct_ensemble_statistics():
+    """Test ``_update_multiproduct``."""
+    settings = {'ensemble_statistics': {'statistics': ['median']}}
+    common_attributes = {
+        'dataset': 'CanESM2',
+        'project': 'CMIP6',
+        'timerange': '2000/2000',
+        'diagnostic': 'd',
+        'variable_group': 'var',
+    }
+    cube = iris.cube.Cube(np.array([1]))
+    products = [
+        PreprocessorFile(cube, 'A',
+                         attributes={'dataset': 'a', **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'B',
+                         attributes={'dataset': 'b', **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'C',
+                         attributes={'dataset': 'c', **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'D',
+                         attributes={'dataset': 'd', **common_attributes},
+                         settings=settings),
+    ]
+    order = ('load', 'ensemble_statistics', 'save')
+    preproc_dir = '/preproc'
+    step = 'ensemble_statistics'
+    output, settings = _recipe._update_multiproduct(
+        products, order, preproc_dir, step)
+
+    assert len(output) == 1
+    product = list(output)[0]
+    assert (product.filename ==
+            '/preproc/d/var/CMIP6_CanESM2_EnsembleMedian_2000-2000.nc')
+
+    for attr in common_attributes:
+        assert attr in product.attributes
+        assert product.attributes[attr] == common_attributes[attr]
+        assert 'alias' in product.attributes
+        assert product.attributes['alias'] == 'EnsembleMedian'
+        assert 'dataset' in product.attributes
+        assert product.attributes['dataset'] == 'CanESM2'
+        assert 'ensemble_statistics' in product.attributes
+        assert product.attributes['ensemble_statistics'] == 'EnsembleMedian'
+
+    assert len(settings) == 1
+    output_products = settings['output_products']
+    assert len(output_products) == 1
+    stats = output_products['CMIP6_CanESM2']
+    assert len(stats) == 1
+    assert 'median' in stats
+    assert (stats['median'].filename ==
+            '/preproc/d/var/CMIP6_CanESM2_EnsembleMedian_2000-2000.nc')
+
+
 def test_update_multiproduct_no_product():
     cube = iris.cube.Cube(np.array([1]))
     products = [


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Re-adds the attributes `dataset` and `alias` (which many diagnostics rely on) to multi_model_statistics output.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1480

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
