### PR TITLE
[v2.7.1 bugfix release] remove unnecessary test in regrid to allow install of iris 3.4 - feature from PR 1846

### DIFF
--- a/tests/integration/preprocessor/_regrid/test_regrid.py
+++ b/tests/integration/preprocessor/_regrid/test_regrid.py
@@ -241,11 +241,6 @@ class Test(tests.Test):
         expected = np.array([[[1]], [[1]], [[1]]])
         np.testing.assert_array_equal(result.data, expected)
 
-        # Make sure that dtype is not preserved (since conversion from float to
-        # int would be necessary)
-        assert np.issubdtype(self.unstructured_grid_cube.dtype, np.integer)
-        assert result.dtype == np.float64
-
         # Make sure that output is a masked array with correct fill value
         # (= maximum int)
         np.testing.assert_allclose(result.data.fill_value,


### PR DESCRIPTION
Port feature (test fix that would fail with iris=3.4) from PR https://github.com/ESMValGroup/ESMValCore/pull/1846 to v2.5.1 bugfix release