### PR TITLE
Make _find_input_files public

### DIFF
--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -144,7 +144,6 @@ def dates_to_timerange(start_date, end_date):
     -------
     str
         ``timerange`` in the form ``'start_date/end_date'``.
-
     """
     start_date = str(start_date)
     end_date = str(end_date)
@@ -283,7 +282,6 @@ def _truncate_dates(date, file_date):
     same number of digits. If this is not the case, pad the dates with leading
     zeros (e.g., use ``date='0100'`` and ``file_date='199901'`` for a correct
     comparison).
-
     """
     date = re.sub("[^0-9]", '', date)
     file_date = re.sub("[^0-9]", '', file_date)
@@ -484,7 +482,7 @@ def _find_input_files(variable, rootpath, drs):
         value for the particular variable) that defines the variable (in the
         ESMValTool sense i.e. piece of data which is being worked on) to
         lookup. This will generally look something like
-        ``{"short_name": "tas", "original_short_name": "tas_custom", "exp": "historical"...}``
+        ``{"short_name": "tas", "original_short_name": "t", "exp": "1pctCO2"...}``
 
     rootpath : Dict[str: list[str]]
         Rootpaths in which to search for files. Keys are projects (e.g. CMIP6)
@@ -505,7 +503,8 @@ def _find_input_files(variable, rootpath, drs):
     Raises
     ------
     KeyError
-        ``variable`` does not contain all of the following keys: ``"short_name"``, ``"original_short_name"``
+        ``variable`` does not contain all of the following keys:
+        ``"short_name"``, ``"original_short_name"``
     """
     short_name = variable['short_name']
     variable['short_name'] = variable['original_short_name']

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -443,7 +443,7 @@ def get_rootpath(rootpath, project):
 
 
 def _find_input_dirs(variable, rootpath, drs):
-    """Return a the full paths to input directories."""
+    """Return the full paths to input directories."""
     project = variable['project']
 
     root = get_rootpath(rootpath, project)
@@ -477,8 +477,35 @@ def _get_filenames_glob(variable, drs):
 def _find_input_files(variable, rootpath, drs):
     """Find available input files.
 
-    Return the files, the directory in which they are located in, and
-    the file name.
+    Parameters
+    ----------
+    variable : Dict[str: str]
+        [Need help here] Metadata (keys are metadata labels, values provide
+        value for the particular variable) that defines the variable (in the
+        ESMValTool sense i.e. piece of data which is being worked on) to
+        lookup. This will generally look something like
+        ``{"short_name": "tas", "original_short_name": "tas_custom", "exp": "historical"...}``
+
+    rootpath : Dict[str: list[str]]
+        Rootpaths in which to search for files. Keys are projects (e.g. CMIP6)
+        and values are lists of paths to try as the rootpath.
+
+    drs : Dict[str: str]
+        DRS to use when searching for files. Keys are projects (e.g. CMIP6) and
+        values are the drs to use (e.g. ESGF).
+
+    Returns
+    -------
+    list[str], list[str], list[str]
+        Files (full path), directories in which they were searched for and
+        filename globs used to look for files. Note that the returned lists are
+        likely all of different lengths (i.e. don't correspond to each other in
+        any particular way).
+
+    Raises
+    ------
+    KeyError
+        ``variable`` does not contain all of the following keys: ``"short_name"``, ``"original_short_name"``
     """
     short_name = variable['short_name']
     variable['short_name'] = variable['original_short_name']


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Makes `_find_input_files` public. This is a super useful function and would be great if it was part of the 'public API' or at least well-documented and explicitly tested so that it can be used with confidence in other parts of the package (my particular interest is for #1572).

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] ~[☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do~

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository