### PR TITLE
Fix calculation of precipitation flux in EMAC on-the-fly CMORizer

### DIFF
--- a/esmvalcore/_config/extra_facets/emac-mappings.yml
+++ b/esmvalcore/_config/extra_facets/emac-mappings.yml
@@ -65,7 +65,7 @@ EMAC:
     od550aer:
       raw_name: [aot_opt_TOT_550_total_cav, aot_opt_TOT_550_total_ave]
       channel: AERmon
-    pr:  # derived from aprl_*, aprc_*, aprs_*
+    pr:  # derived from aprl_*, aprc_*
       channel: Amon
     prc:
       raw_name: [aprc_cav, aprc_ave]

--- a/esmvalcore/cmor/_fixes/emac/emac.py
+++ b/esmvalcore/cmor/_fixes/emac/emac.py
@@ -246,8 +246,7 @@ class Pr(EmacFix):
         """Fix metadata."""
         cube = (
             self.get_cube(cubes, var_name=['aprl_cav', 'aprl_ave']) +
-            self.get_cube(cubes, var_name=['aprc_cav', 'aprc_ave']) +
-            self.get_cube(cubes, var_name=['aprs_cav', 'aprs_ave'])
+            self.get_cube(cubes, var_name=['aprc_cav', 'aprc_ave'])
         )
         cube.var_name = self.vardef.short_name
         return CubeList([cube])

--- a/tests/integration/cmor/_fixes/emac/test_emac.py
+++ b/tests/integration/cmor/_fixes/emac/test_emac.py
@@ -1105,10 +1105,8 @@ def test_pr_fix(cubes_2d):
     """Test fix."""
     cubes_2d[0].var_name = 'aprl_cav'
     cubes_2d[1].var_name = 'aprc_cav'
-    cubes_2d[2].var_name = 'aprs_cav'
     cubes_2d[0].units = 'kg m-2 s-1'
     cubes_2d[1].units = 'kg m-2 s-1'
-    cubes_2d[2].units = 'kg m-2 s-1'
     vardef = get_var_info('EMAC', 'Amon', 'pr')
     extra_facets = get_extra_facets('EMAC', 'EMAC', 'Amon', 'pr', ())
     fix = Pr(vardef, extra_facets=extra_facets)
@@ -1125,7 +1123,7 @@ def test_pr_fix(cubes_2d):
     assert cube.units == 'kg m-2 s-1'
     assert 'positive' not in cube.attributes
 
-    np.testing.assert_allclose(cube.data, [[[3.0]]])
+    np.testing.assert_allclose(cube.data, [[[2.0]]])
 
 
 def test_get_prc_fix():


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

A colleague of us informed us about a slight error in the calculation of the precipitation rate in EMAC. It should be aprc + aprl, right now we use aprc + aprl + aprs. This PR fixes that.

@valeriupredoi it would be really nice if this PR made it into the new relaese, so our colleagues can use it with the Levante module (which always uses the latest version). Since it's just a very minor chance I hope that's not a problem. Cheers! 🍺 

***


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
