### PR TITLE
Create a session directory with suffix "-1", "-2", etc if it already exists

### DIFF
--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -392,13 +392,28 @@ class ESMValTool():
 
         self._run(recipe, session)
 
+    @staticmethod
+    def _create_session_dir(session):
+        """Create `session.session_dir` or an alternative if it exists."""
+        from .exceptions import RecipeError
+
+        session_dir = session.session_dir
+        for suffix in range(1, 1000):
+            try:
+                session_dir.mkdir(parents=True)
+            except FileExistsError:
+                session_dir = Path(f"{session.session_dir}-{suffix}")
+            else:
+                session.session_name = session_dir.name
+                return
+
+        raise RecipeError(
+            f"Output directory '{session.session_dir}' already exists and"
+            " unable to find alternative, aborting to prevent data loss.")
+
     def _run(self, recipe: Path, session) -> None:
         """Run `recipe` using `session`."""
-        # Create run dir
-        if session.session_dir.exists():
-            print(f"ERROR: output directory {session.session_dir} already"
-                  " exists, aborting to prevent data loss")
-        session.session_dir.mkdir(parents=True)
+        self._create_session_dir(session)
         session.run_dir.mkdir()
 
         # configure logging

--- a/tests/unit/main/test_esmvaltool.py
+++ b/tests/unit/main/test_esmvaltool.py
@@ -12,6 +12,7 @@ import esmvalcore.config._logging
 import esmvalcore.esgf
 from esmvalcore import __version__
 from esmvalcore._main import HEADER, ESMValTool
+from esmvalcore.exceptions import RecipeError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -140,6 +141,17 @@ def test_run_session_dir_exists(session):
     session_dir = session.session_dir
     program._create_session_dir(session)
     assert session.session_name == f"{session_dir.name}-1"
+
+
+def test_run_session_dir_exists_alternative_fails(mocker, session):
+    mocker.patch.object(
+        esmvalcore._main.Path,
+        'mkdir',
+        side_effect=FileExistsError,
+    )
+    program = ESMValTool()
+    with pytest.raises(RecipeError):
+        program._create_session_dir(session)
 
 
 def test_clean_preproc_dir(session):

--- a/tests/unit/main/test_esmvaltool.py
+++ b/tests/unit/main/test_esmvaltool.py
@@ -134,11 +134,12 @@ def test_run(mocker, session, offline):
     )
 
 
-def test_run_fail_session_dir_exists(session):
+def test_run_session_dir_exists(session):
     program = ESMValTool()
     session.session_dir.mkdir(parents=True)
-    with pytest.raises(FileExistsError):
-        program._run(Path('/path/to/recipe_test.yml'), session)
+    session_dir = session.session_dir
+    program._create_session_dir(session)
+    assert session.session_name == f"{session_dir.name}-1"
 
 
 def test_clean_preproc_dir(session):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

If the output directory already exists the tool would stop. Now it will try several alternatives by adding a suffix `-1`, `-2,`, etc before giving up. This problem occurs when you try to run multiple recipes with the same name in parallel.


Closes #1817

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
