### PR TITLE
Custom user-defined location for custom CMOR tables

### DIFF
--- a/doc/develop/fixing_data.rst
+++ b/doc/develop/fixing_data.rst
@@ -346,6 +346,7 @@ under project ``native6``.
 
 Configuration
 -------------
+
 An example of a configuration in ``config-developer.yml`` for projects used for
 native datasets is given :ref:`here <configure_native_models>`.
 Make sure to use the option ``cmor_strict: false`` for these projects if you

--- a/doc/develop/fixing_data.rst
+++ b/doc/develop/fixing_data.rst
@@ -351,7 +351,7 @@ An example of a configuration in ``config-developer.yml`` for projects used for
 native datasets is given :ref:`here <configure_native_models>`.
 Make sure to use the option ``cmor_strict: false`` for these projects if you
 want to make use of :ref:`custom_cmor_tables`.
-This allows reading arbitrary variables from native model output.
+This allows reading arbitrary variables from native datasets.
 
 .. _add_new_fix_native_datasets_locate_data:
 

--- a/doc/develop/fixing_data.rst
+++ b/doc/develop/fixing_data.rst
@@ -342,6 +342,16 @@ This section describes how to add support for additional native datasets.
 You can choose to host this new data source either under a dedicated project or
 under project ``native6``.
 
+.. _add_new_fix_native_datasets_config:
+
+Configuration
+-------------
+An example of a configuration in ``config-developer.yml`` for projects used for
+native datasets is given :ref:`here <configure_native_models>`.
+Make sure to use the option ``cmor_strict: false`` for these projects if you
+want to make use of :ref:`custom_cmor_tables`.
+This allows reading arbitrary variables from native model output.
+
 .. _add_new_fix_native_datasets_locate_data:
 
 Locate data

--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -531,7 +531,7 @@ As mentioned in the previous section, the CMOR tables of projects that use
 By default, these are loaded from `esmvalcore/cmor/tables/custom
 <https://github.com/ESMValGroup/ESMValCore/tree/main/esmvalcore/cmor/tables/custom>`_.
 However, by using the special project ``custom`` in the
