### PR TITLE
Added `start_year` and `end_year` attributes to derived variables

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1018,10 +1018,12 @@ def _get_preprocessor_products(variables, profile, order, ancestor_products,
         product.check()
 
         # Ensure that attributes start_year and end_year are always available
-        # for all products
-        start_year, end_year = _parse_period(product.attributes['timerange'])
-        product.attributes['start_year'] = int(str(start_year[0:4]))
-        product.attributes['end_year'] = int(str(end_year[0:4]))
+        # for all products if a timerange is specified
+        if 'timerange' in product.attributes:
+            start_year, end_year = _parse_period(
+                product.attributes['timerange'])
+            product.attributes['start_year'] = int(str(start_year[0:4]))
+            product.attributes['end_year'] = int(str(end_year[0:4]))
 
     return products
 

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1199,6 +1199,13 @@ def _get_preprocessor_task(variables, profiles, config_user, task_name):
             )
             derive_tasks.append(task)
 
+        # Ensure that attributes start_year and end_year are always available
+        # in derived variables
+        for variable in variables:
+            start_year, end_year = _parse_period(variable['timerange'])
+            variable['start_year'] = int(str(start_year[0:4]))
+            variable['end_year'] = int(str(end_year[0:4]))
+
     # Create (final) preprocessor task
     task = _get_single_preprocessor_task(
         variables,

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1017,6 +1017,12 @@ def _get_preprocessor_products(variables, profile, order, ancestor_products,
     for product in products | multimodel_products | ensemble_products:
         product.check()
 
+        # Ensure that attributes start_year and end_year are always available
+        # for all products
+        start_year, end_year = _parse_period(product.attributes['timerange'])
+        product.attributes['start_year'] = int(str(start_year[0:4]))
+        product.attributes['end_year'] = int(str(end_year[0:4]))
+
     return products
 
 
@@ -1198,13 +1204,6 @@ def _get_preprocessor_task(variables, profiles, config_user, task_name):
                 name=derive_name,
             )
             derive_tasks.append(task)
-
-        # Ensure that attributes start_year and end_year are always available
-        # in derived variables
-        for variable in variables:
-            start_year, end_year = _parse_period(variable['timerange'])
-            variable['start_year'] = int(str(start_year[0:4]))
-            variable['end_year'] = int(str(end_year[0:4]))
 
     # Create (final) preprocessor task
     task = _get_single_preprocessor_task(

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1540,6 +1540,41 @@ def test_derive_with_optional_var_nodata(tmp_path, patched_failing_datafinder,
         assert ancestor_product.filename in all_product_files
 
 
+def test_derive_contains_start_end_year(tmp_path, patched_datafinder,
+                                        config_user):
+
+    content = dedent("""
+        diagnostics:
+          diagnostic_name:
+            variables:
+              toz:
+                project: CMIP5
+                mip: Amon
+                exp: historical
+                timerange: '2000/2005'
+                derive: true
+                force_derivation: true
+                additional_datasets:
+                  - {dataset: GFDL-CM3,  ensemble: r1i1p1}
+            scripts: null
+        """)
+
+    recipe = get_recipe(tmp_path, content, config_user)
+
+    # Check generated tasks
+    assert len(recipe.tasks) == 1
+    task = recipe.tasks.pop()
+
+    # Check that start_year and end_year are present in attributes
+    assert len(task.products) == 1
+    product = task.products.pop()
+    assert 'derive' in product.settings
+    assert product.attributes['short_name'] == 'toz'
+    assert product.attributes['timerange'] == '2000/2005'
+    assert product.attributes['start_year'] == 2000
+    assert product.attributes['end_year'] == 2005
+
+
 def create_test_image(basename, cfg):
     """Get a valid path for saving a diagnostic plot."""
     image = Path(cfg['plot_dir']) / (basename + '.' + cfg['output_file_type'])


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR ensures that `start_year` and `end_year` are available for derived variables.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1546 

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
