### PR TITLE
Fixed `clip_timerange` if only a single time point is extracted

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -213,6 +213,12 @@ def _extract_datetime(cube, start_datetime, end_datetime):
             f"to {end_datetime.strftime('%Y-%m-%d')} is outside "
             f"cube time bounds {time_coord.cell(0)} to {time_coord.cell(-1)}.")
 
+    # If only a single point in time is extracted, the new time coordinate of
+    # cube_slice is a scalar coordinate. Convert this back to a regular
+    # dimensional coordinate with length 1.
+    if cube_slice.ndim < cube.ndim:
+        cube_slice = iris.util.new_axis(cube_slice, 'time')
+
     return cube_slice
 
 

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -330,6 +330,8 @@ class TestClipTimerange(tests.Test):
         cube = self._create_cube([0.0], [150.0], [[0.0, 365.0]], 'standard')
         sliced_cube = clip_timerange(cube, '1950/1950')
 
+        assert sliced_cube.coord('time').units == Unit(
+            'days since 1950-01-01', calendar='standard')
         assert_array_equal(sliced_cube.coord('time').points, [150.0])
         assert_array_equal(sliced_cube.coord('time').bounds, [[0.0, 365.0]])
         assert cube.shape == sliced_cube.shape
@@ -339,6 +341,8 @@ class TestClipTimerange(tests.Test):
         cube.coord('time').bounds = None
         sliced_cube = clip_timerange(cube, '1950/1950')
 
+        assert sliced_cube.coord('time').units == Unit(
+            'days since 1950-01-01', calendar='standard')
         assert_array_equal(sliced_cube.coord('time').points, [150.0])
         assert sliced_cube.coord('time').bounds is None
         assert cube.shape == sliced_cube.shape
@@ -353,6 +357,8 @@ class TestClipTimerange(tests.Test):
         cube.add_dim_coord(lat_coord, 1)
         sliced_cube = clip_timerange(cube, '1950/1950')
 
+        assert sliced_cube.coord('time').units == Unit(
+            'days since 1950-01-01', calendar='standard')
         assert_array_equal(sliced_cube.coord('time').points, [150.0])
         assert_array_equal(sliced_cube.coord('time').bounds, [[0.0, 365.0]])
         assert cube.shape == sliced_cube.shape
@@ -362,10 +368,75 @@ class TestClipTimerange(tests.Test):
         cube.coord('time').bounds = None
         sliced_cube = clip_timerange(cube, '1950/1950')
 
+        assert sliced_cube.coord('time').units == Unit(
+            'days since 1950-01-01', calendar='standard')
         assert_array_equal(sliced_cube.coord('time').points, [150.0])
         assert sliced_cube.coord('time').bounds is None
         assert cube.shape == sliced_cube.shape
         assert sliced_cube.coord('time', dim_coords=True)
+
+    def test_clip_timerange_single_year_4d(self):
+        """Test time is not scalar even when time is not first coordinate."""
+        cube = self._create_cube([[[[0.0, 1.0]]]], [150.0], [[0.0, 365.0]],
+                                 'standard')
+        plev_coord = iris.coords.DimCoord([1013.0],
+                                          standard_name='air_pressure')
+        lat_coord = iris.coords.DimCoord([10.0], standard_name='latitude')
+        lon_coord = iris.coords.DimCoord([0.0, 1.0], standard_name='longitude')
+        cube.add_dim_coord(plev_coord, 1)
+        cube.add_dim_coord(lat_coord, 2)
+        cube.add_dim_coord(lon_coord, 3)
+
+        # Order: plev, time, lat, lon
+        cube_1 = cube.copy()
+        cube_1.transpose([1, 0, 2, 3])
+        assert cube_1.shape == (1, 1, 1, 2)
+        sliced_cube = clip_timerange(cube_1, '1950/1950')
+
+        assert sliced_cube is not cube_1
+        assert sliced_cube.coord('time').units == Unit(
+            'days since 1950-01-01', calendar='standard')
+        assert_array_equal(sliced_cube.coord('time').points, [150.0])
+        assert_array_equal(sliced_cube.coord('time').bounds, [[0.0, 365.0]])
+        assert cube_1.shape == sliced_cube.shape
+        assert sliced_cube.coord('time', dim_coords=True)
+        for coord_name in [c.name() for c in cube_1.coords()]:
+            assert (sliced_cube.coord_dims(coord_name) ==
+                    cube_1.coord_dims(coord_name))
+
+        # Order: lat, lon, time, plev
+        cube_2 = cube.copy()
+        cube_2.transpose([2, 3, 0, 1])
+        assert cube_2.shape == (1, 2, 1, 1)
+        sliced_cube = clip_timerange(cube_2, '1950/1950')
+
+        assert sliced_cube is not cube_2
+        assert sliced_cube.coord('time').units == Unit(
+            'days since 1950-01-01', calendar='standard')
+        assert_array_equal(sliced_cube.coord('time').points, [150.0])
+        assert_array_equal(sliced_cube.coord('time').bounds, [[0.0, 365.0]])
+        assert cube_2.shape == sliced_cube.shape
+        assert sliced_cube.coord('time', dim_coords=True)
+        for coord_name in [c.name() for c in cube_2.coords()]:
+            assert (sliced_cube.coord_dims(coord_name) ==
+                    cube_2.coord_dims(coord_name))
+
+        # Order: lon, lat, plev, time
+        cube_3 = cube.copy()
+        cube_3.transpose([3, 2, 1, 0])
+        assert cube_3.shape == (2, 1, 1, 1)
+        sliced_cube = clip_timerange(cube_3, '1950/1950')
+
+        assert sliced_cube is not cube_3
+        assert sliced_cube.coord('time').units == Unit(
+            'days since 1950-01-01', calendar='standard')
+        assert_array_equal(sliced_cube.coord('time').points, [150.0])
+        assert_array_equal(sliced_cube.coord('time').bounds, [[0.0, 365.0]])
+        assert cube_3.shape == sliced_cube.shape
+        assert sliced_cube.coord('time', dim_coords=True)
+        for coord_name in [c.name() for c in cube_3.coords()]:
+            assert (sliced_cube.coord_dims(coord_name) ==
+                    cube_3.coord_dims(coord_name))
 
 
 class TestExtractSeason(tests.Test):

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -335,6 +335,15 @@ class TestClipTimerange(tests.Test):
         assert cube.shape == sliced_cube.shape
         assert sliced_cube.coord('time', dim_coords=True)
 
