### PR TITLE
Fixed chunking in `multi_model_statistics`

### DIFF
--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -296,10 +296,10 @@ def _combine(cubes):
 
 
 def _compute_slices(cubes):
-    """Create cube slices resulting in a combined cube of about 1 GB."""
-    gigabyte = 2**30
+    """Create cube slices resulting in a combined cube of about 1 GiB."""
+    gibibyte = 2**30
     total_bytes = cubes[0].data.nbytes * len(cubes)
-    n_slices = int(np.ceil(total_bytes / gigabyte))
+    n_slices = int(np.ceil(total_bytes / gibibyte))
 
     n_timesteps = cubes[0].shape[0]
     slice_len = int(np.ceil(n_timesteps / n_slices))
@@ -307,7 +307,7 @@ def _compute_slices(cubes):
     for i in range(n_slices):
         start = i * slice_len
         end = (i + 1) * slice_len
-        if end > n_timesteps:
+        if end >= n_timesteps:
             yield slice(start, n_timesteps)
             return
         yield slice(start, end)

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -196,12 +196,12 @@ def test_compute_slices(length, slices):
     assert result == slices
 
 
-def test_compute_slices_early_termination():
-    """Test that ``_compute_slices`` terminates when reaching end index."""
+def test_compute_slices_exceed_end_index():
+    """Test that ``_compute_slices`` terminates when exceeding end index."""
     # The following settings will result in a cube length of 71, 10 slices and
     # a slice length of 8. Thus, without early termination, the last slice
     # would be slice(72, 71), which would result in an exception.
-    cube_data = mock.Mock(nbytes=1.1 * 2**30)  # roughly 1.1 GB
+    cube_data = mock.Mock(nbytes=1.1 * 2**30)  # roughly 1.1 GiB
     cube = mock.Mock(spec=Cube, data=cube_data, shape=(71,))
     cubes = [cube] * 9
 
@@ -219,6 +219,36 @@ def test_compute_slices_early_termination():
         slice(48, 56, None),
         slice(56, 64, None),
         slice(64, 71, None),
+    ]
+    assert slices == expected_slices
+
+
+def test_compute_slices_equals_end_index():
+    """Test that ``_compute_slices`` terminates when reaching end index."""
+    # The following settings will result in a cube length of 36, 13 slices and
+    # a slice length of 3. Thus, without early termination, the last slice
+    # would be slice(36, 39), which would result in an exception.
+    cube_data = mock.Mock(nbytes=1.05 * 2**30)  # roughly 1.05 GiB
+    cube = mock.Mock(spec=Cube, data=cube_data, shape=(36,))
+    cubes = [cube] * 12
+
+    slices = list(mm._compute_slices(cubes))
+
+    # Early termination lead to 12 (instead of 13) slices
+    assert len(slices) == 12
+    expected_slices = [
+        slice(0, 3, None),
+        slice(3, 6, None),
+        slice(6, 9, None),
+        slice(9, 12, None),
+        slice(12, 15, None),
+        slice(15, 18, None),
+        slice(18, 21, None),
+        slice(21, 24, None),
+        slice(24, 27, None),
+        slice(27, 30, None),
+        slice(30, 33, None),
+        slice(33, 36, None),
     ]
     assert slices == expected_slices
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Fixes edge case in chunking of multi-model stats.
<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1499
***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
