### PR TITLE
Fix LWP of ICON on-the-fly CMORizer

### DIFF
--- a/esmvalcore/cmor/_fixes/icon/icon.py
+++ b/esmvalcore/cmor/_fixes/icon/icon.py
@@ -312,6 +312,19 @@ class AllVars(IconFix):
         cube.add_dim_coord(index_coord, horizontal_idx)
 
 
+class Clwvi(IconFix):
+    """Fixes for ``clwvi``."""
+
+    def fix_metadata(self, cubes):
+        """Fix metadata."""
+        cube = (
+            self.get_cube(cubes, var_name='cllvi') +
+            self.get_cube(cubes, var_name='clivi')
+        )
+        cube.var_name = self.vardef.short_name
+        return CubeList([cube])
+
+
 Hur = SetUnitsTo1
 
 

--- a/esmvalcore/config/extra_facets/icon-mappings.yml
+++ b/esmvalcore/config/extra_facets/icon-mappings.yml
@@ -30,6 +30,7 @@ ICON:
     evspsbl: {var_type: atm_2d_ml}
     hfls: {var_type: atm_2d_ml}
     hfss: {var_type: atm_2d_ml}
+    lwp: {raw_name: cllvi, var_type: atm_2d_ml}
     pr: {var_type: atm_2d_ml}
     prw: {var_type: atm_2d_ml}
     ps: {var_type: atm_2d_ml}

--- a/esmvalcore/config/extra_facets/icon-mappings.yml
+++ b/esmvalcore/config/extra_facets/icon-mappings.yml
@@ -26,7 +26,7 @@ ICON:
     # 2D dynamical/meteorological variables
     clivi: {var_type: atm_2d_ml}
     clt: {var_type: atm_2d_ml}
-    clwvi: {raw_name: cllvi, var_type: atm_2d_ml}
+    clwvi: {var_type: atm_2d_ml}
     evspsbl: {var_type: atm_2d_ml}
     hfls: {var_type: atm_2d_ml}
     hfss: {var_type: atm_2d_ml}

--- a/tests/integration/cmor/_fixes/icon/test_icon.py
+++ b/tests/integration/cmor/_fixes/icon/test_icon.py
@@ -9,7 +9,7 @@ from iris import NameConstraint
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube, CubeList
 
-from esmvalcore.cmor._fixes.icon.icon import AllVars, Siconc, Siconca
+from esmvalcore.cmor._fixes.icon.icon import AllVars, Clwvi, Siconc, Siconca
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 from esmvalcore.config._config import get_extra_facets
@@ -324,19 +324,33 @@ def test_areacello_fix(cubes_grid):
     check_lat_lon(cube)
 
 
-# Test clwvi (for extra_facets)
+# Test clwvi (for extra fix)
 
 
 def test_get_clwvi_fix():
     """Test getting of fix."""
     fix = Fix.get_fixes('ICON', 'ICON', 'Amon', 'clwvi')
-    assert fix == [AllVars(None)]
+    assert fix == [Clwvi(None), AllVars(None)]
 
 
-def test_clwvi_fix(cubes_2d):
+def test_clwvi_fix(cubes_regular_grid):
     """Test fix."""
-    fix = get_allvars_fix('Amon', 'clwvi')
-    fixed_cubes = fix.fix_metadata(cubes_2d)
+    cubes = CubeList([
+        cubes_regular_grid[0].copy(),
+        cubes_regular_grid[0].copy()
+    ])
+    cubes[0].var_name = 'cllvi'
+    cubes[1].var_name = 'clivi'
+    cubes[0].units = '1e3 kg m-2'
+    cubes[1].units = '1e3 kg m-2'
+
+    vardef = get_var_info('ICON', 'Amon', 'clwvi')
+    extra_facets = get_extra_facets('ICON', 'ICON', 'Amon', 'clwvi', ())
+    clwvi_fix = Clwvi(vardef, extra_facets=extra_facets)
+    allvars_fix = get_allvars_fix('Amon', 'clwvi')
+
+    fixed_cubes = clwvi_fix.fix_metadata(cubes)
+    fixed_cubes = allvars_fix.fix_metadata(fixed_cubes)
 
     assert len(fixed_cubes) == 1
     cube = fixed_cubes[0]
@@ -344,6 +358,32 @@ def test_clwvi_fix(cubes_2d):
     assert cube.standard_name == ('atmosphere_mass_content_of_cloud_'
                                   'condensed_water')
     assert cube.long_name == 'Condensed Water Path'
+    assert cube.units == 'kg m-2'
+    assert 'positive' not in cube.attributes
+
+    np.testing.assert_allclose(cube.data, [[[0.0, 2000.0], [4000.0, 6000.0]]])
+
+
+# Test lwp (for extra_facets)
+
+
+def test_get_lwp_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('ICON', 'ICON', 'AERmon', 'lwp')
+    assert fix == [AllVars(None)]
+
+
+def test_lwp_fix(cubes_2d):
+    """Test fix."""
+    fix = get_allvars_fix('AERmon', 'lwp')
+    fixed_cubes = fix.fix_metadata(cubes_2d)
+
+    assert len(fixed_cubes) == 1
+    cube = fixed_cubes[0]
+    assert cube.var_name == 'lwp'
+    assert cube.standard_name == ('atmosphere_mass_content_of_cloud_liquid_'
+                                  'water')
+    assert cube.long_name == 'Liquid Water Path'
     assert cube.units == 'kg m-2'
     assert 'positive' not in cube.attributes
 

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -3650,12 +3650,11 @@ def test_dataset_to_file_derived_var(mock_get_input_files,
         'force_derivation': True,
         'frequency': 'mon',
         'mip': 'Amon',
-        'original_short_name': 'lwp',
+        'original_short_name': 'alb',
         'project': 'ICON',
-        'short_name': 'lwp',
+        'short_name': 'alb',
         'start_year': 1990,
         'timerange': '1990/2000',
-        'var_type': 'atm_2d_ml',
     }
     filename = _dataset_to_file(variable, config_user)
     assert filename == sentinel.out_file
