### PR TITLE
Added derivation of `hfns`

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_hfns.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_hfns.dat
@@ -1,0 +1,21 @@
+SOURCE: CMIP6
+!============
+variable_entry:    hfns
+!============
+modeling_realm:    atmos
+!----------------------------------
+! Variable attributes:
+!----------------------------------
+standard_name:
+units:             W m-2
+cell_methods:      time: mean
+cell_measures:     area: areacella
+long_name:         Surface Net Heat Flux
+!----------------------------------
+! Additional variable information:
+!----------------------------------
+dimensions:        longitude latitude time
+out_name:          hfns
+type:              real
+positive:          up
+!----------------------------------

--- a/esmvalcore/preprocessor/_derive/hfns.py
+++ b/esmvalcore/preprocessor/_derive/hfns.py
@@ -1,0 +1,33 @@
+"""Derivation of variable `hfns`."""
+
+from iris import NameConstraint
+
+from ._baseclass import DerivedVariableBase
+
+
+class DerivedVariable(DerivedVariableBase):
+    """Derivation of variable `hfns`."""
+
+    @staticmethod
+    def required(project):
+        """Declare the variables needed for derivation."""
+        required = [
+            {
+                'short_name': 'hfls',
+            },
+            {
+                'short_name': 'hfss',
+            },
+        ]
+        return required
+
+    @staticmethod
+    def calculate(cubes):
+        """Compute surface net heat flux."""
+        hfls_cube = cubes.extract_cube(NameConstraint(var_name='hfls'))
+        hfss_cube = cubes.extract_cube(NameConstraint(var_name='hfss'))
+
+        hfns_cube = hfls_cube + hfss_cube
+        hfns_cube.units = hfls_cube.units
+
+        return hfns_cube

--- a/tests/unit/preprocessor/_derive/test_hfns.py
+++ b/tests/unit/preprocessor/_derive/test_hfns.py
@@ -1,0 +1,45 @@
+"""Test derivation of ``hfns``."""
+import numpy as np
+import pytest
+from iris.cube import CubeList
+
+from esmvalcore.preprocessor._derive import hfns
+
+from .test_shared import get_cube
+
+
+@pytest.fixture
+def cubes():
+    """Input cubes for derivation of ``xch4``."""
+    hfls_cube = get_cube([[[1.0]]], air_pressure_coord=False,
+                         standard_name='surface_upward_latent_heat_flux',
+                         var_name='hfls', units='W m-2')
+    hfss_cube = get_cube([[[1.0]]], air_pressure_coord=False,
+                         standard_name='surface_upward_sensible_heat_flux',
+                         var_name='hfss', units='W m-2')
+    return CubeList([hfls_cube, hfss_cube])
+
+
+def test_hfns_calculate(cubes):
+    """Test function ``calculate``."""
+    derived_var = hfns.DerivedVariable()
+    out_cube = derived_var.calculate(cubes)
+    assert out_cube.shape == (1, 1, 1)
+    assert out_cube.units == 'W m-2'
+    assert out_cube.coords('time')
+    assert out_cube.coords('latitude')
+    assert out_cube.coords('longitude')
+    np.testing.assert_allclose(out_cube.data, [[[2.0]]])
+    np.testing.assert_allclose(out_cube.coord('time').points, [0.0])
+    np.testing.assert_allclose(out_cube.coord('latitude').points, [45.0])
+    np.testing.assert_allclose(out_cube.coord('longitude').points, [10.0])
+
+
+def test_hfns_required():
+    """Test function ``required``."""
+    derived_var = hfns.DerivedVariable()
+    output = derived_var.required(None)
+    assert output == [
+        {'short_name': 'hfls'},
+        {'short_name': 'hfss'},
+    ]


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR adds the derivation of `hfns` also used in the EMAC CMORizer in order to decrease the size of https://github.com/ESMValGroup/ESMValCore/pull/1554.


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
