### PR TITLE
Adapt tests to new version of cf-units

### DIFF
--- a/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_0.py
@@ -13,7 +13,7 @@ from esmvalcore.cmor.table import get_var_info
 from esmvalcore.iris_helpers import date2num
 
 
-class TestAllVars(unittest.TestCase):
+class TestAllVars:
     """Test all vars fixes."""
 
     def setUp(self):
@@ -33,20 +33,19 @@ class TestAllVars(unittest.TestCase):
 
     def test_get(self):
         """Test getting of fix."""
-        self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'ACCESS1-0', 'Amon', 'tas'),
-            [AllVars(None)])
+        assert (Fix.get_fixes('CMIP5', 'ACCESS1-0', 'Amon', 'tas')
+                == [AllVars(None)])
 
     def test_fix_metadata(self):
         """Test fix for bad calendar."""
         cube = self.fix.fix_metadata([self.cube])[0]
         time = cube.coord('time')
         dates = num2date(time.points, time.units.name, time.units.calendar)
-        self.assertEqual(time.units.calendar, 'gregorian')
-        u = Unit('days since 300-01-01 12:00:00', calendar='gregorian')
-        self.assertEqual(dates[0], u.num2date(15))
-        u = Unit('days since 1850-01-01 12:00:00', calendar='gregorian')
-        self.assertEqual(dates[1], u.num2date(15))
+        assert time.units.calendar in ('standard', 'gregorian')
+        u = Unit('days since 300-01-01 12:00:00', calendar='standard')
+        assert dates[0] == u.num2date(15)
+        u = Unit('days since 1850-01-01 12:00:00', calendar='standard')
+        assert dates[1] == u.num2date(15)
 
     def test_fix_metadata_if_not_time(self):
         """Test calendar fix do not fail if no time coord present."""

--- a/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_access1_3.py
@@ -1,5 +1,4 @@
 """Test fixes for ACCESS1-3."""
-import unittest
 from datetime import datetime
 
 from cf_units import Unit, num2date
@@ -12,7 +11,7 @@ from esmvalcore.cmor._fixes.fix import Fix
 from esmvalcore.iris_helpers import date2num
 
 
-class TestAllVars(unittest.TestCase):
+class TestAllVars:
     """Test fixes for all vars."""
 
     def setUp(self):
@@ -32,20 +31,19 @@ class TestAllVars(unittest.TestCase):
 
     def test_get(self):
         """Test getting of fix."""
-        self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'ACCESS1-3', 'Amon', 'tas'),
-            [AllVars(None)])
+        assert (Fix.get_fixes('CMIP5', 'ACCESS1-3', 'Amon', 'tas')
+                == [AllVars(None)])
 
     def test_fix_metadata(self):
         """Test fix for bad calendar."""
         cube = self.fix.fix_metadata([self.cube])[0]
         time = cube.coord('time')
         dates = num2date(time.points, time.units.name, time.units.calendar)
-        self.assertEqual(time.units.calendar, 'gregorian')
-        u = Unit('days since 300-01-01 12:00:00', calendar='gregorian')
-        self.assertEqual(dates[0], u.num2date(15))
-        u = Unit('days since 1850-01-01 12:00:00', calendar='gregorian')
-        self.assertEqual(dates[1], u.num2date(15))
+        assert time.units.calendar in ('standard', 'gregorian')
+        u = Unit('days since 300-01-01 12:00:00', calendar='standard')
+        assert dates[0] == u.num2date(15)
+        u = Unit('days since 1850-01-01 12:00:00', calendar='standard')
+        assert dates[1] == u.num2date(15)
 
     def test_fix_metadata_if_not_time(self):
         """Test calendar fix do not fail if no time coord present."""

--- a/tests/integration/cmor/_fixes/cmip5/test_fgoals_g2.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_fgoals_g2.py
@@ -1,6 +1,4 @@
 """Test FGOALS-g2 fixes."""
-import unittest
-
 from cf_units import Unit
 from iris.coords import DimCoord
 from iris.cube import Cube
@@ -9,7 +7,7 @@ from esmvalcore.cmor._fixes.cmip5.fgoals_g2 import AllVars
 from esmvalcore.cmor.fix import Fix
 
 
-class TestAll(unittest.TestCase):
+class TestAll:
     """Test fixes for all vars."""
 
     def setUp(self):
@@ -31,18 +29,16 @@ class TestAll(unittest.TestCase):
 
     def test_get(self):
         """Test fix get."""
-        self.assertListEqual(
-            Fix.get_fixes('CMIP5', 'FGOALS-G2', 'Amon', 'tas'),
-            [AllVars(None)])
+        assert (Fix.get_fixes('CMIP5', 'FGOALS-G2', 'Amon', 'tas')
+                == [AllVars(None)])
 
     def test_fix_metadata(self):
         """Test calendar fix."""
         cube = self.fix.fix_metadata([self.cube])[0]
 
         time = cube.coord('time')
-        self.assertEqual(time.units.origin,
-                         'day since 1-01-01 00:00:00.000000')
-        self.assertEqual(time.units.calendar, 'gregorian')
+        assert time.units.origin == 'day since 1-01-01 00:00:00.000000'
+        assert time.units.calendar in ('standard', 'gregorian')
 
     def test_fix_metadata_dont_fail_if_not_longitude(self):
         """Test calendar fix."""

--- a/tests/sample_data/multimodel_statistics/test_multimodel.py
+++ b/tests/sample_data/multimodel_statistics/test_multimodel.py
@@ -23,7 +23,7 @@ CALENDAR_PARAMS = (
         marks=pytest.mark.skip(
             reason='Cannot calculate statistics with single cube in list')),
     '365_day',
