### PR TITLE
Update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ exclude: |
   ^esmvalcore/preprocessor/ne_masks/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -19,33 +19,33 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/adrienverge/yamllint
-    rev: 'v1.26.0'
+    rev: 'v1.28.0'
     hooks:
       - id: yamllint
   - repo: https://github.com/codespell-project/codespell
-    rev: 'v2.0.0'
+    rev: 'v2.2.2'
     hooks:
       - id: codespell
   - repo: https://github.com/PyCQA/isort
-    rev: '5.7.0'
+    rev: '5.10.1'
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: 'v0.30.0'
+    rev: 'v0.32.0'
     hooks:
       - id: yapf
-        # see https://github.com/google/yapf/issues/744
-        args: ["--style={based_on_style: pep8, blank_line_before_nested_class_or_def: True}"]
+        additional_dependencies:
+          - 'toml'
   - repo: https://github.com/myint/docformatter
-    rev: 'v1.4'
+    rev: 'v1.5.0'
     hooks:
       - id: docformatter
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.4'
+  - repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.990'
+    rev: 'v0.991'
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Update the pre-commit configuration by running `pre-commit autoupdate` and fixing remaining issues. This should help to make sure that our pre-commit hooks are similar to the tools that get pulled in when doing a development installation.

For exact similarity, we could consider pinning some of the tools (especially formatting tools like docformatter, isort, yapf), but this has the downside that we then need to regularly update those pins. It would make sense to do that and then also update all code, but somehow it seems like it is never quite the right time to do that because there is always someone working on large changes (me in this case in #1609) that would lead to a pretty horrible merge conflict.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
