### PR TITLE
Fixed timerange selection for automatic downloads

### DIFF
--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -124,16 +124,50 @@ def get_start_end_date(filename):
     return start_date, end_date
 
 
+def dates_to_timerange(start_date, end_date):
+    """Convert ``start_date`` and ``end_date`` to ``timerange``.
+
+    Note
+    ----
+    This function ensures that years are in format YYYY (i.e., that the input
+    dates have at least 4 digits). This functions can handle wildcards
+    (``'*'``) and relative time ranges (e.g., ``'P6Y'``).
+
+    Parameters
+    ----------
+    start_date: int or str
+        Start date.
+    end_date: int or str
+        End date.
+
+    Returns
+    -------
+    str
+        ``timerange`` in the form ``'start_date/end_date'``.
+
+    """
+    start_date = str(start_date)
+    end_date = str(end_date)
+
+    # Pad years with 0s if not wildcard or relative time range
+    if start_date != '*' and not start_date.startswith('P'):
+        start_date = start_date.zfill(4)
+    if end_date != '*' and not end_date.startswith('P'):
+        end_date = end_date.zfill(4)
+
+    return f'{start_date}/{end_date}'
+
+
 def _get_timerange_from_years(variable):
     """Build `timerange` tag from tags `start_year` and `end_year`."""
     start_year = variable.get('start_year')
     end_year = variable.get('end_year')
     if start_year and end_year:
-        variable['timerange'] = f'{start_year}/{end_year}'
+        variable['timerange'] = dates_to_timerange(start_year, end_year)
     elif start_year:
-        variable['timerange'] = f'{start_year}/{start_year}'
+        variable['timerange'] = dates_to_timerange(start_year, start_year)
     elif end_year:
-        variable['timerange'] = f'{end_year}/{end_year}'
+        variable['timerange'] = dates_to_timerange(end_year, end_year)
     variable.pop('start_year', None)
     variable.pop('end_year', None)
 
@@ -237,9 +271,19 @@ def _parse_period(timerange):
 
 
 def _truncate_dates(date, file_date):
-    """Truncate dates of different lengths.
+    """Truncate dates of different lengths and convert to integers.
 
-    This allows to compare the dates chronologically.
+    This allows to compare the dates chronologically. For example, this allows
+    comparisons between the formats 'YYYY' and 'YYYYMM', and 'YYYYMM' and
+    'YYYYMMDD'.
+
+    Warning
+    -------
+    This function assumes that the years in ``date`` and ``file_data`` have the
+    same number of digits. If this is not the case, pad the dates with leading
+    zeros (e.g., use ``data='0100'`` and ``file_date='199901'`` for a correct
+    comparison).
+
     """
     date = re.sub("[^0-9]", '', date)
     file_date = re.sub("[^0-9]", '', file_date)
@@ -248,7 +292,7 @@ def _truncate_dates(date, file_date):
     elif len(date) > len(file_date):
         date = date[0:len(file_date)]
 
-    return date, file_date
+    return int(date), int(file_date)
 
 
 def select_files(filenames, timerange):
@@ -261,9 +305,9 @@ def select_files(filenames, timerange):
     the time resolution of the file.
     """
     selection = []
-    start_date, end_date = _parse_period(timerange)
 
     for filename in filenames:
+        start_date, end_date = _parse_period(timerange)
         start, end = get_start_end_date(filename)
 
         start_date, start = _truncate_dates(start_date, start)

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -129,9 +129,9 @@ def dates_to_timerange(start_date, end_date):
 
     Note
     ----
-    This function ensures that years are in format YYYY (i.e., that the input
-    dates have at least 4 digits). This functions can handle wildcards
-    (``'*'``) and relative time ranges (e.g., ``'P6Y'``).
+    This function ensures that dates in years format follow the pattern YYYY (i.e.,
+    that they have at least 4 digits). Other formats, such as  wildcards
+    (``'*'``) and relative time ranges (e.g., ``'P6Y'``) are used unchanged.
 
     Parameters
     ----------

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -279,9 +279,9 @@ def _truncate_dates(date, file_date):
 
     Warning
     -------
-    This function assumes that the years in ``date`` and ``file_data`` have the
+    This function assumes that the years in ``date`` and ``file_date`` have the
     same number of digits. If this is not the case, pad the dates with leading
