### PR TITLE
[TESTING ONLY] Unpin `netCDF4` and run a bunch of hourly tests

### DIFF
--- a/.github/workflows/run-tests-monitor.yml
+++ b/.github/workflows/run-tests-monitor.yml
@@ -1,16 +1,17 @@
 ---
-name: Monitor Tests
+name: Monitor Tests-NETCDF
 on:
   push:
     branches:
       - main
+      - unpin_netcdf
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:
   #  branches:
   #  - main
   schedule:
-    - cron: '0 0 * * *'  # nightly
+    - cron: '0 */1 * * *'  # nightly
 
 jobs:
   linux:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@
 # TODO: read the cron tasking documentation:
 # https://www.netiq.com/documentation/cloud-manager-2-5/ncm-reference/data/bexyssf.html
 
-name: Test
+name: Test-NETCDF
 
 # runs on a push on main and at the end of every day
 on:
@@ -21,13 +21,14 @@ on:
   push:
     branches:
       - main
+      - unpin_netcdf
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:
   #  branches:
   #  - main
   schedule:
-    - cron: '0 0 * * *'  # nightly
+    - cron: '0 */1 * * *'  # nightly
 
 jobs:
   linux:

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - geopy
   - iris>=3.2.1
   - nested-lookup
-  - netcdf4!=1.6.1  # github.com/ESMValGroup/ESMValCore/issues/1723
+  - netcdf4
   - pandas
   - pillow
   - pip!=21.3

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIREMENTS = {
         'jinja2',
         'nc-time-axis',  # needed by iris.plot
         'nested-lookup',
-        'netCDF4!=1.6.1',  # github.com/ESMValGroup/ESMValCore/issues/1723
+        'netCDF4',
         'numpy',
         'pandas',
         'pillow',


### PR DESCRIPTION
This is for **TESTING ONLY** - do not mind it! I have unpinned netCDF4 to pick up the latest (problematic) 1.6.1 and run hourly tests to be sure that the only one that craps the bed is the sample data cache one. FYI @bouweandela 