@@ -3663,7 +3662,7 @@ def test_dataset_to_file_derived_var(mock_get_input_files,
 
     expect_required_var = {
         # Added by get_required
-        'short_name': 'clwvi',
+        'short_name': 'rsdscs',
         # Already present in variable
         'dataset': 'ICON',
         'derive': True,
@@ -3675,15 +3674,15 @@ def test_dataset_to_file_derived_var(mock_get_input_files,
         'project': 'ICON',
         'start_year': 1990,
         'timerange': '1990/2000',
-        'var_type': 'atm_2d_ml',
         # Added by _add_cmor_info
-        'long_name': 'Condensed Water Path',
+        'long_name': 'Surface Downwelling Clear-Sky Shortwave Radiation',
         'modeling_realm': ['atmos'],
-        'original_short_name': 'clwvi',
-        'standard_name': 'atmosphere_mass_content_of_cloud_condensed_water',
-        'units': 'kg m-2',
+        'original_short_name': 'rsdscs',
+        'standard_name':
+        'surface_downwelling_shortwave_flux_in_air_assuming_clear_sky',
+        'units': 'W m-2',
         # Added by _add_extra_facets
-        'raw_name': 'cllvi',
+        'var_type': 'atm_2d_ml',
     }
     mock_get_input_files.assert_called_with(expect_required_var, config_user)
     mock_data_availability.assert_called_once()
@@ -3699,20 +3698,19 @@ def test_get_derive_input_variables(patched_datafinder, config_user):
         'force_derivation': True,
         'frequency': 'mon',
         'mip': 'Amon',
-        'original_short_name': 'lwp',
+        'original_short_name': 'alb',
         'project': 'ICON',
-        'short_name': 'lwp',
+        'short_name': 'alb',
         'start_year': 1990,
         'timerange': '1990/2000',
-        'var_type': 'atm_2d_ml',
-        'variable_group': 'lwp_group',
+        'variable_group': 'alb_group',
     }]
     derive_input = _get_derive_input_variables(variables, config_user)
 
     expected_derive_input = {
-        'lwp_group_derive_input_clwvi': [{
+        'alb_group_derive_input_rsdscs': [{
             # Added by get_required
-            'short_name': 'clwvi',
+            'short_name': 'rsdscs',
             # Already present in variables
             'dataset': 'ICON',
             'derive': True,
@@ -3724,21 +3722,20 @@ def test_get_derive_input_variables(patched_datafinder, config_user):
             'project': 'ICON',
             'start_year': 1990,
             'timerange': '1990/2000',
-            'var_type': 'atm_2d_ml',
             # Added by _add_cmor_info
             'standard_name':
-            'atmosphere_mass_content_of_cloud_condensed_water',
-            'long_name': 'Condensed Water Path',
+            'surface_downwelling_shortwave_flux_in_air_assuming_clear_sky',
+            'long_name': 'Surface Downwelling Clear-Sky Shortwave Radiation',
             'modeling_realm': ['atmos'],
-            'original_short_name': 'clwvi',
-            'units': 'kg m-2',
+            'original_short_name': 'rsdscs',
+            'units': 'W m-2',
             # Added by _add_extra_facets
-            'raw_name': 'cllvi',
+            'var_type': 'atm_2d_ml',
             # Added by append
-            'variable_group': 'lwp_group_derive_input_clwvi',
-        }], 'lwp_group_derive_input_clivi': [{
+            'variable_group': 'alb_group_derive_input_rsdscs',
+        }], 'alb_group_derive_input_rsuscs': [{
             # Added by get_required
-            'short_name': 'clivi',
+            'short_name': 'rsuscs',
             # Already present in variables
             'dataset': 'ICON',
             'derive': True,
@@ -3750,15 +3747,17 @@ def test_get_derive_input_variables(patched_datafinder, config_user):
             'project': 'ICON',
             'start_year': 1990,
             'timerange': '1990/2000',
-            'var_type': 'atm_2d_ml',
             # Added by _add_cmor_info
-            'standard_name': 'atmosphere_mass_content_of_cloud_ice',
-            'long_name': 'Ice Water Path',
+            'standard_name':
+            'surface_upwelling_shortwave_flux_in_air_assuming_clear_sky',
+            'long_name': 'Surface Upwelling Clear-Sky Shortwave Radiation',
             'modeling_realm': ['atmos'],
-            'original_short_name': 'clivi',
-            'units': 'kg m-2',
+            'original_short_name': 'rsuscs',
+            'units': 'W m-2',
+            # Added by _add_extra_facets
+            'var_type': 'atm_2d_ml',
             # Added by append
-            'variable_group': 'lwp_group_derive_input_clivi',
+            'variable_group': 'alb_group_derive_input_rsuscs',
         }],
     }
     assert derive_input == expected_derive_input


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Currently, the ICON on-the-fly CMORizer derives liquid water path (LWP) as `clwvi` minus `clivi`. However, for ICON, LWP = `cliwvi`. This PR fixes that.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