-    zeros (e.g., use ``data='0100'`` and ``file_date='199901'`` for a correct
+    zeros (e.g., use ``date='0100'`` and ``file_date='199901'`` for a correct
     comparison).
 
     """

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -129,8 +129,8 @@ def dates_to_timerange(start_date, end_date):
 
     Note
     ----
-    This function ensures that dates in years format follow the pattern YYYY (i.e.,
-    that they have at least 4 digits). Other formats, such as  wildcards
+    This function ensures that dates in years format follow the pattern YYYY
+    (i.e., that they have at least 4 digits). Other formats, such as  wildcards
     (``'*'``) and relative time ranges (e.g., ``'P6Y'``) are used unchanged.
 
     Parameters

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -28,6 +28,7 @@ from ._data_finder import (
     _get_timerange_from_years,
     _parse_period,
     _truncate_dates,
+    dates_to_timerange,
     get_input_filelist,
     get_multiproduct_filename,
     get_output_file,
@@ -673,7 +674,7 @@ def _get_common_attributes(products, settings):
         timerange = product.attributes['timerange']
         start, end = _parse_period(timerange)
         if 'timerange' not in attributes:
-            attributes['timerange'] = f'{start}/{end}'
+            attributes['timerange'] = dates_to_timerange(start, end)
         else:
             start_date, end_date = _parse_period(attributes['timerange'])
             start_date, start = _truncate_dates(start_date, start)
@@ -692,7 +693,7 @@ def _get_common_attributes(products, settings):
                 start_date = min([start, start_date])
                 end_date = max([end, end_date])
 
-            attributes['timerange'] = f'{start_date}/{end_date}'
+            attributes['timerange'] = dates_to_timerange(start_date, end_date)
 
     # Ensure that attributes start_year and end_year are always available
     start_year, end_year = _parse_period(attributes['timerange'])
@@ -853,9 +854,11 @@ def _update_timerange(variable, config_user):
             timerange = timerange.replace('*', min_date)
         if '*' in timerange.split('/')[1]:
             timerange = timerange.replace('*', max_date)
+        (start_date, end_date) = timerange.split('/')
+        timerange = dates_to_timerange(start_date, end_date)
         check.valid_time_selection(timerange)
 
-    variable.update({'timerange': timerange})
+    variable['timerange'] = timerange
 
 
 def _match_products(products, variables):

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -843,6 +843,22 @@ def _update_timerange(variable, config_user):
     if '*' in timerange:
         (files, _, _) = _find_input_files(variable, config_user['rootpath'],
                                           config_user['drs'])
+        if not files:
+            if not config_user.get('offline', True):
+                msg = (
+                    " Please note that automatic download is not supported "
+                    "with indeterminate time ranges at the moment. Please use "
+                    "a concrete time range (i.e., no wildcards '*') in your "
+                    "recipe or run ESMValTool with --offline=True."
+                )
+            else:
+                msg = ""
+            raise InputFilesNotFound(
+                f"Missing data for {variable['alias']}: "
+                f"{variable['short_name']}. Cannot determine indeterminate "
+                f"time range '{timerange}'.{msg}"
+            )
+
         intervals = [get_start_end_date(name) for name in files]
 
         min_date = min(interval[0] for interval in intervals)

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -813,18 +813,6 @@ def _update_extract_shape(settings, config_user):
         check.extract_shape(settings['extract_shape'])
 
 
-def _format_years(timerange):
-    """Format years that are not given in a 4-digit format."""
-    dates = timerange.split('/')
-    timerange = []
-    for date in dates:
-        if date != '*' and not date.startswith('P') and len(date) < 4:
-            date = date.zfill(4)
-        timerange.append(date)
-
-    return '/'.join(timerange)
-
-
 def _update_timerange(variable, config_user):
     """Update wildcards in timerange with found datetime values.
 
@@ -835,9 +823,6 @@ def _update_timerange(variable, config_user):
         return
 
     timerange = variable.get('timerange')
-    check.valid_time_selection(timerange)
-
-    timerange = _format_years(timerange)
     check.valid_time_selection(timerange)
 
     if '*' in timerange:
@@ -870,9 +855,11 @@ def _update_timerange(variable, config_user):
             timerange = timerange.replace('*', min_date)
         if '*' in timerange.split('/')[1]:
             timerange = timerange.replace('*', max_date)
-        (start_date, end_date) = timerange.split('/')
-        timerange = dates_to_timerange(start_date, end_date)
-        check.valid_time_selection(timerange)
+
+    # Make sure that years are in format YYYY
+    (start_date, end_date) = timerange.split('/')
+    timerange = dates_to_timerange(start_date, end_date)
+    check.valid_time_selection(timerange)
 
     variable['timerange'] = timerange
 

--- a/esmvalcore/esgf/_search.py
+++ b/esmvalcore/esgf/_search.py
@@ -6,9 +6,9 @@ from functools import lru_cache
 import pyesgf.search
 
 from .._data_finder import (
-    _truncate_dates,
     _get_timerange_from_years,
     _parse_period,
+    _truncate_dates,
     get_start_end_date,
 )
 from ._download import ESGFFile
@@ -105,9 +105,9 @@ def esgf_search_files(facets):
 def select_by_time(files, timerange):
     """Select files containing data between a timerange."""
     selection = []
-    start_date, end_date = _parse_period(timerange)
 
     for file in files:
+        start_date, end_date = _parse_period(timerange)
         try:
             start, end = get_start_end_date(file.name)
         except ValueError:

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -22,7 +22,7 @@ from esmvalcore._recipe import (
 )
 from esmvalcore._task import DiagnosticTask
 from esmvalcore.cmor.check import CheckLevels
-from esmvalcore.exceptions import RecipeError
+from esmvalcore.exceptions import InputFilesNotFound, RecipeError
 from esmvalcore.preprocessor import DEFAULT_ORDER, PreprocessingTask
 from esmvalcore.preprocessor._io import concatenate_callback
 
@@ -1036,6 +1036,44 @@ def test_update_timerange_year_format(config_user, input_time, output_time):
     }
     esmvalcore._recipe._update_timerange(variable, config_user)
     assert variable['timerange'] == output_time
