### PR TITLE
Test Github Actions dashboard badge from meercode.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Docker Build Status](https://img.shields.io/docker/cloud/build/esmvalgroup/esmvalcore)](https://hub.docker.com/r/esmvalgroup/esmvalcore/)
 [![Anaconda-Server Badge](https://anaconda.org/esmvalgroup/esmvalcore/badges/installer/conda.svg)](https://conda.anaconda.org/esmvalgroup)
 [![Github Actions Test](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml/badge.svg)](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml)
-![Github Actions Dashboard](https://api.meercode.io/badge//?type=ci-score&lastDay=14)
+![Github Actions Dashboard](https://api.meercode.io/badge/ESMValGroup/ESMValCore?type=ci-score&branch=main&lastDay=14)
 
 ![esmvaltoollogo](https://github.com/ESMValGroup/ESMValCore/blob/main/doc/figures/ESMValTool-logo-2.png)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Docker Build Status](https://img.shields.io/docker/cloud/build/esmvalgroup/esmvalcore)](https://hub.docker.com/r/esmvalgroup/esmvalcore/)
 [![Anaconda-Server Badge](https://anaconda.org/esmvalgroup/esmvalcore/badges/installer/conda.svg)](https://conda.anaconda.org/esmvalgroup)
 [![Github Actions Test](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml/badge.svg)](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml)
-![Github Actions Dashboard](https://api.meercode.io/badge/ESMValGroup/ESMValCore?type=ci-score&branch=main&lastDay=14)
+[![Github Actions Dashboard](https://api.meercode.io/badge/ESMValGroup/ESMValCore?type=ci-success-rate&branch=main&lastDay=14)](https://meercode.io)
 
 ![esmvaltoollogo](https://github.com/ESMValGroup/ESMValCore/blob/main/doc/figures/ESMValTool-logo-2.png)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Docker Build Status](https://img.shields.io/docker/cloud/build/esmvalgroup/esmvalcore)](https://hub.docker.com/r/esmvalgroup/esmvalcore/)
 [![Anaconda-Server Badge](https://anaconda.org/esmvalgroup/esmvalcore/badges/installer/conda.svg)](https://conda.anaconda.org/esmvalgroup)
 [![Github Actions Test](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml/badge.svg)](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml)
+![Github Actions Dashboard](https://api.meercode.io/badge//?type=ci-score&lastDay=14)
 
 ![esmvaltoollogo](https://github.com/ESMValGroup/ESMValCore/blob/main/doc/figures/ESMValTool-logo-2.png)
 


### PR DESCRIPTION
It's good to have CI Dashboard badges so we can have a bird's eye view of what our CI/CD is doing - @bouweandela pointed me to a dashboard from Circle, so I thought I'd have a go at a dash from Github Actions - proves out GA don't have a native dashboard so I found meercode.io offers a very decent integration (not only for GA) - can one of you @bouweandela @zklaus @schlunma please test if the badge is leading to the correct dashboard - it does for me, but I am registered with meercode, so not sure if that's working overall. Cheers :beer: 

**UPDATE at point of moving it to Ready for Review**

Folks see plots and stats and all manners of dashboard-y stuff if they click on the Meercode badge, and autheticate with GitHub. Do we need documentation for this? I think we're fine like this -