### PR TITLE
Remove deprecation warning for regrid schemes already deprecated for v2.7.0

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -394,15 +394,6 @@ The vertical interpolation currently supports the following schemes:
 * ``nearest_extrapolate``: Nearest-neighbour interpolation with nearest-neighbour
   extrapolation, i.e., extrapolation points will take their value from the
   nearest source point.
-
-.. note::
-   Previous versions of ESMValCore (<2.5.0) supported the schemes
-   ``linear_horizontal_extrapolate_vertical`` and
-   ``nearest_horizontal_extrapolate_vertical``. These schemes have been renamed
-   to ``linear_extrapolate`` and ``nearest_extrapolate``, respectively, in
-   version 2.5.0 and are identical to the new schemes. Support for the old
-   names will be removed in version 2.7.0.
-
 * See also :func:`esmvalcore.preprocessor.extract_levels`.
 * See also :func:`esmvalcore.preprocessor.get_cmor_levels`.
 

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -17,8 +17,6 @@ from geopy.geocoders import Nominatim
 from iris.analysis import AreaWeighted, Linear, Nearest, UnstructuredNearest
 from iris.util import broadcast_to_shape
 
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning
-
 from ..cmor._fixes.shared import add_altitude_from_plev, add_plev_from_altitude
 from ..cmor.fix import fix_file, fix_metadata
 from ..cmor.table import CMOR_TABLES

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -860,21 +860,6 @@ def parse_vertical_scheme(scheme):
     (str, str)
         A tuple containing the interpolation and extrapolation scheme.
     """
-    # Issue warning when deprecated schemes are used
-    deprecated_schemes = {
-        'linear_horizontal_extrapolate_vertical': 'linear_extrapolate',
-        'nearest_horizontal_extrapolate_vertical': 'nearest_extrapolate',
-    }
-    if scheme in deprecated_schemes:
-        new_scheme = deprecated_schemes[scheme]
-        deprecation_msg = (
-            f"The vertical regridding scheme ``{scheme}`` has been deprecated "
-            f"in ESMValCore version 2.5.0 and is scheduled for removal in "
-            f"version 2.7.0. It has been renamed to the identical scheme "
-            f"``{new_scheme}`` without any change in functionality.")
-        warnings.warn(deprecation_msg, ESMValCoreDeprecationWarning)
-        scheme = new_scheme
-
     # Check if valid scheme is given
     if scheme not in VERTICAL_SCHEMES:
         raise ValueError(

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -4,7 +4,6 @@ import importlib
 import logging
 import os
 import re
-import warnings
 from copy import deepcopy
 from decimal import Decimal
 from typing import Dict

--- a/tests/unit/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_levels.py
@@ -61,19 +61,6 @@ class Test(tests.Test):
             interpolation, extrapolation = parse_vertical_scheme(scheme)
             assert interpolation, extrapolation == reference[scheme]
 
-        # Deprecated schemes (remove in v2.7)
-        deprecated_references = {
-            'linear_horizontal_extrapolate_vertical': ('linear', 'nearest'),
-            'nearest_horizontal_extrapolate_vertical': ('nearest', 'nearest'),
-        }
-        for scheme in deprecated_references:
-            warn_msg = (
-                "`` has been deprecated in ESMValCore version 2.5.0 and is "
-                "scheduled for removal in version 2.7.0. It has been renamed "
-                "to the identical scheme ``")
-            with pytest.warns(ESMValCoreDeprecationWarning, match=warn_msg):
-                interp, extrap = parse_vertical_scheme(scheme)
-            assert interp, extrap == deprecated_references[scheme]
 
     def test_nop__levels_match(self):
         vcoord = _make_vcoord(self.z, dtype=self.dtype)

--- a/tests/unit/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_levels.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import iris
 import numpy as np
-import pytest
 from numpy import ma
 
 import tests

--- a/tests/unit/preprocessor/_regrid/test_extract_levels.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_levels.py
@@ -10,7 +10,6 @@ import pytest
 from numpy import ma
 
 import tests
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 from esmvalcore.preprocessor._regrid import (
     _MDI,
     VERTICAL_SCHEMES,
@@ -60,7 +59,6 @@ class Test(tests.Test):
         for scheme in self.schemes:
             interpolation, extrapolation = parse_vertical_scheme(scheme)
             assert interpolation, extrapolation == reference[scheme]
-
 
     def test_nop__levels_match(self):
         vcoord = _make_vcoord(self.z, dtype=self.dtype)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Blast! Nearly forgot about these guys :no_bicycles: 

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
