### PR TITLE
Fixed output messages for CMOR logging

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -232,8 +232,8 @@ class CMORCheck():
         """
         if self.has_errors():
             msg = '\n'.join([
-                f'There were errors in variable {self._cube.var_name}:'
-                '\n '.join(self._errors),
+                f'There were errors in variable {self._cube.var_name}:',
+                ' ' + '\n '.join(self._errors),
                 'in cube:',
                 f'{self._cube}',
                 'loaded from file ' +
@@ -252,7 +252,7 @@ class CMORCheck():
         if self.has_warnings():
             msg = '\n'.join([
                 f'There were warnings in variable {self._cube.var_name}:',
-                '\n '.join(self._warnings),
+                ' ' + '\n '.join(self._warnings),
                 'loaded from file ' +
                 self._cube.attributes.get('source_file', ''),
             ])
@@ -268,9 +268,9 @@ class CMORCheck():
         """
         if self.has_debug_messages():
             msg = '\n'.join([
-                'There were metadata changes in variable' +
-                self._cube.var_name,
-                '\n '.join(self._debug_messages),
+                f'There were metadata changes in variable '
+                f'{self._cube.var_name}:',
+                ' ' + '\n '.join(self._debug_messages),
                 'loaded from file ' +
                 self._cube.attributes.get('source_file', ''),
             ])


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Fixes log formatting of CMOR messages.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1492


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
