### PR TITLE
Removed unnecessary test that fails in iris 3.4.0

### DIFF
--- a/tests/integration/preprocessor/_regrid/test_regrid.py
+++ b/tests/integration/preprocessor/_regrid/test_regrid.py
@@ -264,22 +264,3 @@ class Test(tests.Test):
         # Make sure that output is a masked array with correct fill value
         # (= GLOBAL_FILL_VALUE)
         np.testing.assert_allclose(result.data.fill_value, GLOBAL_FILL_VALUE)
-
-    def test_regrid__unstructured_nearest_int(self):
-        """Test unstructured_nearest regridding with cube of ints."""
-        self.unstructured_grid_cube.data = np.full((3, 2, 2), 1, dtype=int)
-        result = regrid(self.unstructured_grid_cube,
-                        self.grid_for_unstructured_nearest,
-                        'unstructured_nearest')
-        expected = np.array([[[1]], [[1]], [[1]]])
-        np.testing.assert_array_equal(result.data, expected)
-
-        # Make sure that dtype is not preserved (since conversion from float to
-        # int would be necessary)
-        assert np.issubdtype(self.unstructured_grid_cube.dtype, np.integer)
-        assert result.dtype == np.float64
-
-        # Make sure that output is a masked array with correct fill value
-        # (= maximum int)
-        np.testing.assert_allclose(result.data.fill_value,
-                                   float(np.iinfo(int).max))


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR removes a test that [fails ](https://github.com/ESMValGroup/ESMValCore/actions/runs/3593600178/jobs/6050760969)after a bugfix that has been introduced with iris 3.4.0 (https://github.com/SciTools/iris/pull/5062). The tests that check that `dtype` is preserved are now located in iris and can be removed from our test suite.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
