### PR TITLE
Fix issue with no files found if timerange start/end differs in length

### DIFF
--- a/esmvalcore/esgf/_search.py
+++ b/esmvalcore/esgf/_search.py
@@ -175,8 +175,8 @@ def select_by_time(files, timerange):
             # just select everything.
             selection.append(file)
         else:
-            start_date, start = _truncate_dates(start_date, start)
-            end_date, end = _truncate_dates(end_date, end)
+            start_date, end = _truncate_dates(start_date, end)
+            end_date, start = _truncate_dates(end_date, start)
             if start <= end_date and end >= start_date:
                 selection.append(file)
 

--- a/esmvalcore/local.py
+++ b/esmvalcore/local.py
@@ -303,9 +303,8 @@ def _select_files(filenames, timerange):
         start_date, end_date = _parse_period(timerange)
         start, end = _get_start_end_date(filename)
 
-        start_date, start = _truncate_dates(start_date, start)
-        end_date, end = _truncate_dates(end_date, end)
-
+        start_date, end = _truncate_dates(start_date, end)
+        end_date, start = _truncate_dates(end_date, start)
         if start <= end_date and end >= start_date:
             selection.append(filename)
 

--- a/tests/unit/local/test_select_files.py
+++ b/tests/unit/local/test_select_files.py
@@ -1,3 +1,5 @@
+import pytest
+
 from esmvalcore.local import _select_files
 
 
@@ -20,7 +22,8 @@ def test_select_files():
     assert result == expected
 
 
-def test_select_files_different_length_start_end():
+@pytest.mark.parametrize('timerange', ['196201/1967', '1962/196706'])
+def test_select_files_different_length_start_end(timerange):
 
     files = [
         "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_195501-195912.nc",
@@ -29,7 +32,7 @@ def test_select_files_different_length_start_end():
         "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_197001-197412.nc",
     ]
 
-    result = _select_files(files, '196201/1967')
+    result = _select_files(files, timerange)
 
     expected = [
         "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_196001-196412.nc",

--- a/tests/unit/local/test_select_files.py
+++ b/tests/unit/local/test_select_files.py
@@ -20,6 +20,25 @@ def test_select_files():
     assert result == expected
 
 
+def test_select_files_different_length_start_end():
+
+    files = [
+        "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_195501-195912.nc",
+        "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_196001-196412.nc",
+        "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_196501-196912.nc",
+        "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_197001-197412.nc",
+    ]
+
+    result = _select_files(files, '196201/1967')
+
+    expected = [
+        "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_196001-196412.nc",
+        "pr_Amon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_196501-196912.nc",
+    ]
+
+    assert result == expected
+
+
 def test_select_files_monthly_resolution():
     """Test file selection works for monthly data."""
     files = [


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes  #1878


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
