### PR TITLE
Fixed issues with multi-model-statistics timeranges

### DIFF
--- a/doc/recipe/overview.rst
+++ b/doc/recipe/overview.rst
@@ -90,11 +90,18 @@ data specifications:
   Please note that `yaml`_ interprets numbers with a leading ``0`` as octal numbers,
   so we recommend to avoid them. For example, use ``128`` to specify the year
   128 instead of ``0128``.)
-  Alternatively, the time range can be specified in `ISO 8601 format <https://en.wikipedia.org/wiki/ISO_8601>`_, for both dates
-  and periods. Or as a wildcard to work with all available data, set the starting
-  point at the first available year, and set the ending point at the last available
-  year. The starting point and end point must be separated with '/'.
-  (e.g key-value ``timerange: '1982/1990'``)
+  Alternatively, the time range can be specified in `ISO 8601 format
+  <https://en.wikipedia.org/wiki/ISO_8601>`_, for both dates and periods.
+  The starting point and end point must be separated with ``/`` (e.g.,
+  ``timerange: '1982/1990'`` will select the data from the years 1982 to 1990,
+  ``timerange: '1910/P2Y'`` will select 2 years of data starting in 1910, or
+  ``P1Y2M/19201231T235959`` will select 1 year and 2 months of data ending on
+  31 December 1920 23:59:59).
+  In addition, wildcards (``'*'``) are accepted, which allow the selection of
+  the first available year for each individual dataset (when used as a starting
+  point) or the last available year (when used as an ending point).
+  For example, use ``timerange: '*/P2Y'`` to select the first 2 years of all
+  datasets or ``timerange: 'P5Y/*'`` to select the last 5 years.
 - model grid (native grid ``grid: gn`` or regridded grid ``grid: gr``, for
   CMIP6 data only).
 
@@ -104,6 +111,7 @@ For example, a datasets section could be:
 
     datasets:
       - {dataset: CanESM2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2004}
+      - {dataset: CanESM5, project: CMIP6, exp: historical, ensemble: r1i1p1f2, timerange: '18900504T100000/189006204T110000'}
       - {dataset: UKESM1-0-LL, project: CMIP6, exp: historical, ensemble: r1i1p1f2, start_year: 2001, end_year: 2004, grid: gn}
       - {dataset: ACCESS-CM2, project: CMIP6, exp: historical, ensemble: r1i1p1f2, timerange: 'P5Y/*', grid: gn}
       - {dataset: EC-EARTH3, alias: custom_alias, project: CMIP6, exp: historical, ensemble: r1i1p1f1, start_year: 2001, end_year: 2004, grid: gn}

--- a/doc/recipe/overview.rst
+++ b/doc/recipe/overview.rst
@@ -76,26 +76,26 @@ Recipe section: ``datasets``
 The ``datasets`` section includes dictionaries that, via key-value pairs, define standardized
 data specifications:
 
-- dataset name (key ``dataset``, value e.g. ``MPI-ESM-LR`` or ``UKESM1-0-LL``)
+- dataset name (key ``dataset``, value e.g. ``MPI-ESM-LR`` or ``UKESM1-0-LL``).
 - project (key ``project``, value ``CMIP5`` or ``CMIP6`` for CMIP data,
   ``OBS`` for observational data, ``ana4mips`` for ana4mips data,
-  ``obs4MIPs`` for obs4MIPs data, ``EMAC`` for EMAC data)
+  ``obs4MIPs`` for obs4MIPs data, ``ICON`` for ICON data).
 - experiment (key ``exp``, value e.g. ``historical``, ``amip``, ``piControl``,
-  ``RCP8.5``)
-- mip (for CMIP data, key ``mip``, value e.g. ``Amon``, ``Omon``, ``LImon``)
-- ensemble member (key ``ensemble``, value e.g. ``r1i1p1``, ``r1i1p1f1``)
-- sub-experiment id (key `sub_experiment`, value e.g. `s2000`, `s(2000:2002)`,
-  for DCPP data only)
-- time range (e.g. key-value ``start_year: 1982``, ``end_year: 1990``.
-  Please note that `yaml`_ interprets numbers with a leading ``0`` as octal numbers,
-  so we recommend to avoid them. For example, use ``128`` to specify the year
-  128 instead of ``0128``.)
+  ``rcp85``).
+- mip (for CMIP data, key ``mip``, value e.g. ``Amon``, ``Omon``, ``LImon``).
+- ensemble member (key ``ensemble``, value e.g. ``r1i1p1``, ``r1i1p1f1``).
+- sub-experiment id (key ``sub_experiment``, value e.g. ``s2000``,
+  ``s(2000:2002)``, for DCPP data only).
+- time range (e.g. key-value ``start_year: 1982``, ``end_year: 1990``).
+  Please note that `yaml`_ interprets numbers with a leading ``0`` as octal
+  numbers, so we recommend to avoid them. For example, use ``128`` to specify
+  the year 128 instead of ``0128``.
   Alternatively, the time range can be specified in `ISO 8601 format
   <https://en.wikipedia.org/wiki/ISO_8601>`_, for both dates and periods.
   In addition, wildcards (``'*'``) are accepted, which allow the selection of
   the first available year for each individual dataset (when used as a starting
   point) or the last available year (when used as an ending point).
