### PR TITLE
Fix timerange wildcard search when deriving variables or downloading files

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -826,23 +826,15 @@ def _update_timerange(variable, config_user):
     check.valid_time_selection(timerange)
 
     if '*' in timerange:
-        (files, _, _) = _find_input_files(variable, config_user['rootpath'],
-                                          config_user['drs'])
-        if not files:
-            if not config_user.get('offline', True):
-                msg = (
-                    " Please note that automatic download is not supported "
-                    "with indeterminate time ranges at the moment. Please use "
-                    "a concrete time range (i.e., no wildcards '*') in your "
-                    "recipe or run ESMValTool with --offline=True."
-                )
-            else:
-                msg = ""
-            raise InputFilesNotFound(
-                f"Missing data for {variable['alias']}: "
-                f"{variable['short_name']}. Cannot determine indeterminate "
-                f"time range '{timerange}'.{msg}"
-            )
+        if config_user.get('offline', True):
+            (files, _, _) = _find_input_files(
+                variable,
+                config_user['rootpath'],
+                config_user['drs'])
+        else:
+            facets = deepcopy(variable)
+            facets.pop('timerange', None)
+            files = [file.name for file in esgf.find_files(**facets)]
 
         intervals = [get_start_end_date(name) for name in files]
 

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1145,10 +1145,12 @@ def _get_derive_input_variables(variables, config_user):
             # Process input data needed to derive variable
             required_vars = get_required(variable['short_name'],
                                          variable['project'])
+            timeranges = set()
             for var in required_vars:
                 _augment(var, variable)
                 _add_cmor_info(var, override=True)
                 _add_extra_facets(var, config_user['extra_facets_dir'])
+                _update_timerange(var, config_user)
                 files = _get_input_files(var, config_user)[0]
                 if var.get('optional') and not files:
                     logger.info(
@@ -1156,6 +1158,13 @@ def _get_derive_input_variables(variables, config_user):
                         "'optional'", var)
                 else:
                     append(group_prefix, var)
