### PR TITLE
Use precommit flake8 instead of pytest-flake8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,4 +27,3 @@ indent_size = 2
 
 [*.{md,Rmd}]
 trim_trailing_whitespace = false
-

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 esmvalcore/cmor @jvegasbsc
 .github/workflows @valeriupredoi
-

--- a/.github/workflows/install-from-pypi.yml
+++ b/.github/workflows/install-from-pypi.yml
@@ -102,8 +102,8 @@ jobs:
         run: pip install esmvalcore 2>&1 | tee pip_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Verify installation
         shell: bash -l {0}
-        run: | 
-          esmvaltool --help 
+        run: |
+          esmvaltool --help
           esmvaltool version 2>&1 | tee pip_install_osx_artifacts_python_${{ matrix.python-version }}/version.txt
       - name: Upload artifacts
         if: ${{ always() }}  # upload artifacts even if fail

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ exclude: |
   ^esmvalcore/preprocessor/ne_masks/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: docformatter
   - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.4'
+    rev: '4.0.1'
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/NOTICE
+++ b/NOTICE
@@ -50,5 +50,3 @@ In addition to using the Software, we encourage the community to join the Softwa
 To join the ESMValTool Development Team, please contact Dr. Birgit Hassler (birgit.hassler@dlr.de) and Dr. Axel Lauer (axel.lauer@dlr.de).
 
 ==========================================