+        # Repeat test without bounds
+        cube.coord('time').bounds = None
+        sliced_cube = clip_timerange(cube, '1950/1950')
+
+        assert_array_equal(sliced_cube.coord('time').points, [150.0])
+        assert sliced_cube.coord('time').bounds is None
+        assert cube.shape == sliced_cube.shape
+        assert sliced_cube.coord('time', dim_coords=True)
+
     def test_clip_timerange_single_year_2d(self):
         """Test that single year stays dimensional coordinate."""
         cube = self._create_cube([[0.0, 1.0]], [150.0], [[0.0, 365.0]],
@@ -346,6 +355,15 @@ class TestClipTimerange(tests.Test):
 
         assert_array_equal(sliced_cube.coord('time').points, [150.0])
         assert_array_equal(sliced_cube.coord('time').bounds, [[0.0, 365.0]])
+        assert cube.shape == sliced_cube.shape
+        assert sliced_cube.coord('time', dim_coords=True)
+
+        # Repeat test without bounds
+        cube.coord('time').bounds = None
+        sliced_cube = clip_timerange(cube, '1950/1950')
+
+        assert_array_equal(sliced_cube.coord('time').points, [150.0])
+        assert sliced_cube.coord('time').bounds is None
         assert cube.shape == sliced_cube.shape
         assert sliced_cube.coord('time', dim_coords=True)
 

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -325,6 +325,30 @@ class TestClipTimerange(tests.Test):
         assert_array_equal(
                 sliced_cube.coord('time').points, expected_time)
 
+    def test_clip_timerange_single_year_1d(self):
+        """Test that single year stays dimensional coordinate."""
+        cube = self._create_cube([0.0], [150.0], [[0.0, 365.0]], 'standard')
+        sliced_cube = clip_timerange(cube, '1950/1950')
+
+        assert_array_equal(sliced_cube.coord('time').points, [150.0])
+        assert_array_equal(sliced_cube.coord('time').bounds, [[0.0, 365.0]])
+        assert cube.shape == sliced_cube.shape
+        assert sliced_cube.coord('time', dim_coords=True)
+
+    def test_clip_timerange_single_year_2d(self):
+        """Test that single year stays dimensional coordinate."""
+        cube = self._create_cube([[0.0, 1.0]], [150.0], [[0.0, 365.0]],
+                                 'standard')
+        lat_coord = iris.coords.DimCoord([10.0, 20.0],
+                                         standard_name='latitude')
+        cube.add_dim_coord(lat_coord, 1)
+        sliced_cube = clip_timerange(cube, '1950/1950')
+
+        assert_array_equal(sliced_cube.coord('time').points, [150.0])
+        assert_array_equal(sliced_cube.coord('time').bounds, [[0.0, 365.0]])
+        assert cube.shape == sliced_cube.shape
+        assert sliced_cube.coord('time', dim_coords=True)
+
 
 class TestExtractSeason(tests.Test):
     """Tests for extract_season."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

The default behavior of `iris.cube.Cube.extract()` is to return a scalar coordinate if only a single value is extracted. This causes some NCL diagnostics to fail if `clip_timerange` extracts only single point in time. This PR fixes this behavior.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1496

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
