### PR TITLE
Fixed `set_range_in_0_360` for dask arrays

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -765,10 +765,10 @@ class CMORCheck():
                 self._cube = self._cube.intersection(lon_extent)
             else:
                 new_lons = coord.core_points().copy()
-                self._set_range_in_0_360(new_lons)
+                new_lons = self._set_range_in_0_360(new_lons)
                 if coord.bounds is not None:
                     new_bounds = coord.bounds.copy()
-                    self._set_range_in_0_360(new_bounds)
+                    new_bounds = self._set_range_in_0_360(new_bounds)
                 else:
                     new_bounds = None
                 new_coord = coord.copy(new_lons, new_bounds)
@@ -796,10 +796,8 @@ class CMORCheck():
 
     @staticmethod
     def _set_range_in_0_360(array):
-        while array.min() < 0:
-            array[array < 0] += 360
-        while array.max() > 360:
-            array[array > 360] -= 360
+        """Convert longitude coordinate to [0, 360]."""
+        return (array + 360.0) % 360.0
 
     def _check_requested_values(self, coord, coord_info, var_name):
         """Check requested values."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

The usage of lazy coordinate arrays in the CMOR checker of #1912 broke the automatic fix of longitudes not in [0, 360] for multidimensional arrays here:

https://github.com/ESMValGroup/ESMValCore/blob/745bb6ffaf6dc2985f7bf19e696718453c9cfd9f/esmvalcore/cmor/check.py#L798-L802

Error:

```
Traceback (most recent call last):                                                                                                                                                                                                                                            
  File "/work/bd0854/b309141/mambaforge/envs/esm/lib/python3.10/site-packages/dask/array/core.py", line 1889, in __setitem__                                                                                                                                                  
    y = where(key, value, self)                                                                                                                                                                                                                                               
  File "/work/bd0854/b309141/mambaforge/envs/esm/lib/python3.10/site-packages/dask/array/routines.py", line 2111, in where                                                                                                                                                    
    return elemwise(np.where, condition, x, y)                                                                                                                                                                                                                                
  File "/work/bd0854/b309141/mambaforge/envs/esm/lib/python3.10/site-packages/dask/array/core.py", line 4762, in elemwise                                                                                                                                                     
    broadcast_shapes(*shapes)                                                                                                                                                                                                                                                 
  File "/work/bd0854/b309141/mambaforge/envs/esm/lib/python3.10/site-packages/dask/array/core.py", line 4690, in broadcast_shapes                                                                                                                                             
    raise ValueError(                                                                                                                                                                                                                                                         
ValueError: operands could not be broadcast together with shapes (200, 360) (nan,) (200, 360)                                                                                                                                                                                 
                                                                                                                                                                                                                                                                              
The above exception was the direct cause of the following exception:                                                                                                                                                                                               
                                                                                                                                                                                                                                                                              
Traceback (most recent call last):                                                                                                                                                                                                                                            
  File "/work/bd0854/b309141/mambaforge/envs/esm/lib/python3.10/multiprocessing/pool.py", line 125, in worker                                                                                                                                                                 
    result = (True, func(*args, **kwds))                                                                                                                                                                                                                                      
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/_task.py", line 795, in _run_task                                                                                                                                                                                         
    output_files = task.run()                                                                                                                                                                                                                                                 
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/_task.py", line 262, in run                                                                                                                                                                                               
    self.output_files = self._run(input_files)                                                                                                                                                                                                                                
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/preprocessor/__init__.py", line 643, in _run                                                                                                                                                                              
    product.apply(step, self.debug)
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/preprocessor/__init__.py", line 430, in apply
    self.cubes = preprocess(self.cubes, step,
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/preprocessor/__init__.py", line 366, in preprocess
    result.append(_run_preproc_function(function, item, settings,
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/preprocessor/__init__.py", line 322, in _run_preproc_function
    return function(items, **kwargs)
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/preprocessor/_ancillary_vars.py", line 166, in add_fx_variables
    fx_cube = _load_fx(cube, fx_info, check_level)
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/preprocessor/_ancillary_vars.py", line 29, in _load_fx
    loaded_cube = fix_metadata(loaded_cube,
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/cmor/fix.py", line 146, in fix_metadata
    cube = checker(cube).check_metadata()
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/cmor/check.py", line 180, in check_metadata
    self._check_coords()
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/cmor/check.py", line 596, in _check_coords
    self._check_coord(coordinate, coord, var_name)
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/cmor/check.py", line 638, in _check_coord
    self._check_coord_points(cmor, coord, var_name)
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/cmor/check.py", line 768, in _check_coord_points
    self._set_range_in_0_360(new_lons)
  File "/home/b/b309141/repos/ESMValCore/esmvalcore/cmor/check.py", line 800, in _set_range_in_0_360
    array[array < 0] += 360
  File "/work/bd0854/b309141/mambaforge/envs/esm/lib/python3.10/site-packages/dask/array/core.py", line 1891, in __setitem__
    raise ValueError(
ValueError: Boolean index assignment in Dask expects equally shaped arrays.
Example: da1[da2] = da3 where da1.shape == (4,), da2.shape == (4,) and da3.shape == (4,).
Alternatively, you can use the extended API that supportsindexing with tuples.
Example: da1[(da2,)] = da3.
```

This PR also removes the usage of the deprecated function [`iris.util.approx_equal`](https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/util.html#iris.util.approx_equal).

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