+                    timeranges.add(var['timerange'])
+            if len(timeranges) > 1:
+                logger.error(
+                    "Differing timeranges with values %s "
+                    "found for required variables %s. "
+                    "Set `timerange` to a common value.",
+                    timeranges, required_vars)
 
     # An empty derive_input (due to all variables marked as 'optional' is
     # handled at a later step

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1537,6 +1537,41 @@ def test_derive_contains_start_end_year(tmp_path, patched_datafinder,
     assert product.attributes['end_year'] == 2005
 
 
+def test_derive_timerange_wildcard(tmp_path, patched_datafinder,
+                                        config_user):
+
+    content = dedent("""
+        diagnostics:
+          diagnostic_name:
+            variables:
+              toz:
+                project: CMIP5
+                mip: Amon
+                exp: historical
+                timerange: '*'
+                derive: true
+                force_derivation: true
+                additional_datasets:
+                  - {dataset: GFDL-CM3,  ensemble: r1i1p1}
+            scripts: null
+        """)
+
+    recipe = get_recipe(tmp_path, content, config_user)
+
+    # Check generated tasks
+    assert len(recipe.tasks) == 1
+    task = recipe.tasks.pop()
+
+    # Check that start_year and end_year are present in attributes
+    assert len(task.products) == 1
+    product = task.products.pop()
+    assert 'derive' in product.settings
+    assert product.attributes['short_name'] == 'toz'
+    assert product.attributes['timerange'] == '1999/2019'
+    assert product.attributes['start_year'] == 1999
+    assert product.attributes['end_year'] == 2019
+
+
 def create_test_image(basename, cfg):
     """Get a valid path for saving a diagnostic plot."""
     image = Path(cfg['plot_dir']) / (basename + '.' + cfg['output_file_type'])

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -22,7 +22,7 @@ from esmvalcore._recipe import (
 )
 from esmvalcore._task import DiagnosticTask
 from esmvalcore.cmor.check import CheckLevels
-from esmvalcore.exceptions import InputFilesNotFound, RecipeError
+from esmvalcore.exceptions import RecipeError
 from esmvalcore.preprocessor import DEFAULT_ORDER, PreprocessingTask
 from esmvalcore.preprocessor._io import concatenate_callback
 

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1572,6 +1572,40 @@ def test_derive_timerange_wildcard(tmp_path, patched_datafinder,
     assert product.attributes['end_year'] == 2019
 
 
+def test_derive_timerange_wildcard(tmp_path, patched_datafinder,
+                                   config_user):
+
+    content = dedent("""
+        diagnostics:
+          diagnostic_name:
+            variables:
+              toz:
+                project: CMIP5
+                mip: Amon
+                exp: historical
+                timerange: '*'
+                derive: true
+                force_derivation: true
+                additional_datasets:
+                  - {dataset: GFDL-CM3,  ensemble: r1i1p1}
+            scripts: null
+        """)
+
+    recipe = get_recipe(tmp_path, content, config_user)
+
+    # Check generated tasks
+    assert len(recipe.tasks) == 1
+    task = recipe.tasks.pop()
+
+    # Check that start_year and end_year are present in attributes
+    assert len(task.products) == 1
+    product = task.products.pop()
+    assert 'derive' in product.settings
+    assert product.attributes['short_name'] == 'toz'
+    assert product.attributes['timerange'] == '1990/2019'
+    assert product.attributes['start_year'] == 1990
+    assert product.attributes['end_year'] == 2019
+
 def create_test_image(basename, cfg):
     """Get a valid path for saving a diagnostic plot."""
     image = Path(cfg['plot_dir']) / (basename + '.' + cfg['output_file_type'])

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1572,40 +1572,6 @@ def test_derive_timerange_wildcard(tmp_path, patched_datafinder,
     assert product.attributes['end_year'] == 2019
 
 
-def test_derive_timerange_wildcard(tmp_path, patched_datafinder,
-                                   config_user):
-
-    content = dedent("""
-        diagnostics:
-          diagnostic_name:
-            variables:
-              toz:
-                project: CMIP5
-                mip: Amon
-                exp: historical
-                timerange: '*'
-                derive: true
-                force_derivation: true
-                additional_datasets:
-                  - {dataset: GFDL-CM3,  ensemble: r1i1p1}
-            scripts: null
-        """)
-
-    recipe = get_recipe(tmp_path, content, config_user)
-
-    # Check generated tasks
-    assert len(recipe.tasks) == 1
-    task = recipe.tasks.pop()
-
-    # Check that start_year and end_year are present in attributes
-    assert len(task.products) == 1
-    product = task.products.pop()
-    assert 'derive' in product.settings
-    assert product.attributes['short_name'] == 'toz'
-    assert product.attributes['timerange'] == '1990/2019'
-    assert product.attributes['start_year'] == 1990
-    assert product.attributes['end_year'] == 2019
-
 def create_test_image(basename, cfg):
     """Get a valid path for saving a diagnostic plot."""
     image = Path(cfg['plot_dir']) / (basename + '.' + cfg['output_file_type'])

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1538,7 +1538,7 @@ def test_derive_contains_start_end_year(tmp_path, patched_datafinder,
 
 
 def test_derive_timerange_wildcard(tmp_path, patched_datafinder,
-                                        config_user):
+                                   config_user):
 
     content = dedent("""
         diagnostics:
@@ -1567,8 +1567,8 @@ def test_derive_timerange_wildcard(tmp_path, patched_datafinder,
     product = task.products.pop()
     assert 'derive' in product.settings
     assert product.attributes['short_name'] == 'toz'
-    assert product.attributes['timerange'] == '1999/2019'
-    assert product.attributes['start_year'] == 1999
+    assert product.attributes['timerange'] == '1990/2019'
+    assert product.attributes['start_year'] == 1990
     assert product.attributes['end_year'] == 2019
 
 

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1038,44 +1038,6 @@ def test_update_timerange_year_format(config_user, input_time, output_time):
     assert variable['timerange'] == output_time
 
 
-def test_update_timerange_no_files_online(config_user):
-    variable = {
-        'alias': 'CMIP6',
-        'project': 'CMIP6',
-        'mip': 'Amon',
-        'short_name': 'tas',
-        'original_short_name': 'tas',
-        'dataset': 'HadGEM3-GC31-LL',
-        'exp': 'historical',
-        'ensemble': 'r2i1p1f1',
-        'grid': 'gr',
-        'timerange': '*/2000',
-    }
-    msg = "Missing data for CMIP6: tas. Cannot determine indeterminate time "
-    with pytest.raises(InputFilesNotFound, match=msg):
-        esmvalcore._recipe._update_timerange(variable, config_user)
-
-
-def test_update_timerange_no_files_offline(config_user):
-    variable = {
-        'alias': 'CMIP6',
-        'project': 'CMIP6',
-        'mip': 'Amon',
-        'short_name': 'tas',
-        'original_short_name': 'tas',
-        'dataset': 'HadGEM3-GC31-LL',
-        'exp': 'historical',
-        'ensemble': 'r2i1p1f1',
-        'grid': 'gr',
-        'timerange': '*/2000',
-    }
-    config_user = dict(config_user)
-    config_user['offline'] = False
-    msg = "Please note that automatic download is not supported"
-    with pytest.raises(InputFilesNotFound, match=msg):
-        esmvalcore._recipe._update_timerange(variable, config_user)
-
-
 def test_reference_dataset(tmp_path, patched_datafinder, config_user,
                            monkeypatch):
 

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -295,13 +295,12 @@ def test_search_esgf(mocker, tmp_path, local_availability, already_downloaded):
     }
     assert input_files == expected[local_availability]
 
+
 @pytest.mark.parametrize('timerange', ['*', '185001/*', '*/185112'])
 def test_search_esgf_timerange(mocker, tmp_path, timerange):
 
-    rootpath = tmp_path / 'local'
     download_dir = tmp_path / 'download_dir'
     esgf_files = create_esgf_search_results()
-
 
     mocker.patch.object(_recipe,
                         'get_input_filelist',

--- a/tests/unit/test_recipe.py
+++ b/tests/unit/test_recipe.py
@@ -295,6 +295,48 @@ def test_search_esgf(mocker, tmp_path, local_availability, already_downloaded):
     }
     assert input_files == expected[local_availability]
 
+@pytest.mark.parametrize('timerange', ['*', '185001/*', '*/185112'])
+def test_search_esgf_timerange(mocker, tmp_path, timerange):
+
+    rootpath = tmp_path / 'local'
+    download_dir = tmp_path / 'download_dir'
+    esgf_files = create_esgf_search_results()
+
+
+    mocker.patch.object(_recipe,
+                        'get_input_filelist',
+                        autospec=True,
+                        return_value=([], [], []))
+    mocker.patch.object(
+        _recipe.esgf,
+        'find_files',
+        autospec=True,
+        return_value=esgf_files,
+    )
+
+    variable = {
+        'project': 'CMIP6',
+        'mip': 'Amon',
+        'frequency': 'mon',
+        'short_name': 'tas',
+        'dataset': 'EC.-Earth3',
+        'exp': 'historical',
+        'ensemble': 'r1i1p1f1',
+        'grid': 'gr',
+        'timerange': timerange,
+        'alias': 'CMIP6_EC-Eeath3_tas',
+    }
+
+    config_user = {
+        'rootpath': None,
+        'drs': None,
+        'offline': False,
+        'download_dir': download_dir
+    }
+    _recipe._update_timerange(variable, config_user)
+
+    assert variable['timerange'] == '185001/185112'
+
 
 def test_write_html_summary(mocker, caplog):
     """Test `Recipe.write_html_summary` failing and logging a message."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->
This pull request should allow to use wildcards in the timerange when deriving variables and when downloading files from the ESGF.

I still have to find a way to add a test for the line that is not covered, which should check that the timeranges for variables needed in order to `derive` are the same, but if you want to test away the current changes feel free to do so. 

Closes #1516 
Closes #1550

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