-``config-developer.yml`` file with the option ``cmor_path```, a custom location
+``config-developer.yml`` file with the option ``cmor_path``, a custom location
 for these custom CMOR tables can be specified:
 
 .. code-block:: yaml
@@ -653,7 +653,10 @@ given :ref:`here <add_new_fix_native_datasets>`.
 
    When using data from native model output, it might be helpful to specify a
    custom location for the :ref:`custom_cmor_tables`.
-   This allows allows reading arbitrary variables from native model output.
+   This allows reading arbitrary variables from native model output.
+   Note that this requires the option ``cmor_strict: false`` in the
+   :ref:`project configuration <configure_native_models>` used for the native
+   model output.
 
 
 .. _config-ref:

--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -586,7 +586,7 @@ Filter preprocessor warnings
 
 It is possible to ignore specific warnings of the preprocessor for a given
 ``project``.
-This is particularly useful for native models which do not follow the CMOR
+This is particularly useful for native datasets which do not follow the CMOR
 standard by default and consequently produce a lot of warnings when handled by
 Iris.
 This can be configured in the ``config-developer.yml`` file for some steps of
@@ -651,9 +651,9 @@ given :ref:`here <add_new_fix_native_datasets>`.
 
 .. hint::
 
-   When using data from native model output, it might be helpful to specify a
-   custom location for the :ref:`custom_cmor_tables`.
-   This allows reading arbitrary variables from native model output.
+   When using native datasets, it might be helpful to specify a custom location
+   for the :ref:`custom_cmor_tables`.
+   This allows reading arbitrary variables from native datasets.
    Note that this requires the option ``cmor_strict: false`` in the
    :ref:`project configuration <configure_native_models>` used for the native
    model output.

--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -510,15 +510,71 @@ related to CMOR table settings available:
 * ``cmor_type``: can be ``CMIP5`` if the CMOR table is in the same format as the
   CMIP5 table or ``CMIP6`` if the table is in the same format as the CMIP6 table.
 * ``cmor_strict``: if this is set to ``false``, the CMOR table will be
-  extended with variables from the ``esmvalcore/cmor/tables/custom`` directory
-  and it is possible to use variables with a ``mip`` which is different from
-  the MIP table in which they are defined.
+  extended with variables from the :ref:`custom_cmor_tables` (by default loaded
+  from the ``esmvalcore/cmor/tables/custom`` directory) and it is possible to
+  use variables with a ``mip`` which is different from the MIP table in which
+  they are defined.
 * ``cmor_path``: path to the CMOR table.
   Relative paths are with respect to `esmvalcore/cmor/tables`_.
   Defaults to the value provided in ``cmor_type`` written in lower case.
 * ``cmor_default_table_prefix``: Prefix that needs to be added to the ``mip``
   to get the name of the file containing the ``mip`` table.
   Defaults to the value provided in ``cmor_type``.
+
+.. _custom_cmor_tables:
+
+Custom CMOR tables
+------------------
+
+As mentioned in the previous section, the CMOR tables of projects that use
+``cmor_strict: false`` will be extended with custom CMOR tables.
+By default, these are loaded from `esmvalcore/cmor/tables/custom`_.
+However, by using the special project ``custom`` in the
+``config-developer.yml`` file with the option ``cmor_path```, a custom location
+for these custom CMOR tables can be specified:
+
+.. code-block:: yaml
+
+   custom:
+     cmor_path: ~/my/own/custom_tables
+
+This path can be given as relative path (relative to `esmvalcore/cmor/tables`_)
+or as absolute path.
+Other options given for this special table will be ignored.
+
+Custom tables in this directory need to follow the naming convention
+``CMOR_{short_name}.dat`` and need to be given in CMIP5 format.
+
+Example for the file ``CMOR_asr.dat``:
+
+.. code-block::
+
+   SOURCE: CMIP5
+   !============
+   variable_entry:    asr
+   !============
+   modeling_realm:    atmos
+   !----------------------------------
+   ! Variable attributes:
+   !----------------------------------
+   standard_name:
+   units:             W m-2
+   cell_methods:      time: mean
+   cell_measures:     area: areacella
+   long_name:         Absorbed shortwave radiation
+   !----------------------------------
+   ! Additional variable information:
+   !----------------------------------
+   dimensions:        longitude latitude time
+   type:              real
+   positive:          down
+   !----------------------------------
+   !
+
+It is also possible to use a special coordinates file ``CMOR_coordinates.dat``.
+If this is not present in the custom directory, the one from the default
+directory (`esmvalcore/cmor/tables/custom/CMOR_coordinates.dat`_) is used.
+
 
 .. _filterwarnings_config-developer:
 
@@ -589,6 +645,12 @@ Example:
 
 A detailed description on how to add support for further native datasets is
 given :ref:`here <add_new_fix_native_datasets>`.
+
+.. hint::
+
+   When using data from native model output, it might be helpful to specify a
+   custom location for the :ref:`custom_cmor_tables`.
+   This allows allows reading arbitrary variables from native model output.
 
 
 .. _config-ref:

--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -528,7 +528,8 @@ Custom CMOR tables
 
 As mentioned in the previous section, the CMOR tables of projects that use
 ``cmor_strict: false`` will be extended with custom CMOR tables.
-By default, these are loaded from `esmvalcore/cmor/tables/custom`_.
+By default, these are loaded from `esmvalcore/cmor/tables/custom
+<https://github.com/ESMValGroup/ESMValCore/tree/main/esmvalcore/cmor/tables/custom>`_.
 However, by using the special project ``custom`` in the
 ``config-developer.yml`` file with the option ``cmor_path```, a custom location
 for these custom CMOR tables can be specified:
@@ -573,7 +574,9 @@ Example for the file ``CMOR_asr.dat``:
 
 It is also possible to use a special coordinates file ``CMOR_coordinates.dat``.
 If this is not present in the custom directory, the one from the default
-directory (`esmvalcore/cmor/tables/custom/CMOR_coordinates.dat`_) is used.
+directory (`esmvalcore/cmor/tables/custom/CMOR_coordinates.dat
+<https://github.com/ESMValGroup/ESMValCore/tree/main/esmvalcore/cmor/tables/custom/CMOR_coordinates.dat>`_)
+is used.
 
 
 .. _filterwarnings_config-developer:

