### PR TITLE
[Github Actions Docs] Full explanation on how to use the GA test triggered by PR comment and added docs link for GA hosted runners 

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -525,7 +525,8 @@ The result of the tests ran by CircleCI can be seen on the
 `CircleCI project page <https://app.circleci.com/pipelines/github/ESMValGroup/ESMValCore?branch=main>`__
 and the result of the tests ran by GitHub Actions can be viewed on the
 `Actions tab <https://github.com/ESMValGroup/ESMValCore/actions>`__
-of the repository.
+of the repository (to learn more about the Github-hosted runners, please have a look
+the `documentation <https://docs.github.com/en/actions/using-github-hosted-runners>`__).
 
 When opening a pull request, if you wish to run the Github Actions `Test <https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml>`__ test,
 you can activate it via a simple comment containing the @runGAtests tag
@@ -533,6 +534,11 @@ you can activate it via a simple comment containing the @runGAtests tag
 bot that will start the test automatically). This is useful
 to check if a certain feature that you included in the Pull Request, and can be tested
 for via the test suite, works across the supported Python versions, and both on Linux and OSX.
+The test is currently deactivated, so before triggering the test via comment, make sure you activate
+the test in the main `Actions page <https://github.com/ESMValGroup/ESMValCore/actions>`__ 
+(click on Test via PR Comment and activate it); also and be sure to deactivate it afterwards
+(the Github API still needs a bit more development, and currently it triggers
+the test for **each comment** irrespective of PR, that's why this needs to be activated/decativated).
 
 The configuration of the tests run by CircleCI can be found in the directory
 `.circleci <https://github.com/ESMValGroup/ESMValCore/blob/main/.circleci>`__,


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Due to https://github.com/ESMValGroup/ESMValCore/issues/1531 the GA test triggered via PR comment is deactivated but can still be used with two more clicks, so I added a bit of docs on how to do it; I also added a link to the GA hosted runners doc page.

***


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
