### PR TITLE
Update esmpy import for ESMF v8.4.0

### DIFF
--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -1,34 +1,41 @@
 # -*- coding: utf-8 -*-
 """Provides regridding for irregular grids."""
 
-import ESMF
+try:
+    import esmpy
+except ImportError as exc:
+    # Prior to v8.4.0, `esmpy`` could be imported as `ESMF`.
+    try:
+        import ESMF as esmpy  # noqa: N811
+    except ImportError:
+        raise exc
 import iris
 import numpy as np
 
 from ._mapping import get_empty_data, map_slices, ref_to_dims_index
 
-ESMF_MANAGER = ESMF.Manager(debug=False)
+ESMF_MANAGER = esmpy.Manager(debug=False)
 
 ESMF_LON, ESMF_LAT = 0, 1
 
 ESMF_REGRID_METHODS = {
-    'linear': ESMF.RegridMethod.BILINEAR,
-    'area_weighted': ESMF.RegridMethod.CONSERVE,
-    'nearest': ESMF.RegridMethod.NEAREST_STOD,
+    'linear': esmpy.RegridMethod.BILINEAR,
+    'area_weighted': esmpy.RegridMethod.CONSERVE,
+    'nearest': esmpy.RegridMethod.NEAREST_STOD,
 }
 
 MASK_REGRIDDING_MASK_VALUE = {
-    ESMF.RegridMethod.BILINEAR: np.array([1]),
-    ESMF.RegridMethod.CONSERVE: np.array([1]),
-    ESMF.RegridMethod.NEAREST_STOD: np.array([]),
+    esmpy.RegridMethod.BILINEAR: np.array([1]),
+    esmpy.RegridMethod.CONSERVE: np.array([1]),
+    esmpy.RegridMethod.NEAREST_STOD: np.array([]),
 }
 
 # ESMF_REGRID_METHODS = {
-#     'bilinear': ESMF.RegridMethod.BILINEAR,
-#     'patch': ESMF.RegridMethod.PATCH,
-#     'conserve': ESMF.RegridMethod.CONSERVE,
-#     'nearest_stod': ESMF.RegridMethod.NEAREST_STOD,
-#     'nearest_dtos': ESMF.RegridMethod.NEAREST_DTOS,
+#     'bilinear': esmpy.RegridMethod.BILINEAR,
+#     'patch': esmpy.RegridMethod.PATCH,
+#     'conserve': esmpy.RegridMethod.CONSERVE,
+#     'nearest_stod': esmpy.RegridMethod.NEAREST_STOD,
+#     'nearest_dtos': esmpy.RegridMethod.NEAREST_DTOS,
 # }
 
 
@@ -85,19 +92,19 @@ def get_grid(esmpy_lat, esmpy_lon,
         num_peri_dims = 1
     else:
         num_peri_dims = 0
-    grid = ESMF.Grid(np.array(esmpy_lat.shape),
-                     num_peri_dims=num_peri_dims,
-                     staggerloc=[ESMF.StaggerLoc.CENTER])
+    grid = esmpy.Grid(np.array(esmpy_lat.shape),
+                      num_peri_dims=num_peri_dims,
+                      staggerloc=[esmpy.StaggerLoc.CENTER])
     grid.get_coords(ESMF_LON)[...] = esmpy_lon
     grid.get_coords(ESMF_LAT)[...] = esmpy_lat
-    grid.add_coords([ESMF.StaggerLoc.CORNER])
+    grid.add_coords([esmpy.StaggerLoc.CORNER])
     grid_lon_corners = grid.get_coords(ESMF_LON,
-                                       staggerloc=ESMF.StaggerLoc.CORNER)
+                                       staggerloc=esmpy.StaggerLoc.CORNER)
     grid_lat_corners = grid.get_coords(ESMF_LAT,
-                                       staggerloc=ESMF.StaggerLoc.CORNER)
+                                       staggerloc=esmpy.StaggerLoc.CORNER)
     grid_lon_corners[...] = esmpy_lon_corners
     grid_lat_corners[...] = esmpy_lat_corners
