### PR TITLE
Restore support for scalar cubes to time selection preprocessor functions

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -6,8 +6,8 @@ constructing seasonal and area averages.
 import copy
 import datetime
 import logging
-from warnings import filterwarnings
 from typing import Union
+from warnings import filterwarnings
 
 import dask.array as da
 import iris
@@ -143,10 +143,14 @@ def _select_timeslice(
     """Slice a cube along its time axis."""
     if select.any():
         coord = cube.coord('time')
-        time_dim = cube.coord_dims(coord)[0]
-        slices = tuple(select if i == time_dim else slice(None)
-                       for i in range(cube.ndim))
-        cube_slice = cube[slices]
+        time_dims = cube.coord_dims(coord)
+        if time_dims:
+            time_dim = time_dims[0]
+            slices = tuple(select if i == time_dim else slice(None)
+                           for i in range(cube.ndim))
+            cube_slice = cube[slices]
+        else:
+            cube_slice = cube
     else:
         cube_slice = None
     return cube_slice

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -2041,6 +2041,17 @@ class TestResampleTime(tests.Test):
         expected = np.arange(12, 48, 24)
         assert_array_equal(result.data, expected)
 
+    def test_scalar_cube(self):
+        """Test average of a 1D field."""
+        data = np.arange(0, 2, 1)
+        times = np.arange(0, 2, 1)
+        cube = self._create_cube(data, times)
+        cube = cube[0]
+
+        result = resample_time(cube, hour=0)
+        expected = np.zeros((1,))
+        assert_array_equal(result.data, expected)
+
     def test_resample_hourly_to_monthly(self):
         """Test average of a 1D field."""
         data = np.arange(0, 24 * 60, 3)
@@ -2069,6 +2080,16 @@ class TestResampleTime(tests.Test):
         data = np.arange(0, 15 * 24, 24)
         times = np.arange(0, 15 * 24, 24)
         cube = self._create_cube(data, times)
+
+        with pytest.raises(ValueError):
+            resample_time(cube, day=16)
+
+    def test_resample_fails_scalar(self):
+        """Test that selecting something that is not in the data fails."""
+        data = np.arange(0, 2 * 24, 24)
+        times = np.arange(0, 2 * 24, 24)
+        cube = self._create_cube(data, times)
+        cube = cube[0]
 
         with pytest.raises(ValueError):
             resample_time(cube, day=16)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Restore support for scalar cubes to time selection preprocessor functions.

Closes #1743


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
