### PR TITLE
Improve esmvalcore.esgf unit test

### DIFF
--- a/tests/unit/esgf/test_search.py
+++ b/tests/unit/esgf/test_search.py
@@ -119,12 +119,13 @@ def get_mock_connection(mocker, search_results):
     cfg = {
         'search_connection': {
             'urls': [
-                'https://esgf-index1.ceda.ac.uk/esg-search',
-                'https://esgf-node.llnl.gov/esg-search',
+                'https://esgf-index1.example.com/esg-search',
+                'https://esgf-index2.example.com/esg-search',
             ]
         },
     }
     mocker.patch.object(_search, "get_esgf_config", return_value=cfg)
+    mocker.patch.object(_search, 'FIRST_ONLINE_INDEX_NODE', None)
 
     ctx = mocker.create_autospec(
         pyesgf.search.context.FileSearchContext,
@@ -207,7 +208,7 @@ def test_esgf_search_files(mocker):
     files = _search.esgf_search_files(facets)
 
     SearchConnection.assert_called_once_with(
-        url='https://esgf-index1.ceda.ac.uk/esg-search')
+        url='https://esgf-index1.example.com/esg-search')
     connection = SearchConnection.return_value
     connection.new_context.assert_called_with(
         pyesgf.search.context.FileSearchContext,
@@ -244,7 +245,6 @@ def test_esgf_search_files(mocker):
 
 def test_esgf_search_uses_second_index_node(mocker):
     """Test that the second index node is used if the first is offline."""
-    mocker.patch.object(_search, 'FIRST_ONLINE_INDEX_NODE', None)
     search_result = mocker.sentinel.search_result
     search_results = [
         requests.exceptions.ReadTimeout("Timeout error message"),
@@ -255,7 +255,7 @@ def test_esgf_search_uses_second_index_node(mocker):
 
     result = _search._search_index_nodes(facets={})
 
-    second_index_node = 'https://esgf-node.llnl.gov/esg-search'
+    second_index_node = 'https://esgf-index2.example.com/esg-search'
     assert _search.FIRST_ONLINE_INDEX_NODE == second_index_node
     assert result == search_result
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

If `FIRST_ONLINE_INDEX_NODE` was already set to a URL by some other code, the unit tests of `esmvalcore.esgf.find_files` would fail as these depended on it being set to `None`. This pull request ensures it is always set to `None` before these tests are started.

Closes #1649

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
