### PR TITLE
suppress installing and reinstalling deps with pip at readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,18 +10,14 @@ build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-4.10"
+  jobs:
+    post_create_environment:
+      - pip install -e .[develop]
 
 # Declare the requirements required to build your docs
 conda:
   environment:
     environment.yml
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - doc
 
 # Build documentation in the doc directory with Sphinx
 sphinx:


### PR DESCRIPTION
sister PR to https://github.com/ESMValGroup/ESMValTool/pull/2913

### Motivation

Readthedocs builds use `pip install --upgrade --upgrade-strategy eager` to install and eventually reinstall everything from the env via pip - this is discussed in https://github.com/readthedocs/readthedocs.org/issues/8890 and is not something good for many reasons, one of them, and a very recent and pertinent one is that the build will chuck a wobbly if the package versions differ from conda-forge to pypi.

### Method

Use jobs with key names, here post env creation job

### Docs output