### PR TITLE
[v2.7.1 bugfix release] Add sematic versioning: set the version number on the development branches to one minor version more than the previous release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools >= 40.6.0", "wheel", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+version_scheme = "release-branch-semver"
 
 [tool.pylint.main]
 jobs = 0


### PR DESCRIPTION
Porting changes by @bouweandela in #1854 to v2.7.1 bugfix release :beer: 