-
-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Anaconda-Server Badge](https://anaconda.org/esmvalgroup/esmvalcore/badges/installer/conda.svg)](https://conda.anaconda.org/esmvalgroup)
 [![Github Actions Test](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml/badge.svg)](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml)
 [![Github Actions Dashboard](https://api.meercode.io/badge/ESMValGroup/ESMValCore?type=ci-success-rate&branch=main&lastDay=14)](https://meercode.io)
-
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ESMValGroup/ESMValCore/main.svg)](https://results.pre-commit.ci/latest/github/ESMValGroup/ESMValCore/main)
 
 ![esmvaltoollogo](https://github.com/ESMValGroup/ESMValCore/blob/main/doc/figures/ESMValTool-logo-2.png)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Github Actions Test](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml/badge.svg)](https://github.com/ESMValGroup/ESMValCore/actions/workflows/run-tests.yml)
 [![Github Actions Dashboard](https://api.meercode.io/badge/ESMValGroup/ESMValCore?type=ci-success-rate&branch=main&lastDay=14)](https://meercode.io)
 
+
 ![esmvaltoollogo](https://github.com/ESMValGroup/ESMValCore/blob/main/doc/figures/ESMValTool-logo-2.png)
 
 ESMValCore: core functionalities for the ESMValTool, a community diagnostic

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,4 +8,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`search`
-

--- a/doc/quickstart/install.rst
+++ b/doc/quickstart/install.rst
@@ -201,7 +201,7 @@ Pre-installed versions on HPC clusters / other servers
 
 
 If you would like to use pre-installed versions on HPC clusters (currently CEDA-JASMIN and DKRZ-Levante),
-and other servers (currently Met Office Linux estate), please have a look at 
+and other servers (currently Met Office Linux estate), please have a look at
 :ref:`these instructions <esmvaltool:install_on_hpc>`.
 
 

--- a/doc/recipe/index.rst
+++ b/doc/recipe/index.rst
@@ -8,4 +8,3 @@ The recipe format
 
     Overview <overview>
     Preprocessor <preprocessor>
-

--- a/doc/recipe/index.rst
+++ b/doc/recipe/index.rst
@@ -8,4 +8,4 @@ The recipe format
 
     Overview <overview>
     Preprocessor <preprocessor>
- 
+

--- a/esmvalcore/_citation.py
+++ b/esmvalcore/_citation.py
@@ -38,8 +38,7 @@ ESMVALTOOL_PAPER = (
 
 
 def _write_citation_files(filename, provenance):
-    """
-    Write citation information provided by the recorded provenance.
+    """Write citation information provided by the recorded provenance.
 
     Recipe and cmip6 data references are saved into one bibtex file.
     cmip6 data references are provided by CMIP6 data citation service.
@@ -133,9 +132,9 @@ def _save_citation_info_txt(product_name, info_urls, other_info):
 def _extract_tags(tags):
     """Extract tags.
 
-    Tags are recorded as a list of strings converted to a string in provenance.
-    For example, a single entry in the list `tags` could be the string
-    "['acknow_project', 'acknow_author']".
+    Tags are recorded as a list of strings converted to a string in
+    provenance. For example, a single entry in the list `tags` could be
+    the string "['acknow_project', 'acknow_author']".
     """
     pattern = re.compile(r'\w+')
     return set(pattern.findall(str(tags)))

--- a/esmvalcore/_config/__init__.py
+++ b/esmvalcore/_config/__init__.py
@@ -1,9 +1,9 @@
 """ESMValTool configuration."""
 from ._config import (
     get_activity,
+    get_extra_facets,
     get_institutes,
     get_project_config,
-    get_extra_facets,
     load_config_developer,
     read_config_developer_file,
     read_config_user_file,

--- a/esmvalcore/_config/extra_facets/ipslcm-mappings.yml
+++ b/esmvalcore/_config/extra_facets/ipslcm-mappings.yml
@@ -111,7 +111,7 @@ IPSL-CM6:
     #  ->  general variables
     precip: {ipsl_varname: precip, <<: *atmvars}
     slp: {ipsl_varname: slp, <<: *atmvars}
-    
+
     #  -> Turbulent fluxes
     taux: {ipsl_varname: taux, <<: *atmvars}
     tauy: {ipsl_varname: tauy, <<: *atmvars}
@@ -136,8 +136,8 @@ IPSL-CM6:
     SWdnSFC: {ipsl_varname: SWdnSFC, <<: *atmvars}
     LWdnSFcclr: {ipsl_varname: LWdnSFcclr, <<: *atmvars}
     SWdnSFcclr: {ipsl_varname: SWdnSFcclr, <<: *atmvars}
-    
-    
+
+
   # =================================================
   Lmon:
     # ===============================================

--- a/esmvalcore/_data_finder.py
+++ b/esmvalcore/_data_finder.py
@@ -144,7 +144,6 @@ def dates_to_timerange(start_date, end_date):
     -------
     str
         ``timerange`` in the form ``'start_date/end_date'``.
-
     """
     start_date = str(start_date)
     end_date = str(end_date)
@@ -283,7 +282,6 @@ def _truncate_dates(date, file_date):
     same number of digits. If this is not the case, pad the dates with leading
     zeros (e.g., use ``date='0100'`` and ``file_date='199901'`` for a correct
     comparison).
-
     """
     date = re.sub("[^0-9]", '', date)
     file_date = re.sub("[^0-9]", '', file_date)

--- a/esmvalcore/cmor/_fixes/__init__.py
+++ b/esmvalcore/cmor/_fixes/__init__.py
@@ -1,6 +1,5 @@
-"""
-Automatic fixes for input data
+"""Automatic fixes for input data.
 
-Module to apply automatic fixes at different levels to input data for known
-errors.
+Module to apply automatic fixes at different levels to input data for
+known errors.
 """

--- a/esmvalcore/cmor/_fixes/cmip5/access1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_0.py
@@ -10,8 +10,7 @@ class AllVars(Fix):
     """Common fixes to all vars."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes wrong calendar 'gregorian' instead of 'proleptic_gregorian'.
 
@@ -23,7 +22,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             try:
@@ -54,7 +52,6 @@ class Cl(ClFixHybridHeightCoord):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cubes = super().fix_metadata(cubes)
         cube = self.get_cube_from_list(cubes)

--- a/esmvalcore/cmor/_fixes/cmip5/access1_3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/access1_3.py
@@ -5,7 +5,6 @@ from cf_units import Unit
 from ..fix import Fix
 from .access1_0 import Cl as BaseCl
 
-
 Cl = BaseCl
 
 
@@ -25,7 +24,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             try:

--- a/esmvalcore/cmor/_fixes/cmip5/bnu_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/bnu_esm.py
@@ -10,8 +10,7 @@ class Cl(ClFixHybridPressureCoord):
     """Fixes for cl."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -23,7 +22,6 @@ class Cl(ClFixHybridPressureCoord):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100
@@ -35,8 +33,7 @@ class FgCo2(Fix):
     """Fixes for fgco2."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes cube units.
 
@@ -48,14 +45,12 @@ class FgCo2(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         self.get_cube_from_list(cubes).units = Unit('kg m-2 s-1')
         return cubes
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes cube units.
 
@@ -67,7 +62,6 @@ class FgCo2(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 12.0 / 44.0
@@ -79,8 +73,7 @@ class Ch4(Fix):
     """Fixes for ch4."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes cube units.
 
@@ -92,14 +85,12 @@ class Ch4(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         self.get_cube_from_list(cubes).units = Unit('1e-9')
         return cubes
 
     def fix_data(self, cube):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes cube units.
 
@@ -112,7 +103,6 @@ class Ch4(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 29.0 / 16.0 * 1.e9
@@ -124,8 +114,7 @@ class Co2(Fix):
     """Fixes for co2."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes cube units.
 
@@ -137,14 +126,12 @@ class Co2(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         self.get_cube_from_list(cubes).units = Unit('1e-6')
         return cubes
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes cube units.
 
@@ -156,7 +143,6 @@ class Co2(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 29.0 / 44.0 * 1.e6
@@ -168,8 +154,7 @@ class SpCo2(Fix):
     """Fixes for spco2."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes cube units.
 
@@ -181,7 +166,6 @@ class SpCo2(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 1.e6
@@ -193,8 +177,7 @@ class Od550Aer(Fix):
     """Fixes for od550aer."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Masks invalid values.
 
@@ -206,7 +189,6 @@ class Od550Aer(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         data = da.ma.masked_equal(cube.core_data(), 1.e36)
         return cube.copy(data)

--- a/esmvalcore/cmor/_fixes/cmip5/canesm2.py
+++ b/esmvalcore/cmor/_fixes/cmip5/canesm2.py
@@ -2,7 +2,6 @@
 from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 
-
 Cl = ClFixHybridPressureCoord
 
 
@@ -10,8 +9,7 @@ class FgCo2(Fix):
     """Fixes for fgco2."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -23,7 +21,6 @@ class FgCo2(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 12.0 / 44.0

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_bgc.py
@@ -5,7 +5,6 @@ from dask import array as da
 from ..fix import Fix
 from .cesm1_cam5 import Cl as BaseCl
 
-
 Cl = BaseCl
 
 
@@ -24,7 +23,6 @@ class Gpp(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         data = da.ma.masked_equal(cube.core_data(), 1.0e33)
         return cube.copy(data)

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_cam5.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_cam5.py
@@ -7,8 +7,7 @@ class Cl(Fix):
     """Fixes for cl."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -20,7 +19,6 @@ class Cl(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_fastchem.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_fastchem.py
@@ -2,5 +2,4 @@
 
 from .cesm1_cam5 import Cl as BaseCl
 
-
 Cl = BaseCl

--- a/esmvalcore/cmor/_fixes/cmip5/cesm1_waccm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cesm1_waccm.py
@@ -2,5 +2,4 @@
 
 from .cesm1_cam5 import Cl as BaseCl
 
-
 Cl = BaseCl

--- a/esmvalcore/cmor/_fixes/cmip5/cnrm_cm5.py
+++ b/esmvalcore/cmor/_fixes/cmip5/cnrm_cm5.py
@@ -7,8 +7,7 @@ class Msftmyz(Fix):
     """Fixes for msftmyz."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -19,7 +18,6 @@ class Msftmyz(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 1e6

--- a/esmvalcore/cmor/_fixes/cmip5/csiro_mk3_6_0.py
+++ b/esmvalcore/cmor/_fixes/cmip5/csiro_mk3_6_0.py
@@ -1,5 +1,4 @@
 """Fixes for CSIRO-Mk3-6-0 model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
@@ -11,8 +11,7 @@ class Sic(Fix):
     """Fixes for sic."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -23,7 +22,6 @@ class Sic(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100
@@ -35,8 +33,7 @@ class Sftlf(Fix):
     """Fixes for sftlf."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -47,7 +44,6 @@ class Sftlf(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100
@@ -59,8 +55,7 @@ class Tos(Fix):
     """Fixes for tos."""
 
     def fix_data(self, cube):
-        """
-        Fix tos data.
+        """Fix tos data.
 
         Fixes mask
 
@@ -71,7 +66,6 @@ class Tos(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube.data = da.ma.masked_equal(cube.core_data(), 273.15)
         return cube
@@ -81,8 +75,7 @@ class Tas(Fix):
     """Fixes for tas."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix potentially missing scalar dimension.
+        """Fix potentially missing scalar dimension.
 
         Parameters
         ----------
@@ -92,7 +85,6 @@ class Tas(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
 
         for cube in cubes:
@@ -109,8 +101,7 @@ class Areacello(Fix):
     """Fixes for areacello."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix potentially missing scalar dimension.
+        """Fix potentially missing scalar dimension.
 
         Parameters
         ----------
@@ -120,7 +111,6 @@ class Areacello(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         areacello = cubes.extract('Areas of grid cell')[0]
         lat = cubes.extract('latitude')[0]
@@ -150,7 +140,6 @@ class Pr(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         new_list = iris.cube.CubeList()
         for cube in cubes:

--- a/esmvalcore/cmor/_fixes/cmip5/fgoals_g2.py
+++ b/esmvalcore/cmor/_fixes/cmip5/fgoals_g2.py
@@ -23,7 +23,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             try:

--- a/esmvalcore/cmor/_fixes/cmip5/fgoals_s2.py
+++ b/esmvalcore/cmor/_fixes/cmip5/fgoals_s2.py
@@ -20,7 +20,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             try:

--- a/esmvalcore/cmor/_fixes/cmip5/fio_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/fio_esm.py
@@ -3,7 +3,6 @@
 from ..fix import Fix
 from .cesm1_cam5 import Cl as BaseCl
 
-
 Cl = BaseCl
 
 
@@ -11,8 +10,7 @@ class Co2(Fix):
     """Fixes for co2."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -23,7 +21,6 @@ class Co2(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 29. / 44. * 1.e6
@@ -35,8 +32,7 @@ class Ch4(Fix):
     """Fixes for ch4."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -47,7 +43,6 @@ class Ch4(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 29. / 16. * 1.e9

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_cm3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_cm3.py
@@ -1,7 +1,6 @@
 """Fixes for GFDL CM3 model."""
-from ..fix import Fix
-
 from ..cmip5.gfdl_esm2g import AllVars as BaseAllVars
+from ..fix import Fix
 
 
 class AllVars(BaseAllVars):
@@ -9,11 +8,10 @@ class AllVars(BaseAllVars):
 
 
 class Areacello(Fix):
-    """Fixes for areacello"""
+    """Fixes for areacello."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes wrong units.
 
@@ -24,7 +22,6 @@ class Areacello(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         cube.units = 'm2'
@@ -35,8 +32,7 @@ class Sftof(Fix):
     """Fix sftof."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units.
 
@@ -47,7 +43,6 @@ class Sftof(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100
@@ -56,11 +51,10 @@ class Sftof(Fix):
 
 
 class Tos(Fix):
-    """Fixes for tos"""
+    """Fixes for tos."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes wrong standard_name.
 
@@ -71,7 +65,6 @@ class Tos(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         cube.standard_name = 'sea_surface_temperature'

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_esm2g.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_esm2g.py
@@ -29,7 +29,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         _get_and_remove(cubes, 'Start time for average period')
         _get_and_remove(cubes, 'End time for average period')
@@ -38,11 +37,10 @@ class AllVars(Fix):
 
 
 class Areacello(Fix):
-    """Fixes for areacello"""
+    """Fixes for areacello."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes wrong units.
 
@@ -53,7 +51,6 @@ class Areacello(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         cube.units = 'm2'
@@ -75,7 +72,6 @@ class Co2(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 1e6
@@ -98,7 +94,6 @@ class FgCo2(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         _get_and_remove(cubes, 'Latitude of tracer (h) points')
         _get_and_remove(cubes, 'Longitude of tracer (h) points')
@@ -109,8 +104,7 @@ class Usi(Fix):
     """Fixes for usi."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes bad standard_name
 
@@ -130,8 +124,7 @@ class Vsi(Fix):
     """Fixes for vsi."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes bad standard_name
 

--- a/esmvalcore/cmor/_fixes/cmip5/gfdl_esm2m.py
+++ b/esmvalcore/cmor/_fixes/cmip5/gfdl_esm2m.py
@@ -1,8 +1,8 @@
 
 """Fixes for GFDL ESM2M."""
 
-from ..fix import Fix
 from ..cmip5.gfdl_esm2g import AllVars as BaseAllVars
+from ..fix import Fix
 
 
 class AllVars(BaseAllVars):
@@ -10,11 +10,10 @@ class AllVars(BaseAllVars):
 
 
 class Areacello(Fix):
-    """Fixes for areacello"""
+    """Fixes for areacello."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes wrong units.
 
@@ -25,7 +24,6 @@ class Areacello(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         cube.units = 'm2'
@@ -36,8 +34,7 @@ class Sftof(Fix):
     """Fixes for sftof."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -48,7 +45,6 @@ class Sftof(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100
@@ -60,8 +56,7 @@ class Co2(Fix):
     """Fixes for co2."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -72,7 +67,6 @@ class Co2(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 1e6
@@ -84,8 +78,7 @@ class Tos(Fix):
     """Fixes for tos."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes wrong standard_name.
 
@@ -96,7 +89,6 @@ class Tos(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         cube.standard_name = 'sea_surface_temperature'

--- a/esmvalcore/cmor/_fixes/cmip5/giss_e2_h.py
+++ b/esmvalcore/cmor/_fixes/cmip5/giss_e2_h.py
@@ -1,5 +1,4 @@
 """Fixes for GISS-E2-H."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/giss_e2_r.py
+++ b/esmvalcore/cmor/_fixes/cmip5/giss_e2_r.py
@@ -1,5 +1,4 @@
 """Fixes for GISS-E2-R."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/hadgem2_cc.py
+++ b/esmvalcore/cmor/_fixes/cmip5/hadgem2_cc.py
@@ -9,8 +9,7 @@ class AllVars(Fix):
     """Fix common errors for all vars."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix latitude.
+        """Fix latitude.
 
         Parameters
         ----------
@@ -19,7 +18,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             lats = cube.coords('latitude')
@@ -35,8 +33,7 @@ class O2(Fix):
     """Fixes for o2."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix standard and long names.
+        """Fix standard and long names.
 
         Parameters
         ----------
@@ -45,7 +42,6 @@ class O2(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         std = 'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water'
         long_name = 'Dissolved Oxygen Concentration'

--- a/esmvalcore/cmor/_fixes/cmip5/hadgem2_es.py
+++ b/esmvalcore/cmor/_fixes/cmip5/hadgem2_es.py
@@ -19,7 +19,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             lats = cube.coords('latitude')
@@ -50,7 +49,6 @@ class O2(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         std = 'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water'
         long_name = 'Dissolved Oxygen Concentration'

--- a/esmvalcore/cmor/_fixes/cmip5/inmcm4.py
+++ b/esmvalcore/cmor/_fixes/cmip5/inmcm4.py
@@ -4,7 +4,6 @@ import iris
 from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 
-
 Cl = ClFixHybridPressureCoord
 
 
@@ -12,8 +11,7 @@ class Gpp(Fix):
     """Fixes for gpp."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -25,7 +23,6 @@ class Gpp(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= -1
@@ -37,8 +34,7 @@ class Lai(Fix):
     """Fixes for lai."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -50,7 +46,6 @@ class Lai(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 0.01
@@ -62,8 +57,7 @@ class Nbp(Fix):
     """Fixes for nbp."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix missing scalar dimension.
+        """Fix missing scalar dimension.
 
         Parameters
         ----------
@@ -73,7 +67,6 @@ class Nbp(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cubes[0].standard_name = (
             'surface_net_downward_mass_flux_of_carbon_dioxide_expressed_as_'
@@ -86,8 +79,7 @@ class BaresoilFrac(Fix):
     """Fixes for baresoilFrac."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix missing scalar dimension.
+        """Fix missing scalar dimension.
 
         Parameters
         ----------
@@ -97,7 +89,6 @@ class BaresoilFrac(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         typebare = iris.coords.AuxCoord(
             'bare_ground',

--- a/esmvalcore/cmor/_fixes/cmip5/ipsl_cm5a_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ipsl_cm5a_lr.py
@@ -1,5 +1,4 @@
 """Fixes for IPSL-CM5A-LR model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/ipsl_cm5a_mr.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ipsl_cm5a_mr.py
@@ -1,5 +1,4 @@
 """Fixes for IPSL-CM5A-MR model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/ipsl_cm5b_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ipsl_cm5b_lr.py
@@ -1,5 +1,4 @@
 """Fixes for IPSL-CM5B-LR model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/miroc5.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc5.py
@@ -5,7 +5,6 @@ from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 from ..shared import round_coordinates
 
-
 Cl = ClFixHybridPressureCoord
 
 
@@ -13,8 +12,7 @@ class Sftof(Fix):
     """Fixes for sftof."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -26,7 +24,6 @@ class Sftof(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100
@@ -38,8 +35,7 @@ class Snw(Fix):
     """Fixes for snw."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -51,7 +47,6 @@ class Snw(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100
@@ -96,8 +91,7 @@ class Msftmyz(Fix):
     """Fixes for msftmyz."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes mask
 
@@ -109,7 +103,6 @@ class Msftmyz(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube.data = da.ma.masked_equal(cube.core_data(), 0.)
         return cube
@@ -133,7 +126,6 @@ class Tas(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         return round_coordinates(cubes)
 
@@ -146,8 +138,7 @@ class Tos(Fix):
     """Fixes for tos."""
 
     def fix_data(self, cube):
-        """
-        Fix tos data.
+        """Fix tos data.
 
         Fixes mask
 
@@ -159,7 +150,6 @@ class Tos(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube.data = da.ma.masked_equal(cube.core_data(), 0.)
         return cube

--- a/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc_esm.py
@@ -15,8 +15,7 @@ class Tro3(Fix):
     """Fixes for tro3."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -28,7 +27,6 @@ class Tro3(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 1000
@@ -40,8 +38,7 @@ class Co2(Fix):
     """Fixes for co2."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes error in cube units
 
@@ -53,7 +50,6 @@ class Co2(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         self.get_cube_from_list(cubes).units = '1.0e-6'
         return cubes
@@ -63,8 +59,7 @@ class AllVars(Fix):
     """Common fixes to all vars."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Fixes error in air_pressure coordinate, sometimes called AR5PL35, and
         error in time coordinate.
@@ -77,7 +72,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             # Fix air_pressure

--- a/esmvalcore/cmor/_fixes/cmip5/miroc_esm_chem.py
+++ b/esmvalcore/cmor/_fixes/cmip5/miroc_esm_chem.py
@@ -7,8 +7,7 @@ class Tro3(Fix):
     """Fixes for tro3."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -19,7 +18,6 @@ class Tro3(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 1000

--- a/esmvalcore/cmor/_fixes/cmip5/mpi_esm_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip5/mpi_esm_lr.py
@@ -2,7 +2,6 @@
 from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 
-
 Cl = ClFixHybridPressureCoord
 
 
@@ -10,8 +9,7 @@ class Pctisccp(Fix):
     """Fixes for pctisccp."""
 
     def fix_data(self, cube):
-        """
-        Fix data.
+        """Fix data.
 
         Fixes discrepancy between declared units and real units
 
@@ -23,7 +21,6 @@ class Pctisccp(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 100

--- a/esmvalcore/cmor/_fixes/cmip5/mpi_esm_mr.py
+++ b/esmvalcore/cmor/_fixes/cmip5/mpi_esm_mr.py
@@ -1,5 +1,4 @@
 """Fixes for MPI-ESM-MR model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/mpi_esm_p.py
+++ b/esmvalcore/cmor/_fixes/cmip5/mpi_esm_p.py
@@ -1,5 +1,4 @@
 """Fixes for MPI-ESM-P model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/mri_cgcm3.py
+++ b/esmvalcore/cmor/_fixes/cmip5/mri_cgcm3.py
@@ -4,7 +4,6 @@ from dask import array as da
 from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 
-
 Cl = ClFixHybridPressureCoord
 
 
@@ -12,8 +11,7 @@ class Msftmyz(Fix):
     """Fixes for msftmyz."""
 
     def fix_data(self, cube):
-        """
-        Fix msftmyz data.
+        """Fix msftmyz data.
 
         Fixes mask
 
@@ -25,7 +23,6 @@ class Msftmyz(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube.data = da.ma.masked_equal(cube.core_data(), 0.)
         return cube
@@ -35,8 +32,7 @@ class ThetaO(Fix):
     """Fixes for thetao."""
 
     def fix_data(self, cube):
-        """
-        Fix thetao data.
+        """Fix thetao data.
 
         Fixes mask
 
@@ -48,7 +44,6 @@ class ThetaO(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube.data = da.ma.masked_equal(cube.core_data(), 0.)
         return cube

--- a/esmvalcore/cmor/_fixes/cmip5/mri_esm1.py
+++ b/esmvalcore/cmor/_fixes/cmip5/mri_esm1.py
@@ -9,8 +9,7 @@ class Msftmyz(Fix):
     """Fixes for msftmyz."""
 
     def fix_data(self, cube):
-        """
-        Fix msftmyz data.
+        """Fix msftmyz data.
 
         Fixes mask
 
@@ -21,7 +20,6 @@ class Msftmyz(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube.data = da.ma.masked_equal(cube.core_data(), 0.)
         return cube

--- a/esmvalcore/cmor/_fixes/cmip5/noresm1_m.py
+++ b/esmvalcore/cmor/_fixes/cmip5/noresm1_m.py
@@ -1,5 +1,4 @@
 """Fixes for NorESM1-M."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord

--- a/esmvalcore/cmor/_fixes/cmip5/noresm1_me.py
+++ b/esmvalcore/cmor/_fixes/cmip5/noresm1_me.py
@@ -20,7 +20,6 @@ class Pr(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         return round_coordinates(cubes, 12, coord_names=['latitude'])
 
@@ -42,6 +41,5 @@ class Tas(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         return round_coordinates(cubes, 12)

--- a/esmvalcore/cmor/_fixes/cmip6/access_cm2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/access_cm2.py
@@ -18,7 +18,6 @@ class Cl(ClFixHybridHeightCoord):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             try:

--- a/esmvalcore/cmor/_fixes/cmip6/access_esm1_5.py
+++ b/esmvalcore/cmor/_fixes/cmip6/access_esm1_5.py
@@ -20,7 +20,6 @@ class Cl(ClFixHybridHeightCoord):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             try:
@@ -98,7 +97,6 @@ class Hus(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         cube.coord('air_pressure').points = \
@@ -122,7 +120,6 @@ class Zg(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         cube.coord('air_pressure').points = \

--- a/esmvalcore/cmor/_fixes/cmip6/cams_csm1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cams_csm1_0.py
@@ -1,7 +1,6 @@
 """Fixes for CAMS-CSM1-0 model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/canesm5.py
+++ b/esmvalcore/cmor/_fixes/cmip6/canesm5.py
@@ -18,7 +18,6 @@ class Co2(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= 1.e-6
@@ -40,7 +39,6 @@ class Gpp(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube.data = da.ma.masked_equal(cube.core_data(), 0.0)
         return cube

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2.py
@@ -52,7 +52,6 @@ class Cl(Fix):
         -------
         str
             Path to the fixed file.
-
         """
         new_path = self._fix_formula_terms(filepath, output_dir)
         dataset = Dataset(new_path, mode='a')
@@ -74,7 +73,6 @@ class Cl(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         lev_coord = cube.coord(var_name='lev')
@@ -106,7 +104,6 @@ class Fgco2(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_depth_coord(cube)
@@ -117,8 +114,8 @@ class Prw(Fix):
     """Fixes for tas."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix latitude_bounds and longitude_bounds data type and round to 4 d.p.
+        """Fix latitude_bounds and longitude_bounds data type and round to 4
+        d.p.
 
         Parameters
         ----------
@@ -128,7 +125,6 @@ class Prw(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             latitude = cube.coord('latitude')
@@ -149,8 +145,7 @@ class Tas(Prw):
     """Fixes for tas."""
 
     def fix_metadata(self, cubes):
-        """
-        Add height (2m) coordinate.
+        """Add height (2m) coordinate.
 
         Fix also done for prw.
         Fix latitude_bounds and longitude_bounds data type and round to 4 d.p.
@@ -163,7 +158,6 @@ class Tas(Prw):
         Returns
         -------
         iris.cube.CubeList
-
         """
         super().fix_metadata(cubes)
         # Specific code for tas
@@ -187,7 +181,6 @@ class Sftlf(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_typeland_coord(cube)
@@ -208,7 +201,6 @@ class Sftof(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_typesea_coord(cube)
@@ -222,8 +214,7 @@ class Tos(Fix):
     """Fixes for tos."""
 
     def fix_metadata(self, cubes):
-        """
-        Round times to 1 d.p. for monthly means.
+        """Round times to 1 d.p. for monthly means.
 
         Required to get hist-GHG and ssp245-GHG Omon tos to concatenate.
 
@@ -235,7 +226,6 @@ class Tos(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
 
@@ -260,7 +250,6 @@ class Omon(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             if cube.coords(axis='Z'):

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_fv2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_fv2.py
@@ -1,10 +1,9 @@
 """Fixes for CESM2-FV2 model."""
+from ..common import SiconcFixScalarCoord
 from .cesm2 import Cl as BaseCl
 from .cesm2 import Fgco2 as BaseFgco2
 from .cesm2 import Omon as BaseOmon
 from .cesm2 import Tas as BaseTas
-from ..common import SiconcFixScalarCoord
-
 
 Cl = BaseCl
 

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm.py
@@ -1,11 +1,11 @@
 """Fixes for CESM2-WACCM model."""
 from netCDF4 import Dataset
 
+from ..common import SiconcFixScalarCoord
 from .cesm2 import Cl as BaseCl
 from .cesm2 import Fgco2 as BaseFgco2
 from .cesm2 import Omon as BaseOmon
 from .cesm2 import Tas as BaseTas
-from ..common import SiconcFixScalarCoord
 
 
 class Cl(BaseCl):
@@ -34,7 +34,6 @@ class Cl(BaseCl):
         -------
         str
             Path to the fixed file.
-
         """
         new_path = self._fix_formula_terms(filepath, output_dir)
         dataset = Dataset(new_path, mode='a')

--- a/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm_fv2.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cesm2_waccm_fv2.py
@@ -1,12 +1,11 @@
 """Fixes for CESM2-WACCM-FV2 model."""
-from .cesm2 import Tas as BaseTas
+from ..common import SiconcFixScalarCoord
 from .cesm2 import Fgco2 as BaseFgco2
 from .cesm2 import Omon as BaseOmon
+from .cesm2 import Tas as BaseTas
 from .cesm2_waccm import Cl as BaseCl
 from .cesm2_waccm import Cli as BaseCli
 from .cesm2_waccm import Clw as BaseClw
-from ..common import SiconcFixScalarCoord
-
 
 Cl = BaseCl
 

--- a/esmvalcore/cmor/_fixes/cmip6/cmcc_cm2_sr5.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cmcc_cm2_sr5.py
@@ -16,7 +16,6 @@ class Cl(ClFixHybridPressureCoord):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         ps_coord = cube.coord(var_name='ps')

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
@@ -5,8 +5,8 @@ from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 from ..shared import (
     add_aux_coords_from_cubes,
+    fix_ocean_depth_coord,
     get_bounds_cube,
-    fix_ocean_depth_coord
 )
 
 
@@ -24,7 +24,6 @@ class Cl(ClFixHybridPressureCoord):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
 
@@ -69,7 +68,6 @@ class Clcalipso(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         alt_40_coord = cube.coord('alt40')
@@ -91,7 +89,6 @@ class Omon(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             if cube.coords(axis='Z'):

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1_hr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1_hr.py
@@ -3,7 +3,6 @@ from .cnrm_cm6_1 import Cl as BaseCl
 from .cnrm_cm6_1 import Cli as BaseCli
 from .cnrm_cm6_1 import Clw as BaseClw
 
-
 Cl = BaseCl
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_esm2_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_esm2_1.py
@@ -5,7 +5,6 @@ from .cnrm_cm6_1 import Cli as BaseCli
 from .cnrm_cm6_1 import Clw as BaseClw
 from .cnrm_cm6_1 import Omon as BaseOmon
 
-
 Cl = BaseCl
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/fgoals_g3.py
+++ b/esmvalcore/cmor/_fixes/cmip6/fgoals_g3.py
@@ -32,7 +32,6 @@ class Tos(OceanFixGrid):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         cube.coord('latitude').points[

--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_cm4.py
@@ -4,8 +4,8 @@ import iris
 from ..common import ClFixHybridPressureCoord, SiconcFixScalarCoord
 from ..fix import Fix
 from ..shared import add_aux_coords_from_cubes, add_scalar_height_coord
-from .gfdl_esm4 import Omon as BaseOmon
 from .gfdl_esm4 import Fgco2 as BaseFgco2
+from .gfdl_esm4 import Omon as BaseOmon
 
 
 class Cl(ClFixHybridPressureCoord):
@@ -22,7 +22,6 @@ class Cl(ClFixHybridPressureCoord):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         coords_to_add = {
@@ -47,8 +46,7 @@ class Tas(Fix):
     """Fixes for tas."""
 
     def fix_metadata(self, cubes):
-        """
-        Add height (2m) coordinate.
+        """Add height (2m) coordinate.
 
         Parameters
         ----------
@@ -58,7 +56,6 @@ class Tas(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         try:
@@ -72,8 +69,7 @@ class Uas(Fix):
     """Fixes for uas."""
 
     def fix_metadata(self, cubes):
-        """
-        Add height (10m) coordinate.
+        """Add height (10m) coordinate.
 
         Parameters
         ----------
@@ -83,7 +79,6 @@ class Uas(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_height_coord(cube, 10.0)
@@ -94,8 +89,7 @@ class Vas(Fix):
     """Fixes for vas."""
 
     def fix_metadata(self, cubes):
-        """
-        Add height (10m) coordinate.
+        """Add height (10m) coordinate.
 
         Parameters
         ----------
@@ -105,7 +99,6 @@ class Vas(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_height_coord(cube, 10.0)

--- a/esmvalcore/cmor/_fixes/cmip6/gfdl_esm4.py
+++ b/esmvalcore/cmor/_fixes/cmip6/gfdl_esm4.py
@@ -1,10 +1,7 @@
 """Fixes for GFDL-ESM4 model."""
 from ..common import SiconcFixScalarCoord
 from ..fix import Fix
-from ..shared import (
-    add_scalar_depth_coord,
-    fix_ocean_depth_coord,
-)
+from ..shared import add_scalar_depth_coord, fix_ocean_depth_coord
 
 
 class Fgco2(Fix):
@@ -21,7 +18,6 @@ class Fgco2(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_depth_coord(cube)
@@ -42,7 +38,6 @@ class Omon(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             if cube.coords(axis='Z'):

--- a/esmvalcore/cmor/_fixes/cmip6/giss_e2_1_g.py
+++ b/esmvalcore/cmor/_fixes/cmip6/giss_e2_1_g.py
@@ -1,7 +1,6 @@
 """Fixes for GISS-E2-1-G model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/giss_e2_1_h.py
+++ b/esmvalcore/cmor/_fixes/cmip6/giss_e2_1_h.py
@@ -1,7 +1,6 @@
 """Fixes for GISS-E2-1-H model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/hadgem3_gc31_ll.py
+++ b/esmvalcore/cmor/_fixes/cmip6/hadgem3_gc31_ll.py
@@ -2,7 +2,6 @@
 from ..common import ClFixHybridHeightCoord
 from .ukesm1_0_ll import AllVars as BaseAllVars
 
-
 AllVars = BaseAllVars
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/icon_esm_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/icon_esm_lr.py
@@ -18,7 +18,6 @@ class AllVars(Fix):
         -------
         iris.cube.CubeList
             Fixed cubes.
-
         """
         varnames_to_change = {
             'latitude': 'lat',

--- a/esmvalcore/cmor/_fixes/cmip6/ipsl_cm5a2_inca.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ipsl_cm5a2_inca.py
@@ -3,7 +3,6 @@ from .ipsl_cm6a_lr import AllVars as BaseAllVars
 from .ipsl_cm6a_lr import Clcalipso as BaseClcalipso
 from .ipsl_cm6a_lr import Omon as BaseOmon
 
-
 AllVars = BaseAllVars
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/ipsl_cm6a_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ipsl_cm6a_lr.py
@@ -9,8 +9,7 @@ class AllVars(Fix):
     """Fixes for thetao."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix cell_area coordinate.
+        """Fix cell_area coordinate.
 
         Parameters
         ----------
@@ -20,7 +19,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         if cube.coords('latitude'):
@@ -44,7 +42,6 @@ class Clcalipso(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         alt_40_coord = cube.coord('height')
@@ -68,7 +65,6 @@ class Omon(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             if cube.coords(axis='Z'):

--- a/esmvalcore/cmor/_fixes/cmip6/ipsl_cm6a_lr_inca.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ipsl_cm6a_lr_inca.py
@@ -3,7 +3,6 @@ from .ipsl_cm6a_lr import AllVars as BaseAllVars
 from .ipsl_cm6a_lr import Clcalipso as BaseClcalipso
 from .ipsl_cm6a_lr import Omon as BaseOmon
 
-
 AllVars = BaseAllVars
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/kace_1_0_g.py
+++ b/esmvalcore/cmor/_fixes/cmip6/kace_1_0_g.py
@@ -1,7 +1,6 @@
 """Fixes for KACE-1-0-G."""
 from ..common import ClFixHybridHeightCoord
 
-
 Cl = ClFixHybridHeightCoord
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/mcm_ua_1_0.py
+++ b/esmvalcore/cmor/_fixes/cmip6/mcm_ua_1_0.py
@@ -38,7 +38,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         coords_to_change = {
             'latitude': 'lat',
@@ -100,7 +99,6 @@ class Omon(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             if cube.coords(axis='Z'):
@@ -124,7 +122,6 @@ class Tas(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_height_coord(cube, 2.0)
@@ -145,7 +142,6 @@ class Uas(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_height_coord(cube, 10.0)

--- a/esmvalcore/cmor/_fixes/cmip6/miroc6.py
+++ b/esmvalcore/cmor/_fixes/cmip6/miroc6.py
@@ -1,7 +1,6 @@
 """Fixes for MIROC6 model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/miroc_es2l.py
+++ b/esmvalcore/cmor/_fixes/cmip6/miroc_es2l.py
@@ -1,7 +1,6 @@
 """Fixes for MIROC-ES2L model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/mpi_esm1_2_xr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/mpi_esm1_2_xr.py
@@ -1,8 +1,8 @@
 """Fixes for MPI-ESM1-2-XR model."""
 
-from .mpi_esm1_2_hr import Tas as BaseTas
-from .mpi_esm1_2_hr import Ta as BaseFix
 from .mpi_esm1_2_hr import SfcWind as BaseSfcWind
+from .mpi_esm1_2_hr import Ta as BaseFix
+from .mpi_esm1_2_hr import Tas as BaseTas
 
 
 class Tas(BaseTas):

--- a/esmvalcore/cmor/_fixes/cmip6/mri_esm2_0.py
+++ b/esmvalcore/cmor/_fixes/cmip6/mri_esm2_0.py
@@ -1,7 +1,6 @@
 """Fixes for MRI-ESM2-0 model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/nesm3.py
+++ b/esmvalcore/cmor/_fixes/cmip6/nesm3.py
@@ -1,7 +1,6 @@
 """Fixes for NESM3 model."""
 from ..common import ClFixHybridPressureCoord
 
-
 Cl = ClFixHybridPressureCoord
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/noresm2_lm.py
+++ b/esmvalcore/cmor/_fixes/cmip6/noresm2_lm.py
@@ -22,7 +22,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             coord_names = [cor.standard_name for cor in cube.coords()]
@@ -68,7 +67,6 @@ class Siconc(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         for cube in cubes:
             latitude = cube.coord('latitude')

--- a/esmvalcore/cmor/_fixes/cmip6/sam0_unicon.py
+++ b/esmvalcore/cmor/_fixes/cmip6/sam0_unicon.py
@@ -2,7 +2,6 @@
 from ..common import ClFixHybridPressureCoord
 from ..fix import Fix
 
-
 Cl = ClFixHybridPressureCoord
 
 
@@ -28,7 +27,6 @@ class Nbp(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         metadata = cube.metadata
         cube *= -1

--- a/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ukesm1_0_ll.py
@@ -17,7 +17,6 @@ class AllVars(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         parent_units = 'parent_time_units'
         bad_value = 'days since 1850-01-01-00-00-00'

--- a/esmvalcore/cmor/_fixes/common.py
+++ b/esmvalcore/cmor/_fixes/common.py
@@ -6,11 +6,7 @@ import numpy as np
 from scipy.ndimage import map_coordinates
 
 from .fix import Fix
-from .shared import (
-    add_plev_from_altitude,
-    add_scalar_typesi_coord,
-    fix_bounds,
-)
+from .shared import add_plev_from_altitude, add_scalar_typesi_coord, fix_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +25,6 @@ class ClFixHybridHeightCoord(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
 
@@ -68,7 +63,6 @@ class ClFixHybridPressureCoord(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
 
@@ -127,7 +121,6 @@ class OceanFixGrid(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         if cube.ndim != 3:
@@ -211,7 +204,6 @@ class SiconcFixScalarCoord(Fix):
         Returns
         -------
         iris.cube.CubeList
-
         """
         cube = self.get_cube_from_list(cubes)
         add_scalar_typesi_coord(cube)

--- a/esmvalcore/cmor/_fixes/emac/emac.py
+++ b/esmvalcore/cmor/_fixes/emac/emac.py
@@ -8,7 +8,6 @@ implemented in ``fix_metadata``, not in ``fix_data``, here. The reason for this
 is that ``fix_metadata`` takes all cubes (and thus all input variables of the
 input file) as argument while ``fix_data`` only takes one cube (the output
 variable) as single argument.
-
 """
 
 import logging
@@ -47,7 +46,6 @@ class AllVars(EmacFix):
         This fix removes the ``formula_terms`` attribute of the hybrid pressure
         level variables to make the corresponding coefficients appear correctly
         in the class:`iris.cube.CubeList` object returned by :mod:`iris.load`.
-
         """
         if 'alevel' not in self.vardef.dimensions:
             return filepath
@@ -359,7 +357,6 @@ class Zg(EmacFix):
 
         Convert geopotential Phi given by EMAC to geopotential height Z using
         Z = Phi / g0 (g0 is standard acceleration of gravity)
-
         """
         g0_value = constants.value('standard acceleration of gravity')
         g0_units = constants.unit('standard acceleration of gravity')

--- a/esmvalcore/cmor/_fixes/fix.py
+++ b/esmvalcore/cmor/_fixes/fix.py
@@ -1,7 +1,7 @@
 """Contains the base class for dataset fixes."""
 import importlib
-import os
 import inspect
+import os
 
 from ..table import CMOR_TABLES
 

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -56,7 +56,6 @@ class IconFix(NativeDatasetFix):
             Input cube does not contain the necessary attribute that specifies
             the download location of the ICON horizontal grid file (see
             ``self.GRID_FILE_ATTR``).
-
         """
         if self.GRID_FILE_ATTR not in cube.attributes:
             raise ValueError(

--- a/esmvalcore/cmor/_fixes/icon/icon.py
+++ b/esmvalcore/cmor/_fixes/icon/icon.py
@@ -100,7 +100,6 @@ class AllVars(IconFix):
             Invalid ``coord_name`` is given; input cube does not contain a
             single unnamed dimension that can be used to add the new
             coordinate.
-
         """
         allowed_coord_names = ('grid_latitude', 'grid_longitude')
         if coord_name not in allowed_coord_names:
@@ -324,7 +323,6 @@ class Siconc(IconFix):
         units (which need to be %) are fixed in a later step in AllVars(). This
         fix here is necessary to fix the "unknown" units that cannot be
         converted to % in AllVars().
-
         """
         cube = self.get_cube(cubes)
         cube.units = '1'

--- a/esmvalcore/cmor/_fixes/ipslcm/ipsl_cm6.py
+++ b/esmvalcore/cmor/_fixes/ipslcm/ipsl_cm6.py
@@ -29,7 +29,6 @@ class AllVars(Fix):
         extra_facets key `use_cdo`
 
         However, we take care of ESMValTool policy re. dependencies licence
-
         """
         if "_" + self.extra_facets.get("group",
                                        "non-sense") + ".nc" not in filepath:

--- a/esmvalcore/cmor/_fixes/native6/era5_land.py
+++ b/esmvalcore/cmor/_fixes/native6/era5_land.py
@@ -1,9 +1,7 @@
 """Fixes for ERA5-Land."""
 import logging
 
-from esmvalcore.cmor._fixes.native6.era5 import (Pr,
-                                                 AllVars)
-
+from esmvalcore.cmor._fixes.native6.era5 import AllVars, Pr
 
 logger = logging.getLogger(__name__)
 logger.info("Load classes from era5.py")

--- a/esmvalcore/cmor/_fixes/native_datasets.py
+++ b/esmvalcore/cmor/_fixes/native_datasets.py
@@ -29,7 +29,6 @@ class NativeDatasetFix(Fix):
         cube: iris.cube.Cube
             Input cube for which missing scalar coordinates will be added
             (in-place).
-
         """
         if 'height2m' in self.vardef.dimensions:
             add_scalar_height_coord(cube, 2.0)
@@ -47,7 +46,6 @@ class NativeDatasetFix(Fix):
         ----------
         cube: iris.cube.Cube
             Input cube whose metadata is changed in-place.
-
         """
         # Fix names
         if self.vardef.standard_name == '':
@@ -97,7 +95,6 @@ class NativeDatasetFix(Fix):
         ------
         ValueError
             Desired variable is not available in the input cubes.
-
         """
         if var_name is None:
             var_name = self.extra_facets.get('raw_name',
@@ -121,7 +118,6 @@ class NativeDatasetFix(Fix):
         guess_bounds: bool, optional (default: True)
             If ``True``, try to guess bounds. If ``False``, do not try to guess
             bounds.
-
         """
         if 'time' not in self.vardef.dimensions:
             return
@@ -142,7 +138,6 @@ class NativeDatasetFix(Fix):
         guess_bounds: bool, optional (default: True)
             If ``True``, try to guess bounds. If ``False``, do not try to guess
             bounds.
-
         """
         if 'latitude' not in self.vardef.dimensions:
             return
@@ -163,7 +158,6 @@ class NativeDatasetFix(Fix):
         guess_bounds: bool, optional (default: True)
             If ``True``, try to guess bounds. If ``False``, do not try to guess
             bounds.
-
         """
         if 'longitude' not in self.vardef.dimensions:
             return
@@ -192,7 +186,6 @@ class NativeDatasetFix(Fix):
         iris.coords.AuxCoord or iris.coords.DimCoord
             Coordinate with bounds. The coordinate is altered in-place; it is
             just returned out of convenience for easy access.
-
         """
         if isinstance(coord, str):
             coord = cube.coord(coord)
@@ -220,7 +213,6 @@ class NativeDatasetFix(Fix):
         iris.coords.AuxCoord or iris.coords.DimCoord
             Fixed time coordinate. The coordinate is altered in-place; it is
             just returned out of convenience for easy access.
-
         """
         if coord is None:
             coord = cube.coord('time')
@@ -248,7 +240,6 @@ class NativeDatasetFix(Fix):
         iris.coords.AuxCoord or iris.coords.DimCoord
             Fixed height coordinate. The coordinate is altered in-place; it is
             just returned out of convenience for easy access.
-
         """
         if coord is None:
             coord = cube.coord('height')
@@ -278,7 +269,6 @@ class NativeDatasetFix(Fix):
         iris.coords.AuxCoord or iris.coords.DimCoord
             Fixed air_pressure coordinate. The coordinate is altered in-place;
             it is just returned out of convenience for easy access.
-
         """
         if coord is None:
             coord = cube.coord('air_pressure')
@@ -308,7 +298,6 @@ class NativeDatasetFix(Fix):
         iris.coords.AuxCoord or iris.coords.DimCoord
             Fixed latitude coordinate. The coordinate is altered in-place; it
             is just returned out of convenience for easy access.
-
         """
         if coord is None:
             coord = cube.coord('latitude')
@@ -337,7 +326,6 @@ class NativeDatasetFix(Fix):
         iris.coords.AuxCoord or iris.coords.DimCoord
             Fixed longitude coordinate. The coordinate is altered in-place; it
             is just returned out of convenience for easy access.
-
         """
         if coord is None:
             coord = cube.coord('longitude')

--- a/esmvalcore/cmor/_fixes/obs4mips/airs_2_1.py
+++ b/esmvalcore/cmor/_fixes/obs4mips/airs_2_1.py
@@ -8,8 +8,7 @@ class AllVars(Fix):
     """Common fixes to all vars."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Change unit of coordinate plev from hPa to Pa.
 
@@ -22,7 +21,6 @@ class AllVars(Fix):
         -------
         iris.cube.CubeList
             Fixed cubes.
-
         """
         for cube in cubes:
             try:

--- a/esmvalcore/cmor/_fixes/obs4mips/ssmi_meris.py
+++ b/esmvalcore/cmor/_fixes/obs4mips/ssmi_meris.py
@@ -9,8 +9,7 @@ class Prw(Fix):
     """Fixes for prw."""
 
     def fix_metadata(self, cubes):
-        """
-        Fix metadata.
+        """Fix metadata.
 
         Remove error and number of observations cubes
 
@@ -21,7 +20,6 @@ class Prw(Fix):
         Returns
         -------
         iris.cube.Cube
-
         """
         cube = self.get_cube_from_list(cubes)
         return CubeList([cube])

--- a/esmvalcore/experimental/config/__init__.py
+++ b/esmvalcore/experimental/config/__init__.py
@@ -4,7 +4,6 @@
 
     ESMValCore configuration.
     By default this will loaded from the file ~/.esmvaltool/config-user.yml.
-
 """
 
 from ._config_object import CFG, Config, Session

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -36,7 +36,6 @@ def add_leading_dim_to_cube(cube, dim_coord):
     ------
     CoordinateMultiDimError
         ``dim_coord`` is not 1D.
-
     """
     # Only 1D dim_coords are supported
     if dim_coord.ndim > 1:

--- a/esmvalcore/preprocessor/_bias.py
+++ b/esmvalcore/preprocessor/_bias.py
@@ -55,7 +55,6 @@ def bias(products, bias_type='absolute', denominator_mask_threshold=1e-3,
         Not exactly one input datasets contains the facet
         ``reference_for_bias: true``; ``bias_type`` is not one of
         ``'absolute'`` or ``'relative'``.
-
     """
     # Get reference product
     reference_product = []

--- a/esmvalcore/preprocessor/_cycles.py
+++ b/esmvalcore/preprocessor/_cycles.py
@@ -41,7 +41,6 @@ def amplitude(cube, coords):
     iris.exceptions.CoordinateNotFoundError
         A coordinate is not found in ``cube`` and cannot be added via
         :mod:`iris.coord_categorisation`.
-
     """
     if isinstance(coords, str):
         coords = [coords]

--- a/esmvalcore/preprocessor/_derive/__init__.py
+++ b/esmvalcore/preprocessor/_derive/__init__.py
@@ -18,7 +18,6 @@ def _get_all_derived_variables():
     dict
         All derived variables with `short_name` (keys) and the associated
         python classes (values).
-
     """
     derivers = {}
     for path in Path(__file__).parent.glob('[a-z]*.py'):
@@ -50,7 +49,6 @@ def get_required(short_name, project):
     -------
     list
         List of dictionaries (including at least the key `short_name`).
-
     """
     if short_name not in ALL_DERIVED_VARIABLES:
         raise NotImplementedError(
@@ -82,7 +80,6 @@ def derive(cubes, short_name, long_name, units, standard_name=None):
     -------
     iris.cube.Cube
         The new derived variable.
-
     """
     if short_name == cubes[0].var_name:
         return cubes[0]

--- a/esmvalcore/preprocessor/_derive/_baseclass.py
+++ b/esmvalcore/preprocessor/_derive/_baseclass.py
@@ -30,7 +30,6 @@ class DerivedVariableBase:
         -------
         list of dict
             List of variable metadata.
-
         """
 
     @staticmethod
@@ -58,5 +57,4 @@ class DerivedVariableBase:
         NotImplementedError
             If the desired variable derivation is not implemented, i.e. if this
             method is called from this base class and not a child class.
-
         """

--- a/esmvalcore/preprocessor/_derive/_shared.py
+++ b/esmvalcore/preprocessor/_derive/_shared.py
@@ -61,7 +61,6 @@ def column_average(cube, hus_cube, zg_cube, ps_cube):
     -------
     iris.cube.Cube
         Column-averaged mole fraction of a gas.
-
     """
     # Convert units of data
     hus_cube.convert_units('1')
@@ -124,7 +123,6 @@ def pressure_level_widths(cube, ps_cube, top_limit=0.0):
     -------
     iris.cube.Cube
         Cube of same shape as ``cube`` containing pressure level widths.
-
     """
     pressure_array = _create_pressure_array(cube, ps_cube, top_limit)
 
@@ -139,10 +137,10 @@ def pressure_level_widths(cube, ps_cube, top_limit=0.0):
 def _create_pressure_array(cube, ps_cube, top_limit):
     """Create an array filled with the ``air_pressure`` coord values.
 
-    The array is created from ``cube`` with the same dimensions as ``cube``.
-    This array is then sandwiched with a 2D array containing the surface
-    pressure and a 2D array containing the top pressure limit.
-
+    The array is created from ``cube`` with the same dimensions as
+    ``cube``. This array is then sandwiched with a 2D array containing
+    the surface pressure and a 2D array containing the top pressure
+    limit.
     """
     # Create 4D array filled with pressure level values
     p_levels = cube.coord('air_pressure').points.astype(np.float32)
@@ -172,7 +170,6 @@ def _get_pressure_level_widths(array, air_pressure_axis=1):
 
     For a 1D array with pressure level columns, return a 1D array with
     pressure level widths.
-
     """
     array = np.copy(array)
     if np.any(np.diff(array, axis=air_pressure_axis) > 0.0):

--- a/esmvalcore/preprocessor/_derive/alb.py
+++ b/esmvalcore/preprocessor/_derive/alb.py
@@ -2,7 +2,6 @@
 
 authors:
     - crez_ba
-
 """
 from iris import NameConstraint
 

--- a/esmvalcore/preprocessor/_derive/co2s.py
+++ b/esmvalcore/preprocessor/_derive/co2s.py
@@ -33,7 +33,6 @@ class DerivedVariable(DerivedVariableBase):
     air pressure (e.g. the 1000 hPa level for grid cells with high elevation).
     To obtain an unmasked ``co2s`` field, it is necessary to fill these masked
     values accordingly, i.e. with the lowest unmasked value for each grid cell.
-
     """
 
     @staticmethod

--- a/esmvalcore/preprocessor/_derive/ctotal.py
+++ b/esmvalcore/preprocessor/_derive/ctotal.py
@@ -1,7 +1,6 @@
 """Derivation of variable `ctotal`."""
 
 import iris
-
 from iris import Constraint
 
 from ._baseclass import DerivedVariableBase

--- a/esmvalcore/preprocessor/_derive/lvp.py
+++ b/esmvalcore/preprocessor/_derive/lvp.py
@@ -2,7 +2,6 @@
 
 authors:
     - weig_ka
-
 """
 
 from iris import NameConstraint

--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -33,7 +33,6 @@ class DerivedVariable(DerivedVariableBase):
         ----
         Some datasets output the variable `clwvi` which only contains `lwp`. In
         these cases, the input `clwvi` cube is just returned.
-
         """
         # CMIP5 and CMIP6 names are slightly different, so use
         # variable name instead to extract cubes

--- a/esmvalcore/preprocessor/_derive/ohc.py
+++ b/esmvalcore/preprocessor/_derive/ohc.py
@@ -1,8 +1,7 @@
 """Derivation of variable `ohc`."""
 import iris
-from iris import Constraint
-
 from cf_units import Unit
+from iris import Constraint
 
 from ._baseclass import DerivedVariableBase
 
@@ -38,8 +37,7 @@ class DerivedVariable(DerivedVariableBase):
 
     @staticmethod
     def calculate(cubes):
-        """
-        Compute ocean heat content.
+        """Compute ocean heat content.
 
         Use c_p*rho_0= 4.09169e+6 J m-3 K-1
         (Kuhlbrodt et al., 2015, Clim. Dyn.)

--- a/esmvalcore/preprocessor/_derive/rlnst.py
+++ b/esmvalcore/preprocessor/_derive/rlnst.py
@@ -2,7 +2,6 @@
 
 authors:
     - weig_ka
-
 """
 from iris import Constraint
 
@@ -30,11 +29,10 @@ class DerivedVariable(DerivedVariableBase):
 
     @staticmethod
     def calculate(cubes):
-        """
-        Compute variable `rlnst`.
+        """Compute variable `rlnst`.
 
-        Compute Net Atmospheric Longwave Cooling
-        to surface and outer space.
+        Compute Net Atmospheric Longwave Cooling to surface and outer
+        space.
         """
         rlds_cube = cubes.extract_cube(
             Constraint(name='surface_downwelling_longwave_flux_in_air'))

--- a/esmvalcore/preprocessor/_derive/rlnstcs.py
+++ b/esmvalcore/preprocessor/_derive/rlnstcs.py
@@ -2,7 +2,6 @@
 
 authors:
     - weig_ka
-
 """
 from iris import Constraint
 
@@ -30,11 +29,10 @@ class DerivedVariable(DerivedVariableBase):
 
     @staticmethod
     def calculate(cubes):
-        """
-        Compute variable `rlnstcs`.
+        """Compute variable `rlnstcs`.
 
-        Compute Net Atmospheric Longwave Cooling
-        to surface and outer space assuming clear sky.
+        Compute Net Atmospheric Longwave Cooling to surface and outer
+        space assuming clear sky.
         """
         rldscs_cube = cubes.extract_cube(
             Constraint(name='surface_downwelling_longwave_flux_in_air_' +

--- a/esmvalcore/preprocessor/_derive/rlus.py
+++ b/esmvalcore/preprocessor/_derive/rlus.py
@@ -2,7 +2,6 @@
 
 authors:
     - lukas_brunner
-
 """
 from iris import Constraint
 

--- a/esmvalcore/preprocessor/_derive/rsnst.py
+++ b/esmvalcore/preprocessor/_derive/rsnst.py
@@ -2,7 +2,6 @@
 
 authors:
     - weig_ka
-
 """
 from iris import Constraint
 

--- a/esmvalcore/preprocessor/_derive/rsnstcs.py
+++ b/esmvalcore/preprocessor/_derive/rsnstcs.py
@@ -2,7 +2,6 @@
 
 authors:
     - weig_ka
-
 """
 from iris import Constraint
 

--- a/esmvalcore/preprocessor/_derive/rsnstcsnorm.py
+++ b/esmvalcore/preprocessor/_derive/rsnstcsnorm.py
@@ -2,7 +2,6 @@
 
 authors:
     - weig_ka
-
 """
 from cf_units import Unit
 from iris import Constraint
@@ -34,12 +33,11 @@ class DerivedVariable(DerivedVariableBase):
 
     @staticmethod
     def calculate(cubes):
-        """
-        Compute `rsnstcs`.
+        """Compute `rsnstcs`.
 
-        Compute Heating from Shortwave Absorption
-        assuming clear sky normalized by
-        the incoming shortwave flux at the top of the atmosphere.
+        Compute Heating from Shortwave Absorption assuming clear sky
+        normalized by the incoming shortwave flux at the top of the
+        atmosphere.
         """
         rsdscs_cube = cubes.extract_cube(
             Constraint(name='surface_downwelling_shortwave_flux_in_air_' +

--- a/esmvalcore/preprocessor/_derive/rsus.py
+++ b/esmvalcore/preprocessor/_derive/rsus.py
@@ -2,7 +2,6 @@
 
 authors:
     - lukas_brunner
-
 """
 from iris import Constraint
 

--- a/esmvalcore/preprocessor/_derive/sispeed.py
+++ b/esmvalcore/preprocessor/_derive/sispeed.py
@@ -1,10 +1,10 @@
 """Derivation of variable `sispeed`."""
 
 import logging
+
 from iris import Constraint
 
 from .._regrid import regrid
-
 from ._baseclass import DerivedVariableBase
 
 logger = logging.getLogger(__name__)
@@ -24,8 +24,7 @@ class DerivedVariable(DerivedVariableBase):
 
     @staticmethod
     def calculate(cubes):
-        """
-        Compute sispeed module from velocity components siu and siv.
+        """Compute sispeed module from velocity components siu and siv.
 
         Arguments
         ---------
@@ -34,7 +33,6 @@ class DerivedVariable(DerivedVariableBase):
         Returns
         -------
             Cube containing sea ice speed.
-
         """
         siu = cubes.extract_cube(Constraint(name='sea_ice_x_velocity'))
         siv = cubes.extract_cube(Constraint(name='sea_ice_y_velocity'))

--- a/esmvalcore/preprocessor/_derive/sithick.py
+++ b/esmvalcore/preprocessor/_derive/sithick.py
@@ -20,8 +20,7 @@ class DerivedVariable(DerivedVariableBase):
 
     @staticmethod
     def calculate(cubes):
-        """
-        Compute sea ice thickness from volume and concentration.
+        """Compute sea ice thickness from volume and concentration.
 
         In CMIP5, `sit` is called `sea_ice_thickness` but it is not real
         thickness. It is ice volume per area unit. In CMIP6, it is called
@@ -34,7 +33,6 @@ class DerivedVariable(DerivedVariableBase):
         Returns
         -------
             Cube containing sea ice speed.
-
         """
         sivol = cubes.extract_cube(Constraint(name='sea_ice_thickness'))
         siconc = cubes.extract_cube(Constraint(name='sea_ice_area_fraction'))

--- a/esmvalcore/preprocessor/_derive/sm.py
+++ b/esmvalcore/preprocessor/_derive/sm.py
@@ -25,7 +25,6 @@ class DerivedVariable(DerivedVariableBase):
         Convert moisture content of soil layer (kg/m2) into volumetric soil
         moisture (m3/m3), assuming density of water 998.2 kg/m2 (at temperature
         20 deg C).
-
         """
         mrsos_cube = cubes.extract_cube(NameConstraint(var_name='mrsos'))
 

--- a/esmvalcore/preprocessor/_derive/toz.py
+++ b/esmvalcore/preprocessor/_derive/toz.py
@@ -39,7 +39,6 @@ class DerivedVariable(DerivedVariableBase):
         ----
         The surface pressure is used as a lower integration bound. A fixed
         upper integration bound of 0 Pa is used.
-
         """
         tro3_cube = cubes.extract_cube(
             iris.Constraint(name='mole_fraction_of_ozone_in_air'))

--- a/esmvalcore/preprocessor/_detrend.py
+++ b/esmvalcore/preprocessor/_detrend.py
@@ -8,8 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def detrend(cube, dimension='time', method='linear'):
-    """
-    Detrend data along a given dimension.
+    """Detrend data along a given dimension.
 
     Parameters
     ----------

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -134,7 +134,6 @@ def load(file, callback=None, ignore_warnings=None):
     ------
     ValueError
         Cubes are empty.
-
     """
     logger.debug("Loading:\n%s", file)
     if ignore_warnings is None:

--- a/esmvalcore/preprocessor/_mapping.py
+++ b/esmvalcore/preprocessor/_mapping.py
@@ -8,11 +8,10 @@ import numpy as np
 
 
 def _is_single_item(testee):
-    """
-    Check if testee is a single item.
+    """Check if testee is a single item.
 
-    Return whether this is a single item, rather than an iterable.
-    We count string types as 'single', also.
+    Return whether this is a single item, rather than an iterable. We
+    count string types as 'single', also.
     """
     return (isinstance(testee, str)
             or not isinstance(testee, collections.abc.Iterable))
@@ -64,8 +63,7 @@ def ref_to_dims_index_as_index(cube, ref):
 
 
 def ref_to_dims_index(cube, ref_to_slice):
-    """
-    Map a list of :class:`iris.coords.DimCoord` to a tuple of indices.
+    """Map a list of :class:`iris.coords.DimCoord` to a tuple of indices.
 
     This method finds the indices of the dimensions in a cube that collectively
     correspond to the given list of :class:`iris.coords.DimCoord`.
@@ -100,8 +98,7 @@ def ref_to_dims_index(cube, ref_to_slice):
 
 
 def get_associated_coords(cube, dimensions):
-    """
-    Return all coords containing any of the given dimensions.
+    """Return all coords containing any of the given dimensions.
 
     Return all coords, dimensional and auxiliary, that contain any of
     the given dimensions.
@@ -125,11 +122,10 @@ def get_associated_coords(cube, dimensions):
 
 
 def get_empty_data(shape, dtype=np.float32):
-    """
-    Create an empty data object of the given shape.
+    """Create an empty data object of the given shape.
 
-    Creates an empty data object of the given shape, potentially of the lazy
-    kind from biggus or dask, depending on the used iris version.
+    Creates an empty data object of the given shape, potentially of the
+    lazy kind from biggus or dask, depending on the used iris version.
     """
     data = np.empty(shape, dtype=dtype)
     mask = np.empty(shape, dtype=bool)
@@ -137,11 +133,10 @@ def get_empty_data(shape, dtype=np.float32):
 
 
 def get_slice_spec(cube, ref_to_slice):
-    """
-    Turn a slice reference into a specification for the slice.
+    """Turn a slice reference into a specification for the slice.
 
-    Turns a slice reference into a specification comprised of the shape as well
-    as the relevant dimensional and auxiliary coordinates.
+    Turns a slice reference into a specification comprised of the shape
+    as well as the relevant dimensional and auxiliary coordinates.
     """
     slice_dims = ref_to_dims_index(cube, ref_to_slice)
     slice_shape = tuple(cube.shape[d] for d in slice_dims)
@@ -150,8 +145,7 @@ def get_slice_spec(cube, ref_to_slice):
 
 
 def index_iterator(dims_to_slice, shape):
-    """
-    Return iterator for subsets of multidimensional objects.
+    """Return iterator for subsets of multidimensional objects.
 
     An iterator over a multidimensional object, giving both source and
     destination indices.
@@ -181,8 +175,7 @@ def get_slice_coords(cube):
 
 
 def map_slices(src, func, src_rep, dst_rep):
-    """
-    Map slices of a cube, replacing them with different slices.
+    """Map slices of a cube, replacing them with different slices.
 
     This method is similar to the standard cube collapsed and aggregated_by
     methods, however, where they completely remove the mapped dimensions, this

--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from ._mapping import get_empty_data, map_slices, ref_to_dims_index
 
-
 ESMF_MANAGER = ESMF.Manager(debug=False)
 
 ESMF_LON, ESMF_LAT = 0, 1
@@ -257,8 +256,7 @@ def get_grid_representant(cube, horizontal_only=False):
 
 
 def get_grid_representants(src, dst):
-    """
-    Construct cubes representing the source and destination grid.
+    """Construct cubes representing the source and destination grid.
 
     This method constructs two new cubes that representant the grids,
     i.e. the spatial dimensions of the given cubes.
@@ -310,8 +308,7 @@ def get_grid_representants(src, dst):
 
 
 def regrid(src, dst, method='linear'):
-    """
-    Regrid src_cube to the grid defined by dst_cube.
+    """Regrid src_cube to the grid defined by dst_cube.
 
     Regrid the data in src_cube onto the grid defined by dst_cube.
 

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -1,5 +1,4 @@
-"""
-Shared functions for preprocessor.
+"""Shared functions for preprocessor.
 
 Utility functions that can be used for multiple preprocessor steps
 """
@@ -22,8 +21,7 @@ def guess_bounds(cube, coords):
 
 
 def get_iris_analysis_operation(operator):
-    """
-    Determine the iris analysis operator from a string.
+    """Determine the iris analysis operator from a string.
 
     Map string to functional operator.
 
@@ -55,8 +53,7 @@ def get_iris_analysis_operation(operator):
 
 
 def operator_accept_weights(operator):
-    """
-    Get if operator support weights.
+    """Get if operator support weights.
 
     Parameters
     ----------
@@ -66,6 +63,5 @@ def operator_accept_weights(operator):
     Returns
     -------
         bool: True if operator support weights, False otherwise
-
     """
     return operator.lower() in ('mean', 'sum', 'rms')

--- a/esmvalcore/preprocessor/_trend.py
+++ b/esmvalcore/preprocessor/_trend.py
@@ -93,7 +93,6 @@ def linear_trend(cube, coordinate='time'):
     iris.exceptions.CoordinateNotFoundError
         The dimensional coordinate with the name ``coordinate`` is not found in
         ``cube``.
-
     """
     coord = cube.coord(coordinate, dim_coords=True)
 
@@ -147,7 +146,6 @@ def linear_trend_stderr(cube, coordinate='time'):
     iris.exceptions.CoordinateNotFoundError
         The dimensional coordinate with the name ``coordinate`` is not found in
         ``cube``.
-
     """
     coord = cube.coord(coordinate, dim_coords=True)
 

--- a/esmvalcore/preprocessor/_units.py
+++ b/esmvalcore/preprocessor/_units.py
@@ -4,9 +4,9 @@ Allows for unit conversions.
 """
 import logging
 
-from cf_units import Unit
 import iris
 import numpy as np
+from cf_units import Unit
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,6 @@ def convert_units(cube, units):
     -------
     iris.cube.Cube
         converted cube.
-
     """
     try:
         cube.convert_units(units)

--- a/esmvalcore/preprocessor/_weighting.py
+++ b/esmvalcore/preprocessor/_weighting.py
@@ -60,7 +60,6 @@ def weighting_landsea_fraction(cube, area_type):
         ``area_type`` is not ``'land'`` or ``'sea'``.
     ValueError
         Land/sea fraction variables ``sftlf`` or ``sftof`` not found.
-
     """
     if area_type not in ('land', 'sea'):
         raise TypeError(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [tool:pytest]
 addopts =
-    --flake8
     --mypy
     --doctest-modules
     --ignore=esmvalcore/cmor/tables/
@@ -10,8 +9,6 @@ addopts =
     --html=test-reports/report.html
 env =
     MPLBACKEND = Agg
-flake8-ignore =
-    doc/conf.py ALL
 log_level = WARNING
 markers =
     installation: Test requires installation of dependencies

--- a/setup.py
+++ b/setup.py
@@ -59,11 +59,9 @@ REQUIREMENTS = {
     ],
     # Test dependencies
     'test': [
-        'flake8<5.0',  # github.com/ESMValGroup/ESMValCore/issues/1696
         'pytest>=3.9,!=6.0.0rc1,!=6.0.0',
         'pytest-cov>=2.10.1',
         'pytest-env',
-        'pytest-flake8>=1.0.6',
         'pytest-html!=2.1.0',
         'pytest-metadata>=1.5.1',
         'pytest-mypy',

--- a/tests/integration/cmor/_fixes/cmip5/test_bnu_esm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_bnu_esm.py
@@ -5,8 +5,14 @@ import numpy.ma as ma
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip5.bnu_esm import (Ch4, Cl, Co2, FgCo2,
-                                                  Od550Aer, SpCo2)
+from esmvalcore.cmor._fixes.cmip5.bnu_esm import (
+    Ch4,
+    Cl,
+    Co2,
+    FgCo2,
+    Od550Aer,
+    SpCo2,
+)
 from esmvalcore.cmor._fixes.common import ClFixHybridPressureCoord
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
@@ -20,7 +26,7 @@ class TestCl(unittest.TestCase):
         self.fix = Cl(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         fix = Fix.get_fixes('CMIP5', 'BNU-ESM', 'Amon', 'cl')
         assert fix == [Cl(None)]
 

--- a/tests/integration/cmor/_fixes/cmip5/test_cnrm_cm5.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_cnrm_cm5.py
@@ -4,8 +4,8 @@ import unittest
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor._fixes.cmip5.cnrm_cm5 import Msftmyz, Msftmyzba
+from esmvalcore.cmor.fix import Fix
 
 
 class TestMsftmyz(unittest.TestCase):
@@ -16,7 +16,7 @@ class TestMsftmyz(unittest.TestCase):
         self.fix = Msftmyz(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'CNRM-CM5', 'Amon', 'msftmyz'),
             [Msftmyz(None)])
@@ -36,7 +36,7 @@ class TestMsftmyzba(unittest.TestCase):
         self.fix = Msftmyzba(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'CNRM-CM5', 'Amon', 'msftmyzba'),
             [Msftmyzba(None)])

--- a/tests/integration/cmor/_fixes/cmip5/test_ec_earth.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_ec_earth.py
@@ -2,18 +2,18 @@
 import unittest
 
 import numpy as np
-
 from cf_units import Unit
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateNotFoundError
+
 from esmvalcore.cmor._fixes.cmip5.ec_earth import (
     Areacello,
     Pr,
     Sftlf,
     Sic,
     Tas,
-    )
+)
 from esmvalcore.cmor.fix import Fix
 
 
@@ -25,7 +25,7 @@ class TestSic(unittest.TestCase):
         self.fix = Sic(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(Fix.get_fixes('CMIP5', 'EC-EARTH', 'Amon', 'sic'),
                              [Sic(None)])
 
@@ -44,7 +44,7 @@ class TestSftlf(unittest.TestCase):
         self.fix = Sftlf(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'EC-EARTH', 'Amon', 'sftlf'), [Sftlf(None)])
 
@@ -88,7 +88,7 @@ class TestTas(unittest.TestCase):
         self.fix = Tas(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(Fix.get_fixes('CMIP5', 'EC-EARTH', 'Amon', 'tas'),
                              [Tas(None)])
 
@@ -145,7 +145,7 @@ class TestAreacello(unittest.TestCase):
         self.fix = Areacello(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'EC-EARTH', 'Omon', 'areacello'),
             [Areacello(None)],
@@ -207,7 +207,7 @@ class TestPr(unittest.TestCase):
         self.fix = Pr(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'EC-EARTH', 'Amon', 'pr'),
             [Pr(None)],

--- a/tests/integration/cmor/_fixes/cmip5/test_fio_esm.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_fio_esm.py
@@ -4,9 +4,9 @@ import unittest
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor.fix import Fix
-from esmvalcore.cmor._fixes.cmip5.fio_esm import Ch4, Cl, Co2
 from esmvalcore.cmor._fixes.cmip5.cesm1_cam5 import Cl as BaseCl
+from esmvalcore.cmor._fixes.cmip5.fio_esm import Ch4, Cl, Co2
+from esmvalcore.cmor.fix import Fix
 
 
 def test_get_cl_fix():
@@ -28,7 +28,7 @@ class TestCh4(unittest.TestCase):
         self.fix = Ch4(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(Fix.get_fixes('CMIP5', 'FIO-ESM', 'Amon', 'ch4'),
                              [Ch4(None)])
 
@@ -47,7 +47,7 @@ class TestCo2(unittest.TestCase):
         self.fix = Co2(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(Fix.get_fixes('CMIP5', 'FIO-ESM', 'Amon', 'co2'),
                              [Co2(None)])
 

--- a/tests/integration/cmor/_fixes/cmip5/test_gfdl_cm2p1.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_gfdl_cm2p1.py
@@ -6,9 +6,14 @@ import iris
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip5.gfdl_cm2p1 import (AllVars, Areacello, Cl,
-                                                     Sftof, Sit)
 from esmvalcore.cmor._fixes.cmip5.cesm1_cam5 import Cl as BaseCl
+from esmvalcore.cmor._fixes.cmip5.gfdl_cm2p1 import (
+    AllVars,
+    Areacello,
+    Cl,
+    Sftof,
+    Sit,
+)
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
@@ -34,7 +39,7 @@ class TestSftof(unittest.TestCase):
         self.fix = Sftof(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-CM2P1', 'fx', 'sftof'),
             [Sftof(None), AllVars(None)])
@@ -56,7 +61,7 @@ class TestAreacello(unittest.TestCase):
         self.fix = Areacello(self.vardef)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-CM2P1', 'Amon', 'areacello'),
             [Areacello(self.vardef), AllVars(self.vardef)])
@@ -98,7 +103,7 @@ class TestSit(unittest.TestCase):
         self.fix = Sit(self.var_info_mock)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-CM2P1', 'OImon', 'sit'),
             [Sit(self.var_info_mock), AllVars(None)])

--- a/tests/integration/cmor/_fixes/cmip5/test_gfdl_cm3.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_gfdl_cm3.py
@@ -17,7 +17,7 @@ class TestSftof(unittest.TestCase):
         self.fix = Sftof(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-CM3', 'fx', 'sftof'),
             [Sftof(None), AllVars(None)])
@@ -38,7 +38,7 @@ class TestAreacello(unittest.TestCase):
         self.fix = Areacello(self.vardef)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-CM3', 'Amon', 'areacello'),
             [Areacello(self.vardef), AllVars(self.vardef)])

--- a/tests/integration/cmor/_fixes/cmip5/test_gfdl_esm2g.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_gfdl_esm2g.py
@@ -7,9 +7,15 @@ import pytest
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip5.gfdl_esm2g import (AllVars, Areacello, Co2,
-                                                     FgCo2, Usi, Vsi,
-                                                     _get_and_remove)
+from esmvalcore.cmor._fixes.cmip5.gfdl_esm2g import (
+    AllVars,
+    Areacello,
+    Co2,
+    FgCo2,
+    Usi,
+    Vsi,
+    _get_and_remove,
+)
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
@@ -68,7 +74,7 @@ class TestCo2(unittest.TestCase):
         self.fix = Co2(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-ESM2G', 'Amon', 'co2'),
             [Co2(None), AllVars(None)])
@@ -89,7 +95,7 @@ class TestUsi(unittest.TestCase):
         self.fix = Usi(self.vardef)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-ESM2G', 'day', 'usi'),
             [Usi(self.vardef), AllVars(self.vardef)])
@@ -109,7 +115,7 @@ class TestVsi(unittest.TestCase):
         self.fix = Vsi(self.vardef)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-ESM2G', 'day', 'vsi'),
             [Vsi(self.vardef), AllVars(self.vardef)])
@@ -129,7 +135,7 @@ class TestAreacello(unittest.TestCase):
         self.fix = Areacello(self.vardef)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-ESM2G', 'fx', 'areacello'),
             [Areacello(self.vardef), AllVars(self.vardef)])

--- a/tests/integration/cmor/_fixes/cmip5/test_gfdl_esm2m.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_gfdl_esm2m.py
@@ -4,8 +4,12 @@ import unittest
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip5.gfdl_esm2m import (AllVars, Areacello, Co2,
-                                                     Sftof)
+from esmvalcore.cmor._fixes.cmip5.gfdl_esm2m import (
+    AllVars,
+    Areacello,
+    Co2,
+    Sftof,
+)
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
@@ -18,7 +22,7 @@ class TestSftof(unittest.TestCase):
         self.fix = Sftof(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-ESM2M', 'fx', 'sftof'),
             [Sftof(None), AllVars(None)])
@@ -38,7 +42,7 @@ class TestCo2(unittest.TestCase):
         self.fix = Co2(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-ESM2M', 'Amon', 'co2'),
             [Co2(None), AllVars(None)])
@@ -59,7 +63,7 @@ class TestAreacello(unittest.TestCase):
         self.fix = Areacello(self.vardef)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'GFDL-ESM2M', 'fx', 'areacello'),
             [Areacello(self.vardef), AllVars(self.vardef)])

--- a/tests/integration/cmor/_fixes/cmip5/test_hadgem2_cc.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_hadgem2_cc.py
@@ -1,14 +1,14 @@
 """Test HADGEM2-CC fixes."""
 import unittest
 
+from esmvalcore.cmor._fixes.cmip5.hadgem2_cc import O2, AllVars
 from esmvalcore.cmor.fix import Fix
-from esmvalcore.cmor._fixes.cmip5.hadgem2_cc import AllVars, O2
 
 
 class TestAllVars(unittest.TestCase):
     """Test allvars fixes."""
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'HADGEM2-CC', 'Amon', 'tas'),
             [AllVars(None)])
@@ -17,7 +17,7 @@ class TestAllVars(unittest.TestCase):
 class TestO2(unittest.TestCase):
     """Test o2 fixes."""
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'HADGEM2-CC', 'Amon', 'o2'),
             [O2(None), AllVars(None)])

--- a/tests/integration/cmor/_fixes/cmip5/test_miroc_esm_chem.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_miroc_esm_chem.py
@@ -5,8 +5,8 @@ import unittest
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor._fixes.cmip5.miroc_esm_chem import Tro3
+from esmvalcore.cmor.fix import Fix
 
 
 class TestTro3(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestTro3(unittest.TestCase):
         self.fix = Tro3(None)
 
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'MIROC-ESM-CHEM', 'Amon', 'tro3'),
             [Tro3(None)])

--- a/tests/integration/cmor/_fixes/cmip5/test_mri_esm1.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_mri_esm1.py
@@ -1,14 +1,14 @@
 """Test MRI-ESM1 fixes."""
 import unittest
 
-from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor._fixes.cmip5.mri_esm1 import Msftmyz
+from esmvalcore.cmor.fix import Fix
 
 
 class TestMsftmyz(unittest.TestCase):
     """Test msftmyz fixes."""
     def test_get(self):
-        """Test fix get"""
+        """Test fix get."""
         self.assertListEqual(
             Fix.get_fixes('CMIP5', 'MRI-ESM1', 'Amon', 'msftmyz'),
             [Msftmyz(None)])

--- a/tests/integration/cmor/_fixes/cmip5/test_noresm1_me.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_noresm1_me.py
@@ -1,10 +1,10 @@
 """Tests for fixes of NorESM1-ME (CMIP5)."""
-import pytest
 import iris
+import pytest
 from iris.cube import CubeList
 
-from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor._fixes.cmip5.noresm1_me import Tas
+from esmvalcore.cmor.fix import Fix
 
 DIM_COORD_SHORT = iris.coords.DimCoord(
     [1.0, 2.0, 3.0],
@@ -68,5 +68,5 @@ def test_tas(cubes_in, cubes_out):
 
 
 def test_get():
-    """Test fix get"""
+    """Test fix get."""
     assert Fix.get_fixes('CMIP5', 'NORESM1-ME', 'Amon', 'tas') == [Tas(None)]

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm_fv2.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2_waccm_fv2.py
@@ -1,6 +1,6 @@
 """Tests for the fixes of CESM2-WACCM-FV2."""
-from esmvalcore.cmor._fixes.cmip6.cesm2 import Tas as BaseTas
 from esmvalcore.cmor._fixes.cmip6.cesm2 import Fgco2 as BaseFgco2
+from esmvalcore.cmor._fixes.cmip6.cesm2 import Tas as BaseTas
 from esmvalcore.cmor._fixes.cmip6.cesm2_waccm import Cl as BaseCl
 from esmvalcore.cmor._fixes.cmip6.cesm2_waccm_fv2 import (
     Cl,

--- a/tests/integration/cmor/_fixes/cmip6/test_cnrm_cm6_1.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cnrm_cm6_1.py
@@ -4,8 +4,13 @@ import iris
 import numpy as np
 import pytest
 
-from esmvalcore.cmor._fixes.cmip6.cnrm_cm6_1 import (Cl, Clcalipso,
-                                                     Cli, Clw, Omon)
+from esmvalcore.cmor._fixes.cmip6.cnrm_cm6_1 import (
+    Cl,
+    Clcalipso,
+    Cli,
+    Clw,
+    Omon,
+)
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 

--- a/tests/integration/cmor/_fixes/cmip6/test_cnrm_esm2_1.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cnrm_esm2_1.py
@@ -7,8 +7,13 @@ from esmvalcore.cmor._fixes.cmip6.cnrm_cm6_1 import Cl as BaseCl
 from esmvalcore.cmor._fixes.cmip6.cnrm_cm6_1 import Clcalipso as BaseClcalipso
 from esmvalcore.cmor._fixes.cmip6.cnrm_cm6_1 import Cli as BaseCli
 from esmvalcore.cmor._fixes.cmip6.cnrm_cm6_1 import Clw as BaseClw
-from esmvalcore.cmor._fixes.cmip6.cnrm_esm2_1 import (Cl, Clcalipso,
-                                                      Cli, Clw, Omon)
+from esmvalcore.cmor._fixes.cmip6.cnrm_esm2_1 import (
+    Cl,
+    Clcalipso,
+    Cli,
+    Clw,
+    Omon,
+)
 from esmvalcore.cmor._fixes.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 

--- a/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
@@ -1,7 +1,7 @@
 """Tests for the fixes of FGOALS-f3-L."""
 
-import numpy as np
 import iris
+import numpy as np
 import pytest
 from cf_units import Unit
 

--- a/tests/integration/cmor/_fixes/cmip6/test_gfdl_cm4.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_gfdl_cm4.py
@@ -3,8 +3,14 @@ import iris
 import numpy as np
 import pytest
 
-from esmvalcore.cmor._fixes.cmip6.gfdl_cm4 import (Cl, Cli, Clw,
-                                                   Fgco2, Omon, Siconc)
+from esmvalcore.cmor._fixes.cmip6.gfdl_cm4 import (
+    Cl,
+    Cli,
+    Clw,
+    Fgco2,
+    Omon,
+    Siconc,
+)
 from esmvalcore.cmor._fixes.common import SiconcFixScalarCoord
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info

--- a/tests/integration/cmor/_fixes/cmip6/test_kiost_esm.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_kiost_esm.py
@@ -3,11 +3,7 @@ import iris
 import pytest
 from cf_units import Unit
 
-from esmvalcore.cmor._fixes.cmip6.kiost_esm import (
-    SfcWind,
-    Siconc,
-    Tas,
-)
+from esmvalcore.cmor._fixes.cmip6.kiost_esm import SfcWind, Siconc, Tas
 from esmvalcore.cmor._fixes.common import SiconcFixScalarCoord
 from esmvalcore.cmor._fixes.fix import Fix
 from esmvalcore.cmor.table import get_var_info

--- a/tests/integration/cmor/_fixes/test_native_datasets.py
+++ b/tests/integration/cmor/_fixes/test_native_datasets.py
@@ -83,7 +83,6 @@ def fix():
     We use `tas` as a dummy variable here, but will use monkeypatching to
     customize the variable information of the fix in the tests below. This will
     allow us to test all common cases.
-
     """
     vardef = get_var_info('CMIP6', 'Amon', 'tas')
     extra_facets = {}

--- a/tests/integration/data_finder.yml
+++ b/tests/integration/data_finder.yml
@@ -460,9 +460,9 @@ get_input_filelist:
     file_patterns:
       - simulation_*_t2m.nc
       - simulation_*_histmth.nc
-    found_files: 
+    found_files:
       - thredds/tgcc/store/p86caub/IPSLCM6/PROD/historical/simulation/ATM/Output/MO/simulation_18500101_18591231_1M_histmth.nc
-    
+
   - drs: default
     variable:
       <<: *ipsl_variable
@@ -475,9 +475,9 @@ get_input_filelist:
     file_patterns:
       - simulation_*_t2m.nc
       - simulation_*_histmth.nc
-    found_files: 
+    found_files:
       - thredds/tgcc/store/p86caub/IPSLCM6/PROD/historical/simulation/ATM/Analyse/TS_MO/simulation_18500101_20141231_1M_t2m.nc
-      
+
   # Test fx files
 
   - drs: default

--- a/tests/integration/preprocessor/_ancillary_vars/__init__.py
+++ b/tests/integration/preprocessor/_ancillary_vars/__init__.py
@@ -1,5 +1,4 @@
-"""
-Test _ancillary_vars.py
+"""Test _ancillary_vars.py.
 
 Integration tests for the esmvalcore.preprocessor._ancillary_vars module
 """

--- a/tests/integration/preprocessor/_derive/test_sispeed.py
+++ b/tests/integration/preprocessor/_derive/test_sispeed.py
@@ -4,9 +4,8 @@ import math
 from unittest import mock
 
 import numpy as np
-
-from iris.cube import Cube, CubeList
 from iris.coords import AuxCoord
+from iris.cube import Cube, CubeList
 
 from esmvalcore.preprocessor._derive.sispeed import DerivedVariable
 

--- a/tests/integration/preprocessor/_io/test_cleanup.py
+++ b/tests/integration/preprocessor/_io/test_cleanup.py
@@ -26,13 +26,13 @@ class TestCleanup(unittest.TestCase):
                 os.rmdir(path)
 
     def test_cleanup(self):
-        """Test cleanup"""
+        """Test cleanup."""
         _io.cleanup([], self.temp_paths)
         for path in self.temp_paths:
             self.assertFalse(os.path.exists(path))
 
     def test_cleanup_when_files_removed(self):
-        """Test cleanup works even with missing files or folders"""
+        """Test cleanup works even with missing files or folders."""
         self.tearDown()
         _io.cleanup([], self.temp_paths)
         for path in self.temp_paths:

--- a/tests/integration/preprocessor/_io/test_save.py
+++ b/tests/integration/preprocessor/_io/test_save.py
@@ -51,14 +51,14 @@ class TestSave(unittest.TestCase):
         return cube, filename
 
     def test_save(self):
-        """Test save"""
+        """Test save."""
         cube, filename = self._create_sample_cube()
         path = save([cube], filename)
         loaded_cube = iris.load_cube(path)
         self._compare_cubes(cube, loaded_cube)
 
     def test_save_alias(self):
-        """Test save"""
+        """Test save."""
         cube, filename = self._create_sample_cube()
         path = save([cube], filename, alias='alias')
         loaded_cube = iris.load_cube(path)
@@ -66,7 +66,7 @@ class TestSave(unittest.TestCase):
         self.assertEqual(loaded_cube.var_name, 'alias')
 
     def test_save_zlib(self):
-        """Test save"""
+        """Test save."""
         cube, filename = self._create_sample_cube()
         path = save([cube], filename, compress=True)
         loaded_cube = iris.load_cube(path)
@@ -92,7 +92,7 @@ class TestSave(unittest.TestCase):
             save([cube])
 
     def test_save_optimized_map(self):
-        """Test save"""
+        """Test save."""
         cube, filename = self._create_sample_cube()
         path = save([cube], filename, optimize_access='map')
         loaded_cube = iris.load_cube(path)
@@ -100,7 +100,7 @@ class TestSave(unittest.TestCase):
         self._check_chunks(path, [2, 2, 1])
 
     def test_save_optimized_timeseries(self):
-        """Test save"""
+        """Test save."""
         cube, filename = self._create_sample_cube()
         path = save([cube], filename, optimize_access='timeseries')
         loaded_cube = iris.load_cube(path)
@@ -108,7 +108,7 @@ class TestSave(unittest.TestCase):
         self._check_chunks(path, [1, 1, 2])
 
     def test_save_optimized_lat(self):
-        """Test save"""
+        """Test save."""
         cube, filename = self._create_sample_cube()
         path = save([cube], filename, optimize_access='latitude')
         loaded_cube = iris.load_cube(path)
@@ -123,7 +123,7 @@ class TestSave(unittest.TestCase):
         self.assertListEqual(expected_chunks, chunking)
 
     def test_save_optimized_lon_time(self):
-        """Test save"""
+        """Test save."""
         cube, filename = self._create_sample_cube()
         path = save([cube], filename, optimize_access='longitude time')
         loaded_cube = iris.load_cube(path)

--- a/tests/integration/preprocessor/_mask/__init__.py
+++ b/tests/integration/preprocessor/_mask/__init__.py
@@ -1,5 +1,4 @@
-"""
-Test _mask.py
+"""Test _mask.py.
 
 Integration tests for the esmvalcore.preprocessor._mask module
 """

--- a/tests/integration/preprocessor/_mask/test_mask.py
+++ b/tests/integration/preprocessor/_mask/test_mask.py
@@ -1,9 +1,6 @@
-"""
-Test mask.
+"""Test mask.
 
-Integration tests for the :func:`esmvalcore.preprocessor._mask`
-module.
-
+Integration tests for the :func:`esmvalcore.preprocessor._mask` module.
 """
 
 import iris
@@ -279,7 +276,7 @@ class Test:
         assert_array_equal(result_1.data, data_1)
 
     def test_mask_fillvalues_zero_threshold(self, tmp_path):
-        """Test the fillvalues mask: func mask_fillvalues for 0-threshold"""
+        """Test the fillvalues mask: func mask_fillvalues for 0-threshold."""
         data_1 = self.mock_data
         data_2 = self.mock_data[0:3]
         data_1.mask = np.ones((4, 3, 3), bool)

--- a/tests/integration/preprocessor/_regrid/__init__.py
+++ b/tests/integration/preprocessor/_regrid/__init__.py
@@ -1,4 +1,1 @@
-"""
-Integration tests for the :mod:`esmvalcore.preprocessor._regrid` module.
-
-"""
+"""Integration tests for the :mod:`esmvalcore.preprocessor._regrid` module."""

--- a/tests/integration/preprocessor/_regrid/test_extract_coordinate_points.py
+++ b/tests/integration/preprocessor/_regrid/test_extract_coordinate_points.py
@@ -1,8 +1,5 @@
-"""
-Integration tests for the :func:`esmvalcore.preprocessor.regrid.regrid`
-function.
-
-"""
+"""Integration tests for the :func:`esmvalcore.preprocessor.regrid.regrid`
+function."""
 
 import unittest
 
@@ -23,7 +20,7 @@ class Test(tests.Test):
         self.cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
 
     def test_extract_point__single_linear(self):
-        """Test linear interpolation when extracting a single point"""
+        """Test linear interpolation when extracting a single point."""
         point = extract_coordinate_points(
             self.cube,
             {'grid_latitude': 2.1, 'grid_longitude': 2.1},
@@ -66,7 +63,7 @@ class Test(tests.Test):
         self.assert_array_equal(point.data, masked)
 
     def test_extract_point__single_nearest(self):
-        """Test nearest match when extracting a single point"""
+        """Test nearest match when extracting a single point."""
 
         point = extract_coordinate_points(
             self.cube,
@@ -99,7 +96,7 @@ class Test(tests.Test):
         self.assert_array_equal(point.data, masked)
 
     def test_extract_point__multiple_linear(self):
-        """Test linear interpolation for an array of one coordinate"""
+        """Test linear interpolation for an array of one coordinate."""
 
         # Test points on the grid edges, on a grid point, halfway and
         # one in between.
@@ -151,7 +148,7 @@ class Test(tests.Test):
         self.assert_array_equal(point.data, masked)
 
     def test_extract_point__multiple_nearest(self):
-        """Test nearest match for an array of one coordinate"""
+        """Test nearest match for an array of one coordinate."""
 
         point = extract_coordinate_points(
             self.cube,
@@ -192,8 +189,8 @@ class Test(tests.Test):
         self.assert_array_equal(point.data, masked)
 
     def test_extract_point__multiple_both_linear(self):
-        """Test for both latitude and longitude arrays, with
-        linear interpolation"""
+        """Test for both latitude and longitude arrays, with linear
+        interpolation."""
         point = extract_coordinate_points(
             self.cube,
             {'grid_latitude': [0, 1.1, 1.5, 1.51, 4, 5],
@@ -223,7 +220,7 @@ class Test(tests.Test):
         np.testing.assert_allclose(point.data, result)
 
     def test_extract_point__multiple_both_nearest(self):
-        """Test for both latitude and longitude arrays, with nearest match"""
+        """Test for both latitude and longitude arrays, with nearest match."""
         point = extract_coordinate_points(
             self.cube,
             {'grid_latitude': [0, 1.1, 1.5, 1.51, 4, 5],

--- a/tests/integration/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/integration/preprocessor/_regrid/test_extract_levels.py
@@ -1,8 +1,5 @@
-"""
-Integration tests for the :func:`esmvalcore.preprocessor.regrid.extract_levels`
-function.
-
-"""
+"""Integration tests for the
+:func:`esmvalcore.preprocessor.regrid.extract_levels` function."""
 
 import unittest
 

--- a/tests/integration/preprocessor/_regrid/test_extract_point.py
+++ b/tests/integration/preprocessor/_regrid/test_extract_point.py
@@ -1,8 +1,5 @@
-"""
-Integration tests for the :func:`esmvalcore.preprocessor.regrid.regrid`
-function.
-
-"""
+"""Integration tests for the :func:`esmvalcore.preprocessor.regrid.regrid`
+function."""
 
 import unittest
 
@@ -23,7 +20,7 @@ class Test(tests.Test):
         self.cs = iris.coord_systems.GeogCS(iris.fileformats.pp.EARTH_RADIUS)
 
     def test_extract_point__single_linear(self):
-        """Test linear interpolation when extracting a single point"""
+        """Test linear interpolation when extracting a single point."""
 
         point = extract_point(self.cube, 2.1, 2.1, scheme='linear')
         self.assertEqual(point.shape, (3,))
@@ -58,7 +55,7 @@ class Test(tests.Test):
         assert point.data.mask.all()
 
     def test_extract_point__single_nearest(self):
-        """Test nearest match when extracting a single point"""
+        """Test nearest match when extracting a single point."""
 
         point = extract_point(self.cube, 2.1, 2.1, scheme='nearest')
         self.assertEqual(point.shape, (3,))
@@ -79,7 +76,7 @@ class Test(tests.Test):
         self.assert_array_equal(point.data, masked)
 
     def test_extract_point__multiple_linear(self):
-        """Test linear interpolation for an array of one coordinate"""
+        """Test linear interpolation for an array of one coordinate."""
 
         # Test points on the grid edges, on a grid point, halfway and
         # one in between.
@@ -121,7 +118,7 @@ class Test(tests.Test):
         self.assert_array_equal(point.data, masked)
 
     def test_extract_point__multiple_nearest(self):
-        """Test nearest match for an array of one coordinate"""
+        """Test nearest match for an array of one coordinate."""
 
         point = extract_point(self.cube, [1, 1.1, 1.5, 1.501, 2, 4], 2,
                               scheme='nearest')
@@ -150,8 +147,8 @@ class Test(tests.Test):
         self.assert_array_equal(point.data, masked)
 
     def test_extract_point__multiple_both_linear(self):
-        """Test for both latitude and longitude arrays, with
-        linear interpolation"""
+        """Test for both latitude and longitude arrays, with linear
+        interpolation."""
         point = extract_point(self.cube, [0, 1.1, 1.5, 1.51, 4, 5],
                               [0, 1.1, 1.5, 1.51, 4, 5], scheme='linear')
         self.assertEqual(point.data.shape, (3, 6, 6))
@@ -179,7 +176,7 @@ class Test(tests.Test):
         np.testing.assert_allclose(point.data, result)
 
     def test_extract_point__multiple_both_nearest(self):
-        """Test for both latitude and longitude arrays, with nearest match"""
+        """Test for both latitude and longitude arrays, with nearest match."""
         point = extract_point(self.cube, [0, 1.1, 1.5, 1.51, 4, 5],
                               [0, 1.1, 1.5, 1.51, 4, 5], scheme='nearest')
         self.assertEqual(point.data.shape, (3, 6, 6))

--- a/tests/integration/preprocessor/_regrid/test_get_cmor_levels.py
+++ b/tests/integration/preprocessor/_regrid/test_get_cmor_levels.py
@@ -1,8 +1,6 @@
-"""
-Integration tests for the :func:
-`esmvalcore.preprocessor.regrid.get_cmor_levels`
-function.
+"""Integration tests for the :func:
 
+`esmvalcore.preprocessor.regrid.get_cmor_levels` function.
 """
 
 import unittest
@@ -15,7 +13,7 @@ from esmvalcore.preprocessor import _regrid
 class TestGetCmorLevels(unittest.TestCase):
     @staticmethod
     def setUpClass():
-        """Read cmor tables before testing"""
+        """Read cmor tables before testing."""
         read_cmor_tables(read_config_developer_file())
 
     def test_cmip6_alt40(self):

--- a/tests/integration/preprocessor/_regrid/test_get_file_levels.py
+++ b/tests/integration/preprocessor/_regrid/test_get_file_levels.py
@@ -1,8 +1,6 @@
-"""
-Integration tests for the :func:
-`esmvalcore.preprocessor.regrid.get_cmor_levels`
-function.
+"""Integration tests for the :func:
 
+`esmvalcore.preprocessor.regrid.get_cmor_levels` function.
 """
 
 import os
@@ -19,7 +17,7 @@ from esmvalcore.preprocessor import _regrid
 
 class TestGetFileLevels(unittest.TestCase):
     def setUp(self):
-        """Prepare the sample file for the test"""
+        """Prepare the sample file for the test."""
         self.cube = iris.cube.Cube(np.ones([2, 2, 2]), var_name='var')
         self.cube.add_dim_coord(
             iris.coords.DimCoord(np.arange(0, 2), var_name='coord'), 0)
@@ -32,7 +30,7 @@ class TestGetFileLevels(unittest.TestCase):
         iris.save(self.cube, self.path)
 
     def tearDown(self):
-        """Remove the sample file for the test"""
+        """Remove the sample file for the test."""
         os.remove(self.path)
 
     def test_get_coord(self):

--- a/tests/integration/preprocessor/_regrid/test_regrid.py
+++ b/tests/integration/preprocessor/_regrid/test_regrid.py
@@ -1,8 +1,5 @@
-"""
-Integration tests for the :func:`esmvalcore.preprocessor.regrid.regrid`
-function.
-
-"""
+"""Integration tests for the :func:`esmvalcore.preprocessor.regrid.regrid`
+function."""
 
 import iris
 import numpy as np

--- a/tests/integration/test_citation.py
+++ b/tests/integration/test_citation.py
@@ -4,8 +4,11 @@ import textwrap
 from prov.model import ProvDocument
 
 import esmvalcore
-from esmvalcore._citation import (CMIP6_URL_STEM, ESMVALTOOL_PAPER,
-                                  _write_citation_files)
+from esmvalcore._citation import (
+    CMIP6_URL_STEM,
+    ESMVALTOOL_PAPER,
+    _write_citation_files,
+)
 from esmvalcore._provenance import ESMVALTOOL_URI_PREFIX
 
 

--- a/tests/parse_pymon.py
+++ b/tests/parse_pymon.py
@@ -1,9 +1,8 @@
-"""
-Parse and display test memory.
+"""Parse and display test memory.
 
-Uses pytest-monitor plugin from https://github.com/CFMTech/pytest-monitor
-Lots of other metrics can be read from the file via sqlite parsing.,
-currently just MEM_USAGE (RES memory, in MB).
+Uses pytest-monitor plugin from https://github.com/CFMTech/pytest-
+monitor Lots of other metrics can be read from the file via sqlite
+parsing., currently just MEM_USAGE (RES memory, in MB).
 """
 import sqlite3
 import sys

--- a/tests/sample_data/multimodel_statistics/test_multimodel.py
+++ b/tests/sample_data/multimodel_statistics/test_multimodel.py
@@ -92,7 +92,8 @@ def get_cache_key(value):
     """Get a cache key that is hopefully unique enough for unpickling.
 
     If this doesn't avoid problems with unpickling the cached data,
-    manually clean the pytest cache with the command `pytest --cache-clear`.
+    manually clean the pytest cache with the command `pytest --cache-
+    clear`.
     """
     py_version = platform.python_version()
     return (f'{value}_iris-{iris.__version__}_'

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -126,7 +126,7 @@ class TestCMORCheck(unittest.TestCase):
             )
 
     def test_report_debug_message(self):
-        """"Test report debug message function"""
+        """"Test report debug message function."""
         checker = CMORCheck(self.cube, self.var_info)
         self.assertFalse(checker.has_debug_messages())
         checker.report_debug_message('New debug message')
@@ -302,8 +302,8 @@ class TestCMORCheck(unittest.TestCase):
         np.testing.assert_allclose(lon_coord.bounds.max(), 351.0)
 
     def test_bad_generic_level(self):
-        """Test check fails in metadata if generic level coord
-        has wrong var_name."""
+        """Test check fails in metadata if generic level coord has wrong
+        var_name."""
         depth_coord = CoordinateInfoMock('depth')
         depth_coord.axis = 'Z'
         depth_coord.generic_lev_name = 'olevel'
@@ -367,26 +367,34 @@ class TestCMORCheck(unittest.TestCase):
         self._check_fails_in_metadata()
 
     def test_check_bad_var_standard_name_strict_flag(self):
-        """Test check fails for a bad variable standard_name with
-        --cmor-check strict."""
+        """Test check fails for a bad variable standard_name with.
+
+        --cmor-check strict.
+        """
         self.cube.standard_name = 'wind_speed'
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_bad_var_long_name_strict_flag(self):
-        """Test check fails for a bad variable long_name with
-        --cmor-check strict."""
+        """Test check fails for a bad variable long_name with.
+
+        --cmor-check strict.
+        """
         self.cube.long_name = "Near-Surface Wind Speed"
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_bad_var_units_strict_flag(self):
-        """Test check fails for a bad variable units with
-        --cmor-check strict."""
+        """Test check fails for a bad variable units with.
+
+        --cmor-check strict.
+        """
         self.cube.units = "kg"
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_bad_attributes_strict_flag(self):
-        """Test check fails for a bad variable attribute with
-        --cmor-check strict."""
+        """Test check fails for a bad variable attribute with.
+
+        --cmor-check strict.
+        """
         self.var_info.standard_name = "surface_upward_latent_heat_flux"
         self.var_info.positive = "up"
         self.cube = self.get_cube(self.var_info)
@@ -394,70 +402,82 @@ class TestCMORCheck(unittest.TestCase):
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_bad_rank_strict_flag(self):
-        """Test check fails for a bad variable rank with
-        --cmor-check strict."""
+        """Test check fails for a bad variable rank with.
+
+        --cmor-check strict.
+        """
         lat = iris.coords.AuxCoord.from_coord(self.cube.coord('latitude'))
         self.cube.remove_coord('latitude')
         self.cube.add_aux_coord(lat, self.cube.coord_dims('longitude'))
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_bad_coord_var_name_strict_flag(self):
-        """Test check fails for bad coord var_name with
-        --cmor-check strict"""
+        """Test check fails for bad coord var_name with.
+
+        --cmor-check strict
+        """
         self.var_info.table_type = 'CMIP5'
         self.cube.coord('longitude').var_name = 'bad_name'
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_missing_lon_strict_flag(self):
-        """Test check fails for missing longitude with --cmor-check strict"""
+        """Test check fails for missing longitude with --cmor-check strict."""
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('longitude')
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_missing_lat_strict_flag(self):
-        """Test check fails for missing latitude with --cmor-check strict"""
+        """Test check fails for missing latitude with --cmor-check strict."""
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('latitude')
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_missing_time_strict_flag(self):
-        """Test check fails for missing time with --cmor-check strict"""
+        """Test check fails for missing time with --cmor-check strict."""
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('time')
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_missing_coord_strict_flag(self):
-        """Test check fails for missing coord other than lat and lon
-         with --cmor-check strict"""
+        """Test check fails for missing coord other than lat and lon with
+        --cmor-check strict."""
         self.var_info.coordinates.update(
             {'height2m': CoordinateInfoMock('height2m')}
         )
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_bad_var_standard_name_relaxed_flag(self):
-        """Test check reports warning for a bad variable standard_name with
-        --cmor-check relaxed."""
+        """Test check reports warning for a bad variable standard_name with.
+
+        --cmor-check relaxed.
+        """
         self.cube.standard_name = 'wind_speed'
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.RELAXED)
 
     def test_check_bad_var_long_name_relaxed_flag(self):
-        """Test check reports warning for a bad variable long_name with
-        --cmor-check relaxed."""
+        """Test check reports warning for a bad variable long_name with.
+
+        --cmor-check relaxed.
+        """
         self.cube.long_name = "Near-Surface Wind Speed"
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.RELAXED)
 
     def test_check_bad_var_units_relaxed_flag(self):
-        """Test check reports warning for a bad variable units with
-        --cmor-check relaxed."""
+        """Test check reports warning for a bad variable units with.
+
+        --cmor-check relaxed.
+        """
         self.cube.units = "kg"
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.RELAXED)
 
     def test_check_bad_attributes_relaxed_flag(self):
-        """Test check report warnings for a bad variable attribute with
-        --cmor-check relaxed."""
+        """Test check report warnings for a bad variable attribute with.
+
+        --cmor-check relaxed.
+        """
         self.var_info.standard_name = "surface_upward_latent_heat_flux"
         self.var_info.positive = "up"
         self.cube = self.get_cube(self.var_info)
@@ -466,8 +486,10 @@ class TestCMORCheck(unittest.TestCase):
                                          check_level=CheckLevels.RELAXED)
 
     def test_check_bad_rank_relaxed_flag(self):
-        """Test check report warnings for a bad variable rank with
-        --cmor-check relaxed."""
+        """Test check report warnings for a bad variable rank with.
+
+        --cmor-check relaxed.
+        """
         lat = iris.coords.AuxCoord.from_coord(self.cube.coord('latitude'))
         self.cube.remove_coord('latitude')
         self.cube.add_aux_coord(lat, self.cube.coord_dims('longitude'))
@@ -475,29 +497,31 @@ class TestCMORCheck(unittest.TestCase):
                                          check_level=CheckLevels.RELAXED)
 
     def test_check_bad_coord_standard_name_relaxed_flag(self):
-        """Test check reports warning for bad coord var_name with
-        --cmor-check relaxed"""
+        """Test check reports warning for bad coord var_name with.
+
+        --cmor-check relaxed
+        """
         self.var_info.table_type = 'CMIP5'
         self.cube.coord('longitude').var_name = 'bad_name'
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.RELAXED)
 
     def test_check_missing_lon_relaxed_flag(self):
-        """Test check fails for missing longitude with --cmor-check relaxed"""
+        """Test check fails for missing longitude with --cmor-check relaxed."""
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('longitude')
         self._check_fails_in_metadata(automatic_fixes=False,
                                       check_level=CheckLevels.RELAXED)
 
     def test_check_missing_lat_relaxed_flag(self):
-        """Test check fails for missing latitude with --cmor-check relaxed"""
+        """Test check fails for missing latitude with --cmor-check relaxed."""
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('latitude')
         self._check_fails_in_metadata(automatic_fixes=False,
                                       check_level=CheckLevels.RELAXED)
 
     def test_check_missing_time_relaxed_flag(self):
-        """Test check fails for missing latitude with --cmor-check relaxed"""
+        """Test check fails for missing latitude with --cmor-check relaxed."""
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('time')
         self._check_fails_in_metadata(automatic_fixes=False,
@@ -505,7 +529,7 @@ class TestCMORCheck(unittest.TestCase):
 
     def test_check_missing_coord_relaxed_flag(self):
         """Test check reports warning for missing coord other than lat and lon
-        with --cmor-check relaxed"""
+        with --cmor-check relaxed."""
         self.var_info.coordinates.update(
             {'height2m': CoordinateInfoMock('height2m')}
         )
@@ -513,29 +537,37 @@ class TestCMORCheck(unittest.TestCase):
                                          check_level=CheckLevels.RELAXED)
 
     def test_check_bad_var_standard_name_none_flag(self):
-        """Test check reports warning for a bad variable standard_name with
-        --cmor-check ignore."""
+        """Test check reports warning for a bad variable standard_name with.
+
+        --cmor-check ignore.
+        """
         self.cube.standard_name = 'wind_speed'
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.IGNORE)
 
     def test_check_bad_var_long_name_none_flag(self):
-        """Test check reports warning for a bad variable long_name with
-        --cmor-check ignore."""
+        """Test check reports warning for a bad variable long_name with.
+
+        --cmor-check ignore.
+        """
         self.cube.long_name = "Near-Surface Wind Speed"
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.IGNORE)
 
     def test_check_bad_var_units_none_flag(self):
-        """Test check reports warning for a bad variable unit with
-        --cmor-check ignore."""
+        """Test check reports warning for a bad variable unit with.
+
+        --cmor-check ignore.
+        """
         self.cube.units = "kg"
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.IGNORE)
 
     def test_check_bad_attributes_none_flag(self):
-        """Test check reports warning for a bad variable attribute with
-        --cmor-check ignore."""
+        """Test check reports warning for a bad variable attribute with.
+
+        --cmor-check ignore.
+        """
         self.var_info.standard_name = "surface_upward_latent_heat_flux"
         self.var_info.positive = "up"
         self.cube = self.get_cube(self.var_info)
@@ -544,8 +576,10 @@ class TestCMORCheck(unittest.TestCase):
                                          check_level=CheckLevels.IGNORE)
 
     def test_check_bad_rank_none_flag(self):
-        """Test check reports warning for a bad variable rank with
-        --cmor-check ignore."""
+        """Test check reports warning for a bad variable rank with.
+
+        --cmor-check ignore.
+        """
         lat = iris.coords.AuxCoord.from_coord(self.cube.coord('latitude'))
         self.cube.remove_coord('latitude')
         self.cube.add_aux_coord(lat, self.cube.coord_dims('longitude'))
@@ -553,32 +587,38 @@ class TestCMORCheck(unittest.TestCase):
                                          check_level=CheckLevels.IGNORE)
 
     def test_check_bad_coord_standard_name_none_flag(self):
-        """Test check reports warning for bad coord var_name with
-        --cmor-check ignore."""
+        """Test check reports warning for bad coord var_name with.
+
+        --cmor-check ignore.
+        """
         self.var_info.table_type = 'CMIP5'
         self.cube.coord('longitude').var_name = 'bad_name'
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.IGNORE)
 
     def test_check_missing_lon_none_flag(self):
-        """Test check reports warning for missing longitude with
-        --cmor-check ignore"""
+        """Test check reports warning for missing longitude with.
+
+        --cmor-check ignore
+        """
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('longitude')
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.IGNORE)
 
     def test_check_missing_lat_none_flag(self):
-        """Test check reports warning for missing latitude with
-        --cmor-check ignore"""
+        """Test check reports warning for missing latitude with.
+
+        --cmor-check ignore
+        """
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('latitude')
         self._check_warnings_on_metadata(automatic_fixes=False,
                                          check_level=CheckLevels.IGNORE)
 
     def test_check_missing_time_none_flag(self):
-        """Test check reports warning for missing time
-        with --cmor-check ignore"""
+        """Test check reports warning for missing time with --cmor-check
+        ignore."""
         self.var_info.table_type = 'CMIP5'
         self.cube.remove_coord('time')
         self._check_warnings_on_metadata(automatic_fixes=False,
@@ -586,7 +626,7 @@ class TestCMORCheck(unittest.TestCase):
 
     def test_check_missing_coord_none_flag(self):
         """Test check reports warning for missing coord other than lat, lon and
-        time with --cmor-check ignore"""
+        time with --cmor-check ignore."""
         self.var_info.coordinates.update(
             {'height2m': CoordinateInfoMock('height2m')}
         )
@@ -620,11 +660,10 @@ class TestCMORCheck(unittest.TestCase):
         self.assertTrue(checker.has_debug_messages())
 
     def test_non_requested(self):
-        """
-        Warning if requested values are not present.
+        """Warning if requested values are not present.
 
-        Check issue a warning if a values requested
-        for a coordinate are not correct in the metadata step
+        Check issue a warning if a values requested for a coordinate are
+        not correct in the metadata step
         """
         coord = self.cube.coord('air_pressure')
         values = np.linspace(0, 40, len(coord.points))
@@ -648,11 +687,10 @@ class TestCMORCheck(unittest.TestCase):
             self.cube.coord('air_pressure').points, reference)
 
     def test_requested_str_values(self):
-        """
-        Warning if requested values are not present.
+        """Warning if requested values are not present.
 
-        Check issue a warning if a values requested
-        for a coordinate are not correct in the metadata step
+        Check issue a warning if a values requested for a coordinate are
+        not correct in the metadata step
         """
         region_coord = CoordinateInfoMock('basin')
         region_coord.standard_name = 'region'
@@ -905,7 +943,7 @@ class TestCMORCheck(unittest.TestCase):
         self._check_fails_in_metadata()
 
     def test_bad_out_name_multidim_latitude(self):
-        """Warning if multidimensional lat has bad var_name at metadata"""
+        """Warning if multidimensional lat has bad var_name at metadata."""
         self.var_info.table_type = 'CMIP6'
         self.cube.remove_coord('latitude')
         self.cube.add_aux_coord(
@@ -920,7 +958,7 @@ class TestCMORCheck(unittest.TestCase):
         self._check_debug_messages_on_metadata()
 
     def test_bad_out_name_multidim_longitude(self):
-        """Warning if multidimensional lon has bad var_name at metadata"""
+        """Warning if multidimensional lon has bad var_name at metadata."""
         self.var_info.table_type = 'CMIP6'
         self.cube.remove_coord('longitude')
         self.cube.add_aux_coord(
@@ -935,7 +973,7 @@ class TestCMORCheck(unittest.TestCase):
         self._check_debug_messages_on_metadata(automatic_fixes=True)
 
     def test_bad_bounds_in_multidim_longitude(self):
-        """Warning if multidimensional lon has bad var_name at metadata"""
+        """Warning if multidimensional lon has bad var_name at metadata."""
         self.var_info.table_type = 'CMIP6'
         self.cube.remove_coord('longitude')
         lons = np.reshape(np.linspace(180, 540, num=20*20), (20, 20))
@@ -965,19 +1003,19 @@ class TestCMORCheck(unittest.TestCase):
         self._check_debug_messages_on_metadata()
 
     def test_bad_out_name_onedim_latitude(self):
-        """Warning if onedimensional lat has bad var_name at metadata"""
+        """Warning if onedimensional lat has bad var_name at metadata."""
         self.var_info.table_type = 'CMIP6'
         self.cube.coord('latitude').var_name = 'bad_name'
         self._check_fails_in_metadata()
 
     def test_bad_out_name_onedim_longitude(self):
-        """Warning if onedimensional lon has bad var_name at metadata"""
+        """Warning if onedimensional lon has bad var_name at metadata."""
         self.var_info.table_type = 'CMIP6'
         self.cube.coord('longitude').var_name = 'bad_name'
         self._check_fails_in_metadata()
 
     def test_bad_out_name_other(self):
-        """Warning if general coordinate has bad var_name at metadata"""
+        """Warning if general coordinate has bad var_name at metadata."""
         self.var_info.table_type = 'CMIP6'
         self.cube.coord('time').var_name = 'bad_name'
         self._check_fails_in_metadata()
@@ -1054,7 +1092,7 @@ class TestCMORCheck(unittest.TestCase):
         self._check_fails_in_metadata(frequency='wrong_freq')
 
     def test_time_bounds(self):
-        """Test time bounds are guessed for all frequencies"""
+        """Test time bounds are guessed for all frequencies."""
         freqs = ['hr', '3hr', '6hr', 'day', 'mon', 'yr', 'dec']
         guessed = []
         for freq in freqs:
@@ -1067,7 +1105,7 @@ class TestCMORCheck(unittest.TestCase):
         assert len(guessed) == len(freqs)
 
     def test_no_time_bounds(self):
-        """Test time bounds are not guessed for instantaneous data"""
+        """Test time bounds are not guessed for instantaneous data."""
         self.var_info.coordinates['time'].must_have_bounds = 'no'
         self.var_info.coordinates['time1'] = (
             self.var_info.coordinates.pop('time'))
@@ -1092,8 +1130,7 @@ class TestCMORCheck(unittest.TestCase):
                  var_info,
                  set_time_units="days since 1850-1-1 00:00:00",
                  frequency=None):
-        """
-        Create a cube based on a specification.
+        """Create a cube based on a specification.
 
         Parameters
         ----------
@@ -1107,7 +1144,6 @@ class TestCMORCheck(unittest.TestCase):
         Returns
         -------
         iris.cube.Cube
-
         """
         coords = []
         scalar_coords = []

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -439,8 +439,10 @@ class TestCMORCheck(unittest.TestCase):
         self._check_fails_in_metadata(automatic_fixes=False)
 
     def test_check_missing_coord_strict_flag(self):
-        """Test check fails for missing coord other than lat and lon with
-        --cmor-check strict."""
+        """Test check fails for missing coord other than lat and lon with.
+
+        --cmor-check strict.
+        """
         self.var_info.coordinates.update(
             {'height2m': CoordinateInfoMock('height2m')}
         )

--- a/tests/unit/experimental/test_config.py
+++ b/tests/unit/experimental/test_config.py
@@ -23,7 +23,8 @@ from esmvalcore.experimental.config._config_validators import (
     validate_string_or_none,
 )
 from esmvalcore.experimental.config._validated_config import (
-    InvalidConfigParameter, )
+    InvalidConfigParameter,
+)
 
 
 def generate_validator_testcases(valid):

--- a/tests/unit/preprocessor/_derive/test_toz.py
+++ b/tests/unit/preprocessor/_derive/test_toz.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import esmvalcore.preprocessor._derive.toz as toz
+
 from .test_co2s import get_coord_spec, get_ps_cube
 
 

--- a/tests/unit/preprocessor/_detrend/test_detrend.py
+++ b/tests/unit/preprocessor/_detrend/test_detrend.py
@@ -4,11 +4,10 @@ import unittest
 
 import iris
 import iris.coords
-from iris.cube import Cube
 import numpy as np
 import pytest
 from cf_units import Unit
-
+from iris.cube import Cube
 from numpy.testing import assert_array_almost_equal
 
 from esmvalcore.preprocessor._detrend import detrend

--- a/tests/unit/preprocessor/_mapping/test_mapping.py
+++ b/tests/unit/preprocessor/_mapping/test_mapping.py
@@ -6,8 +6,11 @@ import iris
 import numpy as np
 
 import tests
-from esmvalcore.preprocessor._mapping import (get_empty_data, map_slices,
-                                              ref_to_dims_index)
+from esmvalcore.preprocessor._mapping import (
+    get_empty_data,
+    map_slices,
+    ref_to_dims_index,
+)
 
 
 class TestHelpers(tests.Test):

--- a/tests/unit/preprocessor/_mask/test_mask.py
+++ b/tests/unit/preprocessor/_mask/test_mask.py
@@ -2,17 +2,21 @@
 
 import unittest
 
-import numpy as np
-
 import iris
-import tests
+import numpy as np
 from cf_units import Unit
-from esmvalcore.preprocessor._mask import (_apply_fx_mask,
-                                           count_spells, _get_fx_mask,
-                                           mask_above_threshold,
-                                           mask_below_threshold,
-                                           mask_glaciated, mask_inside_range,
-                                           mask_outside_range)
+
+import tests
+from esmvalcore.preprocessor._mask import (
+    _apply_fx_mask,
+    _get_fx_mask,
+    count_spells,
+    mask_above_threshold,
+    mask_below_threshold,
+    mask_glaciated,
+    mask_inside_range,
+    mask_outside_range,
+)
 
 
 class Test(tests.Test):

--- a/tests/unit/preprocessor/_regrid/__init__.py
+++ b/tests/unit/preprocessor/_regrid/__init__.py
@@ -1,7 +1,4 @@
-"""
-Unit tests for the :mod:`esmvalcore.preprocessor.regrid` module.
-
-"""
+"""Unit tests for the :mod:`esmvalcore.preprocessor.regrid` module."""
 
 import iris
 import iris.fileformats
@@ -10,10 +7,7 @@ from iris.coords import AuxCoord, CellMethod, DimCoord
 
 
 def _make_vcoord(data, dtype=None):
-    """
-    Create a synthetic test vertical coordinate.
-
-    """
+    """Create a synthetic test vertical coordinate."""
     if dtype is None:
         dtype = np.dtype('int8')
 
@@ -44,10 +38,7 @@ def _make_cube(data,
                dim_coord=True,
                dtype=None,
                rotated=False):
-    """
-    Create a 3d synthetic test cube.
-
-    """
+    """Create a 3d synthetic test cube."""
     if dtype is None:
         dtype = np.dtype('int8')
 

--- a/tests/unit/preprocessor/_regrid/test__create_cube.py
+++ b/tests/unit/preprocessor/_regrid/test__create_cube.py
@@ -1,8 +1,5 @@
-"""
-Unit tests for the :func:`esmvalcore.preprocessor.regrid._create_cube`
-function.
-
-"""
+"""Unit tests for the :func:`esmvalcore.preprocessor.regrid._create_cube`
+function."""
 
 import unittest
 

--- a/tests/unit/preprocessor/_regrid/test__stock_cube.py
+++ b/tests/unit/preprocessor/_regrid/test__stock_cube.py
@@ -1,8 +1,5 @@
-"""
-Unit tests for the :func:`esmvalcore.preprocessor.regrid._stock_cube`
-function.
-
-"""
+"""Unit tests for the :func:`esmvalcore.preprocessor.regrid._stock_cube`
+function."""
 
 import unittest
 from unittest import mock
@@ -11,9 +8,15 @@ import iris
 import numpy as np
 
 import tests
-from esmvalcore.preprocessor._regrid import (_LAT_MAX, _LAT_MIN, _LAT_RANGE,
-                                             _LON_MAX, _LON_MIN, _LON_RANGE)
-from esmvalcore.preprocessor._regrid import _global_stock_cube
+from esmvalcore.preprocessor._regrid import (
+    _LAT_MAX,
+    _LAT_MIN,
+    _LAT_RANGE,
+    _LON_MAX,
+    _LON_MIN,
+    _LON_RANGE,
+    _global_stock_cube,
+)
 
 
 class Test(tests.Test):

--- a/tests/unit/preprocessor/test_runner.py
+++ b/tests/unit/preprocessor/test_runner.py
@@ -1,5 +1,8 @@
-from esmvalcore.preprocessor import (DEFAULT_ORDER, MULTI_MODEL_FUNCTIONS,
-                                     _get_itype)
+from esmvalcore.preprocessor import (
+    DEFAULT_ORDER,
+    MULTI_MODEL_FUNCTIONS,
+    _get_itype,
+)
 
 
 def test_first_argument_name():

--- a/tests/unit/test_iris_io.py
+++ b/tests/unit/test_iris_io.py
@@ -41,8 +41,7 @@ def create_regular_cube():
 
 
 def test_iris_save_with_lazy_coordinate(tmp_path):
-    """
-    Test saving a cube with fully lazy coords and data.
+    """Test saving a cube with fully lazy coords and data.
 
     Motivated by https://github.com/SciTools/iris/issues/4599
     """
@@ -56,8 +55,7 @@ def test_iris_save_with_lazy_coordinate(tmp_path):
 
 
 def test_iris_save_with_regular_coordinate(tmp_path):
-    """
-    Test saving a cube with numpy array coords and data.
+    """Test saving a cube with numpy array coords and data.
 
     Motivated by https://github.com/SciTools/iris/issues/4599
     """

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -1,20 +1,19 @@
-"""Checks to ensure that files follow the naming convention"""
+"""Checks to ensure that files follow the naming convention."""
 
 import os
 import unittest
 
 
 class TestNaming(unittest.TestCase):
-    """Test naming of files and folders"""
+    """Test naming of files and folders."""
 
     def setUp(self):
-        """Prepare tests"""
+        """Prepare tests."""
         folder = os.path.join(__file__, '..', '..', '..')
         self.esmvaltool_folder = os.path.abspath(folder)
 
     def test_windows_reserved_names(self):
-        """
-        Check that no file or folder uses a Windows reserved name
+        """Check that no file or folder uses a Windows reserved name.
 
         Files can not differ from a reserved name by the extension only
         """
@@ -37,8 +36,7 @@ class TestNaming(unittest.TestCase):
                 reserved_names.isdisjoint(without_extensions), error_msg)
 
     def test_avoid_casing_collisions(self):
-        """
-        Check that there are no names differing only in the capitalization
+        """Check that there are no names differing only in the capitalization.
 
         This includes folders differing from files
         """
@@ -52,8 +50,8 @@ class TestNaming(unittest.TestCase):
                 'capitalization'.format(dirpath))
 
     def test_no_namelist(self):
-        """
-        Check that there are no namelist references in file and folder names
+        """Check that there are no namelist references in file and folder
+        names.
 
         This will help us to avoid bad merges with stale branches
         """


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Loads of issues between `pytest-flake8` and `flake8` - they diverged proper, and it appears they started doing so since last year. We are currently pinning `flake8<5` to address an inherent issue in `pytest-flake8` but this is not a long term solution. This PR starts the case to run `flake8` as a pre-commit hook. See #1699 and refs inside it - loads other projects are dropping flake8 from the pytest env.


Closes #1699 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