-  The starting point and end point must be separated with ``/`` (e.g.,
+  The starting point and end point must be separated with ``/`` (e.g. key-value
   ``timerange: '1982/1990'``).
   More examples are given :ref:`here <timerange_examples>`.
 - model grid (native grid ``grid: gn`` or regridded grid ``grid: gr``, for

--- a/doc/recipe/overview.rst
+++ b/doc/recipe/overview.rst
@@ -92,16 +92,12 @@ data specifications:
   128 instead of ``0128``.)
   Alternatively, the time range can be specified in `ISO 8601 format
   <https://en.wikipedia.org/wiki/ISO_8601>`_, for both dates and periods.
-  The starting point and end point must be separated with ``/`` (e.g.,
-  ``timerange: '1982/1990'`` will select the data from the years 1982 to 1990,
-  ``timerange: '1910/P2Y'`` will select 2 years of data starting in 1910, or
-  ``P1Y2M/19201231T235959`` will select 1 year and 2 months of data ending on
-  31 December 1920 23:59:59).
   In addition, wildcards (``'*'``) are accepted, which allow the selection of
   the first available year for each individual dataset (when used as a starting
   point) or the last available year (when used as an ending point).
-  For example, use ``timerange: '*/P2Y'`` to select the first 2 years of all
-  datasets or ``timerange: 'P5Y/*'`` to select the last 5 years.
+  The starting point and end point must be separated with ``/`` (e.g.,
+  ``timerange: '1982/1990'``).
+  More examples are given :ref:`here <timerange_examples>`.
 - model grid (native grid ``grid: gn`` or regridded grid ``grid: gr``, for
   CMIP6 data only).
 
@@ -111,7 +107,6 @@ For example, a datasets section could be:
 
     datasets:
       - {dataset: CanESM2, project: CMIP5, exp: historical, ensemble: r1i1p1, start_year: 2001, end_year: 2004}
-      - {dataset: CanESM5, project: CMIP6, exp: historical, ensemble: r1i1p1f2, timerange: '18900504T100000/189006204T110000'}
       - {dataset: UKESM1-0-LL, project: CMIP6, exp: historical, ensemble: r1i1p1f2, start_year: 2001, end_year: 2004, grid: gn}
       - {dataset: ACCESS-CM2, project: CMIP6, exp: historical, ensemble: r1i1p1f2, timerange: 'P5Y/*', grid: gn}
       - {dataset: EC-EARTH3, alias: custom_alias, project: CMIP6, exp: historical, ensemble: r1i1p1f1, start_year: 2001, end_year: 2004, grid: gn}
@@ -164,6 +159,8 @@ The same simplified syntax can be used to add multiple sub-experiment ids:
     datasets:
       - {dataset: MIROC6, project: CMIP6, exp: dcppA-hindcast, ensemble: r1i1p1f1, sub_experiment: s(2000:2002), grid: gn, start_year: 2003, end_year: 2004}
 
+.. _timerange_examples:
+
 When using the ``timerange`` tag to specify the start and end points, possible values can be as follows:
 
   - A start and end point specified with a resolution up to seconds (YYYYMMDDThhmmss)
@@ -175,6 +172,7 @@ When using the ``timerange`` tag to specify the start and end points, possible v
   - A start point or end point, and a relative period with a resolution up to second (P[n]Y[n]M[n]DT[n]H[n]M[n]S).
     * ``timerange: '1980/P5Y'``. Starting from 01/01/1980, spans 5 years.
     * ``timerange: 'P2Y5M/198202``. Ending at 28/02/1982, spans 2 years and 5 months.
+
   - A wildcard to load all available years, the first available start point or the last available end point.
     * ``timerange: '*'``. Finds all available years.
     * ``timerange: '*/1982``. Finds first available point, spans to 31/12/1982.


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR

- fixes an issue with integer auxiliary time coordinates in the `multi_model_statistics` preprocessor that occurs when preprocessor like `annual_statitics` are used in combination with `multi_model_statistics`.
- Adds the attributes `start_year` and `end_year` to the multi-models statistics output that is needed by many diagnostics.
- Fixes the timerange of multi-models statistics output  when `span=overlap` is used.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1485

Link to documentation: https://esmvaltool--1486.org.readthedocs.build/projects/ESMValCore/en/1486/recipe/overview.html

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
