### PR TITLE
Fix `force_derivation` bug

### DIFF
--- a/doc/recipe/overview.rst
+++ b/doc/recipe/overview.rst
@@ -180,6 +180,22 @@ When using the ``timerange`` tag to specify the start and end points, possible v
     * ``timerange: '198003/*``. Starting from 01/03/1980, spans until the last available point.
     * ``timerange: 'P5M/*``. Finds last available point, spans 5 months backwards from it.
 
+.. note::
+
+   Please make sure to use a consistent number of digits for the start and end
+   point when using ``timerange``, e.g., instead of ``198005/2000``, use
+   ``198005/200012``.
+   Otherwise, it might happen that ESMValTool does not find your data even
+   though the corresponding years are available.
+   This also applies to wildcards:
+   Wildcards are usually resolved using the timerange in the file name.  If
+   this is given in the form ``YYYYMM``, then the other time point in
+   ``timerange`` needs to be in the same format, e.g., use ``*/200012`` instead
+   of ``*/2000`` in this case.
+   If you use wildcards and get an unexpected error about missing data, have a
+   look at the resolved ``timerange`` in the error message (``ERROR No input
+   files found for variable {'timerange': '197901/2000', ...}``) and make sure
+   that the number of digits in it is consistent.
 
 Note that this section is not required, as datasets can also be provided in the
 Diagnostics_ section.

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1161,14 +1161,15 @@ def _get_derive_input_variables(variables, config_user):
 
     for variable in variables:
         group_prefix = variable['variable_group'] + '_derive_input_'
-        if not variable.get('force_derivation') and '*' in variable['timerange']:
+        if not variable.get('force_derivation') and \
+           '*' in variable['timerange']:
             raise RecipeError(
                 f"Error in {variable['short_name']}: "
                 "Setting force_derivation to False and using wildcards "
                 "in time range is not allowed."
-                )    
+                )
         elif not variable.get('force_derivation') and _get_input_files(
-            variable, config_user)[0]:
+           variable, config_user)[0]:
             # No need to derive, just process normally up to derive step
             var = deepcopy(variable)
             append(group_prefix, var)

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1164,9 +1164,11 @@ def _get_derive_input_variables(variables, config_user):
         if not variable.get('force_derivation') and \
            '*' in variable['timerange']:
             raise RecipeError(
-                f"Error in {variable['short_name']}: "
-                "Setting force_derivation to False and using wildcards "
-                "in time range is not allowed."
+                f"Error in derived variable: {variable['short_name']}: "
+                "Using 'force_derivation: false' (the default option) "
+                "in combination with wildcards ('*') in timerange is "
+                "not allowed; explicitly use 'force_derivation: true' "
+                "or avoid the use of wildcards in timerange."
                 )
         elif not variable.get('force_derivation') and _get_input_files(
            variable, config_user)[0]:

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1161,9 +1161,15 @@ def _get_derive_input_variables(variables, config_user):
 
     for variable in variables:
         group_prefix = variable['variable_group'] + '_derive_input_'
-        if not variable.get('force_derivation'):
+        if not variable.get('force_derivation') and '*' in variable['timerange']:
+            raise RecipeError(
+                f"Error in {variable['short_name']}: "
+                "Setting force_derivation to False and using wildcards "
+                "in time range is not allowed."
+                )    
+        elif not variable.get('force_derivation') and _get_input_files(
+            variable, config_user)[0]:
             # No need to derive, just process normally up to derive step
-            _update_timerange(variable, config_user)
             var = deepcopy(variable)
             append(group_prefix, var)
         else:

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1170,7 +1170,7 @@ def _get_derive_input_variables(variables, config_user):
                 "not allowed; explicitly use 'force_derivation: true' "
                 "or avoid the use of wildcards in timerange."
                 )
-        elif not variable.get('force_derivation') and _get_input_files(
+        if not variable.get('force_derivation') and _get_input_files(
            variable, config_user)[0]:
             # No need to derive, just process normally up to derive step
             var = deepcopy(variable)

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1610,6 +1610,37 @@ def test_derive_timerange_wildcard(tmp_path, patched_datafinder,
     assert product.attributes['end_year'] == 2019
 
 
+def test_derive_fail_timerange_wildcard(tmp_path, patched_datafinder,
+                                        config_user):
+
+    content = dedent("""
+        diagnostics:
+          diagnostic_name:
+            variables:
+              toz:
+                project: CMIP5
+                mip: Amon
+                exp: historical
+                timerange: '*'
+                derive: true
+                force_derivation: false
+                additional_datasets:
+                  - {dataset: GFDL-CM3,  ensemble: r1i1p1}
+            scripts: null
+        """)
+    msg = (
+      "Error in derived variable: toz: "
+      "Using 'force_derivation: false' (the default option) "
+      "in combination with wildcards ('*') in timerange is "
+      "not allowed; explicitly use 'force_derivation: true' "
+      "or avoid the use of wildcards in timerange")
+
+    with pytest.raises(RecipeError) as rec_err:
+        get_recipe(tmp_path, content, config_user)
+
+    assert msg in rec_err.value.failed_tasks[0].message
+
+
 def create_test_image(basename, cfg):
     """Get a valid path for saving a diagnostic plot."""
     image = Path(cfg['plot_dir']) / (basename + '.' + cfg['output_file_type'])


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

This PR adds a check that does not allow to combine `force_derivation: false` and wildcards in the `timerange` tag and should the previous `force_derivation: false` behaviour.


Closes #1626 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