-    'gregorian',
+    'standard',
     pytest.param(
         'proleptic_gregorian',
         marks=pytest.mark.xfail(

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -22,7 +22,7 @@ SPAN_OPTIONS = ('overlap', 'full')
 
 FREQUENCY_OPTIONS = ('daily', 'monthly', 'yearly')  # hourly
 
-CALENDAR_OPTIONS = ('360_day', '365_day', 'gregorian', 'proleptic_gregorian',
+CALENDAR_OPTIONS = ('360_day', '365_day', 'standard', 'proleptic_gregorian',
                     'julian')
 
 
@@ -35,7 +35,7 @@ def assert_array_allclose(this, other):
 
 
 def timecoord(frequency,
-              calendar='gregorian',
+              calendar='standard',
               offset='days since 1850-01-01',
               num=3):
     """Return a time coordinate with the given time points and calendar."""
@@ -58,7 +58,7 @@ def timecoord(frequency,
 
 def generate_cube_from_dates(
     dates,
-    calendar='gregorian',
+    calendar='standard',
     offset='days since 1850-01-01',
     fill_val=1,
     len_data=3,
@@ -350,19 +350,19 @@ def test_unsupported_statistics_fail(statistic, error):
 
 
 @pytest.mark.parametrize('calendar1, calendar2, expected', (
-    ('360_day', '360_day', '360_day'),
-    ('365_day', '365_day', '365_day'),
-    ('365_day', '360_day', 'gregorian'),
-    ('360_day', '365_day', 'gregorian'),
-    ('gregorian', '365_day', 'gregorian'),
-    ('proleptic_gregorian', 'julian', 'gregorian'),
-    ('julian', '365_day', 'gregorian'),
+    ('360_day', '360_day', ('360_day',)),
+    ('365_day', '365_day', ('365_day',)),
+    ('365_day', '360_day', ('standard', 'gregorian')),
+    ('360_day', '365_day', ('standard', 'gregorian')),
+    ('standard', '365_day', ('standard', 'gregorian')),
+    ('proleptic_gregorian', 'julian', ('standard', 'gregorian')),
+    ('julian', '365_day', ('standard', 'gregorian')),
 ))
 def test_get_consistent_time_unit(calendar1, calendar2, expected):
     """Test same calendar returned or default if calendars differ.
 
     Expected behaviour: If the calendars are the same, return that one.
-    If the calendars are not the same, return 'gregorian'.
+    If the calendars are not the same, return 'standard'.
     """
     cubes = (
         generate_cube_from_dates('monthly', calendar=calendar1),
@@ -370,7 +370,7 @@ def test_get_consistent_time_unit(calendar1, calendar2, expected):
     )
 
     result = mm._get_consistent_time_unit(cubes)
-    assert result.calendar == expected
+    assert result.calendar in expected
 
 
 @pytest.mark.parametrize('span', SPAN_OPTIONS)
@@ -395,7 +395,7 @@ def test_align(span):
     calendars = set(cube.coord('time').units.calendar for cube in result_cubes)
 
     assert len(calendars) == 1
-    assert list(calendars)[0] == 'gregorian'
+    assert list(calendars)[0] in ('standard', 'gregorian')
 
     shapes = set(cube.shape for cube in result_cubes)
 
@@ -528,7 +528,7 @@ def test_edge_case_different_time_offsets(span):
 
     time_coord = result_cube.coord('time')
 
-    assert time_coord.units.calendar == 'gregorian'
+    assert time_coord.units.calendar in ('standard', 'gregorian')
     assert time_coord.units.origin == 'days since 1850-01-01'
 
     desired = np.array((14., 45., 73.))
@@ -640,7 +640,7 @@ def test_unify_time_coordinates():
                                      calendar='360_day',
                                      offset='days since 1850-01-01')
     cube2 = generate_cube_from_dates('monthly',
-                                     calendar='gregorian',
+                                     calendar='standard',
                                      offset='days since 1943-05-16')
 
     mm._unify_time_coordinates([cube1, cube2])
@@ -787,7 +787,7 @@ def test_ignore_tas_scalar_height_coord():
 def test_daily_inconsistent_calendars():
     """Determine behaviour for inconsistent calendars.
 
-    Deviating calendars should be converted to gregorian. Missing data
+    Deviating calendars should be converted to standard. Missing data
     inside original bounds is filled with nearest neighbour Missing data
     outside original bounds is masked.
     """
@@ -804,7 +804,7 @@ def test_daily_inconsistent_calendars():
 
     leapcube = generate_cube_from_dates(
         leapdates,
-        calendar='gregorian',
+        calendar='standard',
         offset='days since 1850-01-01',
         fill_val=1,
     )
@@ -821,7 +821,7 @@ def test_daily_inconsistent_calendars():
     # span=full
     aligned_cubes = mm._align(cubes, span='full')
     for cube in aligned_cubes:
-        assert cube.coord('time').units.calendar == "gregorian"
+        assert cube.coord('time').units.calendar in ("standard", "gregorian")
         assert cube.shape == (367, )
         assert cube[59].coord('time').points == 789  # 29 Feb 1852
     np.ma.is_masked(aligned_cubes[1][366].data)  # outside original range
@@ -834,7 +834,7 @@ def test_daily_inconsistent_calendars():
     # span=overlap
     aligned_cubes = mm._align(cubes, span='overlap')
     for cube in aligned_cubes:
-        assert cube.coord('time').units.calendar == "gregorian"
+        assert cube.coord('time').units.calendar in ("standard", "gregorian")
         assert cube.shape == (365, )
         assert cube[59].coord('time').points == 790  # 1 March 1852
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->
This is a bugfix to address recent test failures due to a change in cf-units.

Closes #1655 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