--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -92,7 +92,10 @@ A detailed description of how to include new native datasets is given
 
    When using data from native model output, it might be helpful to specify a
    custom location for the :ref:`custom_cmor_tables`.
-   This allows allows reading arbitrary variables from native model output.
+   This allows reading arbitrary variables from native model output.
+   Note that this requires the option ``cmor_strict: false`` in the
+   :ref:`project configuration <configure_native_models>` used for the native
+   model output.
 
 .. _read_native_obs:
 

--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -88,6 +88,12 @@ project, e.g., ``ICON`` (mostly native models).
 A detailed description of how to include new native datasets is given
 :ref:`here <add_new_fix_native_datasets>`.
 
+.. hint::
+
+   When using data from native model output, it might be helpful to specify a
+   custom location for the :ref:`custom_cmor_tables`.
+   This allows allows reading arbitrary variables from native model output.
+
 .. _read_native_obs:
 
 Supported native reanalysis/observational datasets

--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -90,9 +90,9 @@ A detailed description of how to include new native datasets is given
 
 .. hint::
 
-   When using data from native model output, it might be helpful to specify a
-   custom location for the :ref:`custom_cmor_tables`.
-   This allows reading arbitrary variables from native model output.
+   When using native datasets, it might be helpful to specify a custom location
+   for the :ref:`custom_cmor_tables`.
+   This allows reading arbitrary variables from native datasets.
    Note that this requires the option ``cmor_strict: false`` in the
    :ref:`project configuration <configure_native_models>` used for the native
    model output.

--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -26,6 +26,7 @@
 #   cmor_path: ~/my/own/custom_tables
 ###############################################################################
 ---
+
 CMIP6:
   cmor_strict: true
   input_dir:

--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -2,8 +2,8 @@
 # Developer's configuration file for the ESMValTool
 ###############################################################################
 # This file retains the project- and machine-dependent directory and file name
-# definitions of the input and output data
-# Each dictionary is structured as follows
+# definitions of the input and output data.
+# Each dictionary is structured as follows:
 #
 # PROJECT:
 #   input_dir:
@@ -14,10 +14,18 @@
 #   input_file:
 #   output_file:
 #
-# Only the default drs is mandatory, the others are optional
+# Only the default drs is mandatory, the others are optional.
+#
+# In addition, an entry for the custom tables can be given. For this, only the
+# option 'cmor_path' is considered, which specifies the directory from which
+# custom CMOR tables are loaded. 'cmor_path' can be a relative path (relative
+# to ESMValCore/esmvalcore/cmor/tables) or an absolute path. By default, uses
+# ESMValCore/esmvalcore/cmor/tables/custom.
+#
+# custom:
+#   cmor_path: ~/my/own/custom_tables
 ###############################################################################
 ---
-
 CMIP6:
   cmor_strict: true
   input_dir:

--- a/tests/integration/cmor/test_read_cmor_tables.py
+++ b/tests/integration/cmor/test_read_cmor_tables.py
@@ -62,3 +62,6 @@ def test_read_custom_cmor_tables():
 
     cmip6_table = CMOR_TABLES['CMIP6']
     assert cmip6_table.default is custom_table
+
+    # Restore default tables
+    read_cmor_tables(read_config_developer_file())

--- a/tests/integration/cmor/test_read_cmor_tables.py
+++ b/tests/integration/cmor/test_read_cmor_tables.py
@@ -5,6 +5,17 @@ from esmvalcore.cmor.table import CMOR_TABLES
 from esmvalcore.cmor.table import __file__ as root
 from esmvalcore.cmor.table import read_cmor_tables
 
