### PR TITLE
Add `driver` and `sub_experiment` tags to generate dataset aliases

### DIFF
--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1253,8 +1253,8 @@ def _get_preprocessor_task(variables, profiles, config_user, task_name):
 class Recipe:
     """Recipe object."""
 
-    info_keys = ('project', 'activity', 'dataset', 'exp', 'ensemble',
-                 'version')
+    info_keys = ('project', 'activity', 'dataset', 'exp', 'sub_experiment',
+                 'ensemble', 'version')
     """List of keys to be used to compose the alias, ordered by priority."""
 
     def __init__(self,

--- a/esmvalcore/_recipe.py
+++ b/esmvalcore/_recipe.py
@@ -1253,8 +1253,8 @@ def _get_preprocessor_task(variables, profiles, config_user, task_name):
 class Recipe:
     """Recipe object."""
 
-    info_keys = ('project', 'activity', 'dataset', 'exp', 'sub_experiment',
-                 'ensemble', 'version')
+    info_keys = ('project', 'activity', 'driver', 'dataset', 'exp',
+                 'sub_experiment', 'ensemble', 'version')
     """List of keys to be used to compose the alias, ordered by priority."""
 
     def __init__(self,

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1769,7 +1769,7 @@ def test_alias_generation(tmp_path, patched_datafinder, config_user):
         diagnostics:
           diagnostic_name:
             variables:
-              ta:
+              pr:
                 project: CMIP5
                 mip: Amon
                 exp: historical
@@ -1779,6 +1779,8 @@ def test_alias_generation(tmp_path, patched_datafinder, config_user):
                 type: reanaly
                 tier: 2
                 version: latest
+                domain: EUR-11
+                rcm_version: 1
                 additional_datasets:
                   - {dataset: GFDL-CM3,  ensemble: r1i1p1}
                   - {dataset: EC-EARTH,  ensemble: r1i1p1}
@@ -1792,13 +1794,15 @@ def test_alias_generation(tmp_path, patched_datafinder, config_user):
                   - {project: CMIP6, activity: CMP, dataset: GF2, ensemble: r1}
                   - {project: CMIP6, activity: HRMP, dataset: EC, ensemble: r1}
                   - {project: CMIP6, activity: HRMP, dataset: HA, ensemble: r1}
+                  - {project: CORDEX, driver: ICHEC-EC-EARTH, dataset: SMHI-RCA4, ensemble: r1, mip: mon}
+                  - {project: CORDEX, driver: MIROC-MIROC5, dataset: SMHI-RCA4, ensemble: r1, mip: mon}
             scripts: null
         """)  # noqa:
 
     recipe = get_recipe(tmp_path, content, config_user)
     assert len(recipe.diagnostics) == 1
     diag = recipe.diagnostics['diagnostic_name']
-    var = diag['preprocessor_output']['ta']
+    var = diag['preprocessor_output']['pr']
     for dataset in var:
         if dataset['project'] == 'CMIP5':
             if dataset['dataset'] == 'GFDL-CM3':
@@ -1824,6 +1828,11 @@ def test_alias_generation(tmp_path, patched_datafinder, config_user):
                 assert dataset['alias'] == 'CMIP6_HRMP_EC'
             else:
                 assert dataset['alias'] == 'CMIP6_HRMP_HA'
+        elif dataset['project'] == 'CORDEX':
+            if dataset['driver'] == 'ICHEC-EC-EARTH':
+                assert dataset['alias'] == 'CORDEX_ICHEC-EC-EARTH'
+            else:
+                assert dataset['alias'] == 'CORDEX_MIROC-MIROC5'
         else:
             if dataset['version'] == 1:
                 assert dataset['alias'] == 'OBS_1'

--- a/tests/integration/test_recipe.py
+++ b/tests/integration/test_recipe.py
@@ -1784,6 +1784,8 @@ def test_alias_generation(tmp_path, patched_datafinder, config_user):
                   - {dataset: EC-EARTH,  ensemble: r1i1p1}
                   - {dataset: EC-EARTH,  ensemble: r2i1p1}
                   - {dataset: EC-EARTH,  ensemble: r3i1p1, alias: my_alias}
+                  - {dataset: FGOALS-g3, sub_experiment: s1960, ensemble: r1}
+                  - {dataset: FGOALS-g3, sub_experiment: s1961, ensemble: r1}
                   - {project: OBS, dataset: ERA-Interim,  version: 1}
                   - {project: OBS, dataset: ERA-Interim,  version: 2}
                   - {project: CMIP6, activity: CMP, dataset: GF3, ensemble: r1}
@@ -1801,6 +1803,11 @@ def test_alias_generation(tmp_path, patched_datafinder, config_user):
         if dataset['project'] == 'CMIP5':
             if dataset['dataset'] == 'GFDL-CM3':
                 assert dataset['alias'] == 'CMIP5_GFDL-CM3'
+            elif dataset['dataset'] == 'FGOALS-g3':
+                if dataset['sub_experiment'] == 's1960':
+                    assert dataset['alias'] == 'CMIP5_FGOALS-g3_s1960'
+                else:
+                    assert dataset['alias'] == 'CMIP5_FGOALS-g3_s1961'
             else:
                 if dataset['ensemble'] == 'r1i1p1':
                     assert dataset['alias'] == 'CMIP5_EC-EARTH_r1i1p1'


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->
This pull requests adds addintional keys to create unique aliases for CORDEX datasets and datasets with a sub_experiment tag.

Closes #1885 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
~- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