-    grid.add_item(ESMF.GridItem.MASK, ESMF.StaggerLoc.CENTER)
+    grid.add_item(esmpy.GridItem.MASK, esmpy.StaggerLoc.CENTER)
     return grid
 
 
@@ -128,9 +135,9 @@ def cube_to_empty_field(cube):
     circular = is_lon_circular(lon)
     esmpy_coords = coords_iris_to_esmpy(lat, lon, circular)
     grid = get_grid(*esmpy_coords, circular=circular)
-    field = ESMF.Field(grid,
-                       name=cube.long_name,
-                       staggerloc=ESMF.StaggerLoc.CENTER)
+    field = esmpy.Field(grid,
+                        name=cube.long_name,
+                        staggerloc=esmpy.StaggerLoc.CENTER)
     return field
 
 
@@ -151,13 +158,13 @@ def regrid_mask_2d(src_data, regridding_arguments, mask_threshold):
     regrid_method = regridding_arguments['regrid_method']
     original_src_mask = np.ma.getmaskarray(src_data)
     src_field.data[...] = ~original_src_mask.T
-    src_mask = src_field.grid.get_item(ESMF.GridItem.MASK,
-                                       ESMF.StaggerLoc.CENTER)
+    src_mask = src_field.grid.get_item(esmpy.GridItem.MASK,
+                                       esmpy.StaggerLoc.CENTER)
     src_mask[...] = original_src_mask.T
-    center_mask = dst_field.grid.get_item(ESMF.GridItem.MASK,
-                                          ESMF.StaggerLoc.CENTER)
+    center_mask = dst_field.grid.get_item(esmpy.GridItem.MASK,
+                                          esmpy.StaggerLoc.CENTER)
     center_mask[...] = 0
-    mask_regridder = ESMF.Regrid(
+    mask_regridder = esmpy.Regrid(
         src_mask_values=MASK_REGRIDDING_MASK_VALUE[regrid_method],
         dst_mask_values=np.array([]),
         **regridding_arguments)
@@ -177,14 +184,14 @@ def build_regridder_2d(src_rep, dst_rep, regrid_method, mask_threshold):
         'srcfield': src_field,
         'dstfield': dst_field,
         'regrid_method': regrid_method,
-        'unmapped_action': ESMF.UnmappedAction.IGNORE,
+        'unmapped_action': esmpy.UnmappedAction.IGNORE,
         'ignore_degenerate': True,
     }
     dst_mask = regrid_mask_2d(src_rep.data,
                               regridding_arguments, mask_threshold)
-    field_regridder = ESMF.Regrid(src_mask_values=np.array([1]),
-                                  dst_mask_values=np.array([1]),
-                                  **regridding_arguments)
+    field_regridder = esmpy.Regrid(src_mask_values=np.array([1]),
+                                   dst_mask_values=np.array([1]),
+                                   **regridding_arguments)
 
     def regridder(src):
         """Regrid 2d for irregular grids."""

--- a/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
+++ b/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
@@ -90,11 +90,15 @@ MASK_REGRIDDING_MASK_VALUE = {
             MASK_REGRIDDING_MASK_VALUE)
 @mock.patch('esmvalcore.preprocessor._regrid_esmpy.ESMF_REGRID_METHODS',
             ESMF_REGRID_METHODS)
-@mock.patch('ESMF.Manager', mock.Mock)
-@mock.patch('ESMF.GridItem', MockGridItem)
-@mock.patch('ESMF.RegridMethod', MockRegridMethod)
-@mock.patch('ESMF.StaggerLoc', MockStaggerLoc)
-@mock.patch('ESMF.UnmappedAction', MockUnmappedAction)
+@mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.Manager', mock.Mock)
+@mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.GridItem',
+            MockGridItem)
+@mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.RegridMethod',
+            MockRegridMethod)
+@mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.StaggerLoc',
+            MockStaggerLoc)
+@mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.UnmappedAction',
+            MockUnmappedAction)
 class TestHelpers(tests.Test):
     """Unit tests for helper functions."""
 