+CUSTOM_CFG_DEVELOPER = {
+    'custom': {'cmor_path': Path(root).parent / 'tables' / 'custom'},
+    'CMIP6': {
+        'cmor_strict': True,
+        'input_dir': {'default': '/'},
+        'input_file': '*.nc',
+        'output_file': 'out.nc',
+        'cmor_type': 'CMIP6',
+    },
+}
+
 
 def test_read_cmor_tables():
     """Test that the function `read_cmor_tables` loads the tables correctly."""
@@ -33,3 +44,21 @@ def test_read_cmor_tables():
     table = CMOR_TABLES[project]
     assert Path(table._cmor_folder) == table_path / 'obs4mips' / 'Tables'
     assert table.strict is False
+
+
+def test_read_custom_cmor_tables():
+    """Test reading of custom CMOR tables."""
+    read_cmor_tables(CUSTOM_CFG_DEVELOPER)
+
+    assert len(CMOR_TABLES) == 2
+    assert 'CMIP6' in CMOR_TABLES
+    assert 'custom' in CMOR_TABLES
+
+    custom_table = CMOR_TABLES['custom']
+    assert (Path(custom_table._cmor_folder) ==
+            Path(root).parent / 'tables' / 'custom')
+    assert (Path(custom_table._coordinates_file) ==
+            Path(root).parent / 'tables' / 'custom' / 'CMOR_coordinates.dat')
+
+    cmip6_table = CMOR_TABLES['CMIP6']
+    assert cmip6_table.default is custom_table

--- a/tests/integration/cmor/test_table.py
+++ b/tests/integration/cmor/test_table.py
@@ -347,12 +347,45 @@ class TestCustomInfo(unittest.TestCase):
         """
         cls.variables_info = CustomInfo()
 
+    def test_custom_tables_default_location(self):
+        """Test constructor with default tables location."""
+        custom_info = CustomInfo()
+        expected_cmor_folder = os.path.join(
+            os.path.dirname(esmvalcore.cmor.__file__),
+            'tables',
+            'custom',
+        )
+        expected_coordinate_file = os.path.join(
+            os.path.dirname(esmvalcore.cmor.__file__),
+            'tables',
+            'custom',
+            'CMOR_coordinates.dat',
+        )
+        self.assertEqual(custom_info._cmor_folder, expected_cmor_folder)
+        self.assertEqual(custom_info._coordinates_file,
+                         expected_coordinate_file)
+
     def test_custom_tables_location(self):
         """Test constructor with custom tables location."""
         cmor_path = os.path.dirname(os.path.realpath(esmvalcore.cmor.__file__))
         cmor_tables_path = os.path.join(cmor_path, 'tables', 'cmip5')
         cmor_tables_path = os.path.abspath(cmor_tables_path)
-        CustomInfo(cmor_tables_path)
+        custom_info = CustomInfo(cmor_tables_path)
+        self.assertEqual(custom_info._cmor_folder, cmor_tables_path)
+
+        expected_coordinate_file = os.path.join(
+            os.path.dirname(esmvalcore.cmor.__file__),
+            'tables',
+            'custom',
+            'CMOR_coordinates.dat',
+        )
+        self.assertEqual(custom_info._coordinates_file,
+                         expected_coordinate_file)
+
+    def test_custom_tables_invalid_location(self):
+        """Test constructor with invalid custom tables location."""
+        with self.assertRaises(ValueError):
+            CustomInfo('this_file_does_not_exist.dat')
 
     def test_get_variable_netcre(self):
         """Get tas variable."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR allows the specification of a custom location for the custom CMOR tables in the `config-developer.yml` file (using the `custom` key).

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1623 

Link to documentation:

- https://esmvaltool--1625.org.readthedocs.build/projects/ESMValCore/en/1625/quickstart/find_data.html#datasets-in-native-format
- https://esmvaltool--1625.org.readthedocs.build/projects/ESMValCore/en/1625/quickstart/configure.html#custom-cmor-tables
- https://esmvaltool--1625.org.readthedocs.build/projects/ESMValCore/en/1625/develop/fixing_data.html#add-support-for-new-native-datasets

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
