### PR TITLE
Order recipe output in index.html

### DIFF
--- a/esmvalcore/_provenance.py
+++ b/esmvalcore/_provenance.py
@@ -2,6 +2,7 @@
 import copy
 import logging
 import os
+from functools import total_ordering
 
 from netCDF4 import Dataset
 from PIL import Image
@@ -98,6 +99,7 @@ def get_task_provenance(task, recipe_entity):
     return activity
 
 
+@total_ordering
 class TrackedFile:
     """File with provenance tracking."""
 
@@ -140,6 +142,15 @@ class TrackedFile:
     def __repr__(self):
         """Return representation string (e.g., used by ``pformat``)."""
         return f"{self.__class__.__name__}: {self.filename}"
+
+    def __eq__(self, other):
+        return hasattr(other, 'filename') and other.filename == self.filename
+
+    def __lt__(self, other):
+        return hasattr(other, 'filename') and other.filename < self.filename
+
+    def __hash__(self):
+        return hash(self.filename)
 
     def copy_provenance(self):
         """Create a copy with identical provenance information."""

--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -191,7 +191,9 @@ def write_ncl_settings(settings, filename, mode='wt'):
     lines = []
 
     # ignore some settings for NCL diagnostic
-    ignore_settings = ['profile_diagnostic', ]
+    ignore_settings = [
+        'profile_diagnostic',
+    ]
     for sett in ignore_settings:
         settings_copy = dict(settings)
         if 'diag_script_info' not in settings_copy:
@@ -274,7 +276,7 @@ class BaseTask:
         """Return a mapping of product attributes."""
         return {
             product.filename: product.attributes
-            for product in self.products
+            for product in sorted(self.products)
         }
 
     def print_ancestors(self):
@@ -414,7 +416,9 @@ class DiagnosticTask(BaseTask):
         run_dir.mkdir(parents=True, exist_ok=True)
 
         # ignore some settings for diagnostic
-        ignore_settings = ['profile_diagnostic', ]
+        ignore_settings = [
+            'profile_diagnostic',
+        ]
         for sett in ignore_settings:
             settings_copy = dict(self.settings)
             settings_copy.pop(sett, None)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

This pull request updates how the `index.html` file is written during a run:
- the order of diagnostics from the recipe is preserved
- the output files per diagnostic are sorted alphabetically

As requested in https://github.com/ESMValGroup/ESMValTool/discussions/3015#discussioncomment-4721528

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
