### PR TITLE
add CMOR check exception for a basin coord named sector

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -437,7 +437,6 @@ class CMORCheck():
                                 coord.var_name,
                                 coordinate.out_name,
                             )
-                            # coord.var_name = coordinate.out_name
                         else:
                             self.report_error(
                                 'Coordinate {0} has var name {1} '

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -426,6 +426,18 @@ class CMORCheck():
                                 coordinate.out_name,
                             )
                             coord.var_name = coordinate.out_name
+                        elif (self._cmor_var.table_type in 'CMIP6' and
+                              coordinate.name == "basin" and
+                              coord.var_name == "sector"):
+                            self.report_debug_message(
+                                'Coordinate {0} has var name {1} '
+                                'instead of {2}. '
+                                "But that's considered OK and ignored.",
+                                coordinate.name,
+                                coord.var_name,
+                                coordinate.out_name,
+                            )
+                            # coord.var_name = coordinate.out_name
                         else:
                             self.report_error(
                                 'Coordinate {0} has var name {1} '


### PR DESCRIPTION
## Description

Add a CMOR check exception for an auxcoord named basin that has an out_name == sector. As discussed in PR #1607.

Closes Issue #1587

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
