### PR TITLE
Remove support for Mistral in `config-user.yml`

### DIFF
--- a/esmvalcore/config-user.yml
+++ b/esmvalcore/config-user.yml
@@ -189,32 +189,6 @@ drs:
 #  OBS6: default
 #  native6: default
 
-# Site-specific entries: DKRZ-Mistral
-# Uncomment the lines below to locate data on Mistral at DKRZ.
-# Note: Use ``offline: false`` only on login and prepost nodes.
-#auxiliary_data_dir: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/AUX
-#rootpath:
-#  CMIP6: /mnt/lustre02/work/ik1017/CMIP6/data/CMIP6
-#  CMIP5: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/CMIP5_DKRZ
-#  CMIP3: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/CMIP3
-#  CORDEX: /mnt/lustre02/work/ik1017/C3SCORDEX/data/c3s-cordex/output
-#  OBS: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/OBS
-#  OBS6: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/OBS
-#  obs4MIPs: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/OBS
-#  ana4mips: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/OBS
-#  native6: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/RAWOBS
-#  RAWOBS: /mnt/lustre02/work/bd0854/DATA/ESMValTool2/RAWOBS
-#drs:
-#  CMIP6: DKRZ
-#  CMIP5: DKRZ
-#  CMIP3: DKRZ
-#  CORDEX: BADC
-#  obs4MIPs: default
-#  ana4mips: default
-#  OBS: default
-#  OBS6: default
-#  native6: default
-
 # Site-specific entries: ETHZ
 # Uncomment the lines below to locate data at ETHZ.
 #rootpath:


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->
This PR removes the Mistral entry from the `config-user.yml` file because Mistral has just been turned off. Sorry for the last minute PR but it would be good to remove unnecessary lines from the `config-user.yml` for the upcoming release.

Related to https://github.com/ESMValGroup/ESMValTool/discussions/2631

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
~~- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added~~
~~- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~~
~~- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~~
~~- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date~~
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