+
+
+def test_update_timerange_no_files_online(config_user):
+    variable = {
+        'alias': 'CMIP6',
+        'project': 'CMIP6',
+        'mip': 'Amon',
+        'short_name': 'tas',
+        'original_short_name': 'tas',
+        'dataset': 'HadGEM3-GC31-LL',
+        'exp': 'historical',
+        'ensemble': 'r2i1p1f1',
+        'grid': 'gr',
+        'timerange': '*/2000',
+    }
+    msg = "Missing data for CMIP6: tas. Cannot determine indeterminate time "
+    with pytest.raises(InputFilesNotFound, match=msg):
+        esmvalcore._recipe._update_timerange(variable, config_user)
+
+
+def test_update_timerange_no_files_offline(config_user):
+    variable = {
+        'alias': 'CMIP6',
+        'project': 'CMIP6',
+        'mip': 'Amon',
+        'short_name': 'tas',
+        'original_short_name': 'tas',
+        'dataset': 'HadGEM3-GC31-LL',
+        'exp': 'historical',
+        'ensemble': 'r2i1p1f1',
+        'grid': 'gr',
+        'timerange': '*/2000',
+    }
+    config_user = dict(config_user)
+    config_user['offline'] = False
+    msg = "Please note that automatic download is not supported"
+    with pytest.raises(InputFilesNotFound, match=msg):
+        esmvalcore._recipe._update_timerange(variable, config_user)
 
 
 def test_reference_dataset(tmp_path, patched_datafinder, config_user,

--- a/tests/unit/test_data_finder.py
+++ b/tests/unit/test_data_finder.py
@@ -1,0 +1,65 @@
+"""Unit tests for ``_data_finder.py``."""
+import pytest
+
+from esmvalcore._data_finder import _truncate_dates, dates_to_timerange
+
+TEST_DATES_TO_TIMERANGE = [
+    (2000, 2000, '2000/2000'),
+    (1, 2000, '0001/2000'),
+    (2000, 1, '2000/0001'),
+    (1, 2, '0001/0002'),
+    ('2000', '2000', '2000/2000'),
+    ('1', '2000', '0001/2000'),
+    (2000, '1', '2000/0001'),
+    ('1', 2, '0001/0002'),
+    ('*', '*', '*/*'),
+    (2000, '*', '2000/*'),
+    ('2000', '*', '2000/*'),
+    (1, '*', '0001/*'),
+    ('1', '*', '0001/*'),
+    ('*', 2000, '*/2000'),
+    ('*', '2000', '*/2000'),
+    ('*', 1, '*/0001'),
+    ('*', '1', '*/0001'),
+    ('P5Y', 'P5Y', 'P5Y/P5Y'),
+    (2000, 'P5Y', '2000/P5Y'),
+    ('2000', 'P5Y', '2000/P5Y'),
+    (1, 'P5Y', '0001/P5Y'),
+    ('1', 'P5Y', '0001/P5Y'),
+    ('P5Y', 2000, 'P5Y/2000'),
+    ('P5Y', '2000', 'P5Y/2000'),
+    ('P5Y', 1, 'P5Y/0001'),
+    ('P5Y', '1', 'P5Y/0001'),
+    ('*', 'P5Y', '*/P5Y'),
+    ('P5Y', '*', 'P5Y/*'),
+]
+
+
+@pytest.mark.parametrize('start_date,end_date,expected_timerange',
+                         TEST_DATES_TO_TIMERANGE)
+def test_dates_to_timerange(start_date, end_date, expected_timerange):
+    """Test ``dates_to_timerange``."""
+    timerange = dates_to_timerange(start_date, end_date)
+    assert timerange == expected_timerange
+
+
+TEST_TRUNCATE_DATES = [
+    ('2000', '2000', (2000, 2000)),
+    ('200001', '2000', (2000, 2000)),
+    ('2000', '200001', (2000, 2000)),
+    ('200001', '2000', (2000, 2000)),
+    ('200001', '200001', (200001, 200001)),
+    ('20000102', '200001', (200001, 200001)),
+    ('200001', '20000102', (200001, 200001)),
+    ('20000102', '20000102', (20000102, 20000102)),
+    ('20000102T23:59:59', '20000102', (20000102, 20000102)),
+    ('20000102', '20000102T23:59:59', (20000102, 20000102)),
+    ('20000102T235959', '20000102T01:02:03', (20000102235959, 20000102010203)),
+]
+
+
+@pytest.mark.parametrize('date,date_file,expected_output', TEST_TRUNCATE_DATES)
+def test_truncate_dates(date, date_file, expected_output):
+    """Test ``_truncate_dates``."""
+    output = _truncate_dates(date, date_file)
+    assert output == expected_output


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR makes sure that the years in `timerange` are always in the format `YYYY`.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1515

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
