### PR TITLE
Fix severe bug in `mask_fillvalues`

### DIFF
--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -271,7 +271,7 @@ def _get_geometries_from_shp(shapefilename):
     # Index 0 grabs the lowest resolution mask (no zoom)
     geometries = list(reader.geometries())
     if not geometries:
-        msg = f"Could not find any geometry in {shapefilename}"
+        msg = "Could not find any geometry in {}".format(shapefilename)
         raise ValueError(msg)
 
     # TODO might need this for a later, more enhanced, version

--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -269,9 +269,9 @@ def _get_geometries_from_shp(shapefilename):
     """Get the mask geometries out from a shapefile."""
     reader = shpreader.Reader(shapefilename)
     # Index 0 grabs the lowest resolution mask (no zoom)
-    geometries = [contour for contour in reader.geometries()]
+    geometries = list(reader.geometries)
     if not geometries:
-        msg = "Could not find any geometry in {}".format(shapefilename)
+        msg = f"Could not find any geometry in {shapefilename}"
         raise ValueError(msg)
 
     # TODO might need this for a later, more enhanced, version
@@ -377,7 +377,7 @@ def count_spells(data, threshold, axis, spell_length):
         axis += data.ndim
     # Threshold the data to find the 'significant' points.
     if not threshold:
-        data_hits = da.ones_like(data)
+        data_hits = np.ones_like(data)
     else:
         data_hits = data > float(threshold)
     # Make an array with data values "windowed" along the time axis.
@@ -645,7 +645,8 @@ def mask_fillvalues(products,
                     used.add(product)
             else:
                 raise NotImplementedError(
-                    "Unable to handle {} dimensional data".format(n_dims))
+                    f"Unable to handle {n_dims} dimensional data"
+                )
 
     if np.any(combined_mask):
         logger.debug("Applying fillvalues mask")
@@ -673,8 +674,9 @@ def _get_fillvalues_mask(cube, threshold_fraction, min_value, time_window):
     # basic checks
     if threshold_fraction < 0 or threshold_fraction > 1.0:
         raise ValueError(
-            "Fraction of missing values {} should be between 0 and 1.0".format(
-                threshold_fraction))
+            f"Fraction of missing values {threshold_fraction} should be "
+            f"between 0 and 1.0"
+        )
     nr_time_points = len(cube.coord('time').points)
     if time_window > nr_time_points:
         msg = "Time window (in time units) larger than total time span. Stop."

--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -269,7 +269,7 @@ def _get_geometries_from_shp(shapefilename):
     """Get the mask geometries out from a shapefile."""
     reader = shpreader.Reader(shapefilename)
     # Index 0 grabs the lowest resolution mask (no zoom)
-    geometries = list(reader.geometries)
+    geometries = list(reader.geometries())
     if not geometries:
         msg = f"Could not find any geometry in {shapefilename}"
         raise ValueError(msg)
@@ -377,7 +377,7 @@ def count_spells(data, threshold, axis, spell_length):
         axis += data.ndim
     # Threshold the data to find the 'significant' points.
     if not threshold:
-        data_hits = np.ones_like(data)
+        data_hits = np.ones_like(data, dtype=bool)
     else:
         data_hits = data > float(threshold)
     # Make an array with data values "windowed" along the time axis.

--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -169,8 +169,8 @@ def mask_landsea(cube, mask_out, always_use_ne_mask=False):
 def mask_landseaice(cube, mask_out):
     """Mask out either landsea (combined) or ice.
 
-    Function that masks out either landsea (land and seas) or ice (Antarctica
-    and Greenland and some wee glaciers).
+    Function that masks out either landsea (land and seas) or ice (Antarctica,
+    Greenland and some glaciers).
 
     It uses dedicated ancillary variables (sftgif).
 
@@ -377,7 +377,7 @@ def count_spells(data, threshold, axis, spell_length):
         axis += data.ndim
     # Threshold the data to find the 'significant' points.
     if not threshold:
-        data_hits = data
+        data_hits = da.ones_like(data)
     else:
         data_hits = data > float(threshold)
     # Make an array with data values "windowed" along the time axis.


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR fixes a severe bug which lead to a wrong masking of data with `mask_fillvalues` if the data contains zeros. This has already been discussed [2 years ago](https://github.com/ESMValGroup/ESMValCore/issues/487#issuecomment-677732121) and has recently lead to problems.

I also fixed some prospector issues along the way.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Related to #487

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
