### PR TITLE
Tweak `extract_point` preprocessor: explain what it returns if one point coord outside cube and add explicit test 

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1654,6 +1654,11 @@ match the respective latitude and longitude coordinate to those of the
 input coordinates. If the input coordinate is a scalar, the dimension
 will be missing in the output cube (that is, it will be a scalar).
 
+If the point to be extracted has at least one of the coordinate point
+values outside the interval of the cube's same coordinate values, then
+no extrapolation will be performed, and the resulting extracted cube
+will have fully masked data.
+
 Parameters:
   * ``cube``: the input dataset cube.
   * ``latitude``, ``longitude``: coordinates (as floating point

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -405,10 +405,11 @@ def extract_point(cube, latitude, longitude, scheme):
 
     Returns
     -------
-    Returns a cube with the extracted point(s), and with adjusted
-    latitude and longitude coordinates (see above). If desired point
-    outside values for at least one coordinate, this cube will have fully
-    masked data.
+    :py:class:`~iris.cube.Cube`
+        Returns a cube with the extracted point(s), and with adjusted
+        latitude and longitude coordinates (see above). If desired point
+        outside values for at least one coordinate, this cube will have fully
+        masked data.
 
     Raises
     ------

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -387,6 +387,11 @@ def extract_point(cube, latitude, longitude, scheme):
     scalar, the dimension will be missing in the output cube (that is,
     it will be a scalar).
 
+    If the point to be extracted has at least one of the coordinate point
+    values outside the interval of the cube's same coordinate values, then
+    no extrapolation will be performed, and the resulting extracted cube
+    will have fully masked data.
+
     Parameters
     ----------
     cube : cube
@@ -401,7 +406,9 @@ def extract_point(cube, latitude, longitude, scheme):
     Returns
     -------
     Returns a cube with the extracted point(s), and with adjusted
-    latitude and longitude coordinates (see above).
+    latitude and longitude coordinates (see above). If desired point
+    outside values for at least one coordinate, this cube will have fully
+    masked data.
 
     Raises
     ------

--- a/tests/integration/preprocessor/_regrid/test_extract_point.py
+++ b/tests/integration/preprocessor/_regrid/test_extract_point.py
@@ -51,6 +51,12 @@ class Test(tests.Test):
         self.assertEqual(point.shape, (3,))
         self.assert_array_equal(point.data, masked)
 
+        point = extract_point(self.cube, 30, 30, scheme='nearest')
+        self.assertEqual(point.shape, (3,))
+        # do it the proletarian way, back to basics is good sometimes
+        assert np.ma.is_masked(point.data)
+        assert point.data.mask.all()
+
     def test_extract_point__single_nearest(self):
         """Test nearest match when extracting a single point"""
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

I panicked a little bit while reviewing one of @sloosvel 's PRs dealing with yet another extraction scenario since I thought the extraction process can do extrapolation on top of the known interpolation and we'd end up extracting a point in Italy when the cube only contains Nigeria, in which case data would be absolutely bonkers. It proves out that in that case the code don't fail, but returns fully masked data of the extracted point cube - good - but this is mentioned nowhere! So here it is, mentioned here, and added a test for good measure - even though there was a test for outside points extraction, this one checks specifically for the mask to be full.

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