@@ -199,7 +203,7 @@ class TestHelpers(tests.Test):
         self.scalar_coord = mock.Mock(iris.coords.AuxCoord,
                                       long_name='scalar_coord',
                                       ndim=1,
-                                      shape=(1,))
+                                      shape=(1, ))
         data_shape = lon_2d_points.shape
         raw_data = np.arange(np.prod(data_shape)).reshape(data_shape)
         mask = np.zeros(data_shape)
@@ -386,7 +390,8 @@ class TestHelpers(tests.Test):
             mock.call(0, staggerloc=mock.sentinel.sl_corner),
             mock.call(1, staggerloc=mock.sentinel.sl_corner),
         ]
-        with mock.patch('ESMF.Grid', MockGrid) as mg:
+        with mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.Grid',
+                        MockGrid) as mg:
             mg.get_coords.reset_mock()
             mg.add_coords.reset_mock()
             mg.add_item.reset_mock()
@@ -409,7 +414,8 @@ class TestHelpers(tests.Test):
             mock.call(0, staggerloc=mock.sentinel.sl_corner),
             mock.call(1, staggerloc=mock.sentinel.sl_corner),
         ]
-        with mock.patch('ESMF.Grid', MockGrid) as mg:
+        with mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.Grid',
+                        MockGrid) as mg:
             mg.get_coords.reset_mock()
             mg.add_coords.reset_mock()
             mg.add_item.reset_mock()
@@ -455,8 +461,8 @@ class TestHelpers(tests.Test):
         is_circ = is_lon_circular(self.lon_2d_non_circular)
         self.assertFalse(is_circ)
 
-    @mock.patch('ESMF.Grid', MockGrid)
-    @mock.patch('ESMF.Field')
+    @mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.Grid', MockGrid)
+    @mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.Field')
     @pytest.mark.skipif(sys.version_info.major == 3
                         and sys.version_info.minor == 9,
                         reason="bug in mock.py for Python 3.9.0 and 3.9.1")
@@ -478,7 +484,7 @@ class TestHelpers(tests.Test):
 
     @mock.patch('esmvalcore.preprocessor._regrid_esmpy.cube_to_empty_field',
                 mock_cube_to_empty_field)
-    @mock.patch('ESMF.Regrid')
+    @mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.Regrid')
     def test_build_regridder_2d_masked_data(self, mock_regrid):
         """Test building of 2d regridder for masked data."""
         mock_regrid.return_value = mock.Mock(return_value=mock.Mock(
@@ -518,7 +524,7 @@ class TestHelpers(tests.Test):
 
     @mock.patch('esmvalcore.preprocessor._regrid_esmpy.cube_to_empty_field',
                 mock_cube_to_empty_field)
-    @mock.patch('ESMF.Regrid')
+    @mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.Regrid')
     def test_regridder_2d_unmasked_data(self, mock_regrid):
         """Test regridder for unmasked 2d data."""
         field_regridder = mock.Mock(return_value=mock.Mock(data=self.data.T))
@@ -533,7 +539,7 @@ class TestHelpers(tests.Test):
 
     @mock.patch('esmvalcore.preprocessor._regrid_esmpy.cube_to_empty_field',
                 mock_cube_to_empty_field)
-    @mock.patch('ESMF.Regrid')
+    @mock.patch('esmvalcore.preprocessor._regrid_esmpy.esmpy.Regrid')
     def test_regridder_2d_masked_data(self, mock_regrid):
         """Test regridder for masked 2d data."""
         field_regridder = mock.Mock(return_value=mock.Mock(data=self.data.T))


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Related to #1870.


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
