### PR TITLE
Core `_io.concatenate()` may fail due to case when one of the cubes is scalar - this fixes that

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -134,7 +134,6 @@ def load(file, callback=None, ignore_warnings=None):
     ------
     ValueError
         Cubes are empty.
-
     """
     logger.debug("Loading:\n%s", file)
     if ignore_warnings is None:
@@ -501,9 +500,10 @@ def _concatenate_overlapping_cubes(cubes):
                                     data_start_1.month, data_start_1.day,
                                     start_overlap.year, start_overlap.month,
                                     start_overlap.day)
+            # convert c1_delta scalar cube to vector cube, if needed
+            if c1_delta.data.shape == ():
+                c1_delta = iris.util.new_axis(c1_delta, scalar_coord="time")
             cubes = iris.cube.CubeList([c1_delta, cubes[1]])
-            logger.debug("Attempting concatenatenation of %s with %s",
-                         c1_delta, cubes[1])
             try:
                 cubes = [iris.cube.CubeList(cubes).concatenate_cube()]
             except iris.exceptions.ConcatenateError as ex:

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -504,6 +504,8 @@ def _concatenate_overlapping_cubes(cubes):
             if c1_delta.data.shape == ():
                 c1_delta = iris.util.new_axis(c1_delta, scalar_coord="time")
             cubes = iris.cube.CubeList([c1_delta, cubes[1]])
+            logger.debug("Attempting concatenatenation of %s with %s",
+                         c1_delta, cubes[1])
             try:
                 cubes = [iris.cube.CubeList(cubes).concatenate_cube()]
             except iris.exceptions.ConcatenateError as ex:

--- a/tests/integration/preprocessor/_io/test_concatenate.py
+++ b/tests/integration/preprocessor/_io/test_concatenate.py
@@ -14,7 +14,6 @@ from iris.aux_factory import (
 )
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube, CubeList
-from iris.exceptions import ConcatenateError
 
 from esmvalcore.preprocessor import _io
 
@@ -375,8 +374,10 @@ class TestConcatenate(unittest.TestCase):
                      var_name='sample',
                      dim_coords_and_dims=((time_coord_2, 0), ))
         cubes_single_ovlp = [cube2, cube1]
-        with self.assertRaises(ConcatenateError):
-            _io.concatenate(cubes_single_ovlp)
+        cubess = _io.concatenate(cubes_single_ovlp)
+        # this tests the scalar to vector cube conversion too
+        time_points = cubess.coord("time").core_points()
+        np.testing.assert_array_equal(time_points, [1., 1.5, 5., 7.])
 
     def test_concatenate_no_time_coords(self):
         """Test a more generic case."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1716

The introduction of scalar cubes in iris complicates a number of things, including our advanced concatenation mechanism - it is possible, as seen from the test case changed in this PR, that along the path of concatenation as we do it, one of the processed cubes that we use as intermediary laison to be *scalar* - then the whole show crumbles. I am not a fan of scalar cubes as they are defined in iris, but that's for another day. Anyway, this PR fixes that particular corner case, and adds a test case (converts the previous test case to a more meaningful one, that is). 

All started from @bouweandela 's [comment](https://github.com/ESMValGroup/ESMValCore/pull/1713#issuecomment-1236850683) - cheers, Bouwe! :beer: 
***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
