### PR TITLE
Allowed usage of `multi_model_statistics` on cubes with identical `name()` and `units` (but e.g. different long_name)

### DIFF
--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -397,7 +397,7 @@ def _equalise_var_metadata(cubes):
             if not vals:  # all names were `None`
                 names[attr] = None
             else:  # always use first encountered value
-                names[attr] = sorted(names[attr])[0]
+                names[attr] = vals[0]
 
     # Assign equal names for cubes with identical cube.name() and cube.units
     for cube in cubes:
@@ -648,7 +648,7 @@ def multi_model_statistics(products,
       :attr:`~iris.coords.Coord.standard_name`,
       :attr:`~iris.coords.Coord.long_name`, and
       :attr:`~iris.coords.Coord.var_name` (which will be arbitrarily set to the
-      first encountered value of different cubes have different values for
+      first encountered value if different cubes have different values for
       them).
     - :attr:`~iris.cube.Cube.attributes`: Differing attributes are deleted,
       see :func:`iris.util.equalise_attributes`.

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -630,12 +630,12 @@ def multi_model_statistics(products,
 
     This function can handle cubes with differing metadata:
 
-    - Cubes with identical :meth:`~iris.coords.Coord.name`s and
+    - Cubes with identical :meth:`~iris.coords.Coord.name` and
       :attr:`~iris.coords.Coord.units` will get identical values for
       :attr:`~iris.coords.Coord.standard_name`,
       :attr:`~iris.coords.Coord.long_name`, and
-      :attr:`~iris.coords.Coord.var_name` (which is ``None`` if the different
-      cubes have different values for them).
+      :attr:`~iris.coords.Coord.var_name` (which will be ``None`` if the
+      different cubes have different values for them).
     - :attr:`~iris.cube.Cube.attributes`: Differing attributes are deleted,
       see :func:`iris.util.equalise_attributes`.
     - :attr:`~iris.cube.Cube.cell_methods`: All cell methods are deleted

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -1064,10 +1064,7 @@ def test_preserve_equal_name_cubes(equal_names):
     assert_array_allclose(stat_cube.data, np.ma.array([5.0, 5.0, 5.0]))
 
     for name in all_names:
-        if name in equal_names:
-            assert getattr(stat_cube, name) == 'air_pressure'
-        else:
-            assert getattr(stat_cube, name) is None
+        assert getattr(stat_cube, name) == 'air_pressure'
 
 
 @pytest.mark.parametrize('equal_names', EQUAL_NAMES)
@@ -1102,33 +1099,37 @@ def test_equalise_var_metadata():
     # Prepare names of input cubes accordingly
     cubes[0].units = 'kg'
     cubes[0].standard_name = 'air_pressure'
+    cubes[0].long_name = 'b'
     cubes[1].units = 'kg'
     cubes[1].standard_name = 'air_pressure'
+    cubes[1].long_name = 'a'
     cubes[1].var_name = 'y'
     cubes[2].units = 'kg'
     cubes[3].units = 'm'
+    cubes[3].long_name = 'X'
     cubes[4].units = 'm'
+    cubes[4].long_name = 'X'
 
     mm._equalise_var_metadata(cubes)
 
     assert cubes[0].standard_name == 'air_pressure'
-    assert cubes[0].long_name is None
-    assert cubes[0].var_name is None
+    assert cubes[0].long_name == 'a'
+    assert cubes[0].var_name == 'x'
     assert cubes[0].units == 'kg'
     assert cubes[1].standard_name == 'air_pressure'
-    assert cubes[1].long_name is None
-    assert cubes[1].var_name is None
+    assert cubes[1].long_name == 'a'
+    assert cubes[1].var_name == 'x'
     assert cubes[1].units == 'kg'
     assert cubes[2].standard_name is None
     assert cubes[2].long_name is None
     assert cubes[2].var_name == 'x'
     assert cubes[2].units == 'kg'
     assert cubes[3].standard_name is None
-    assert cubes[3].long_name is None
+    assert cubes[3].long_name == 'X'
     assert cubes[3].var_name == 'x'
     assert cubes[3].units == 'm'
     assert cubes[4].standard_name is None
-    assert cubes[4].long_name is None
+    assert cubes[4].long_name == 'X'
     assert cubes[4].var_name == 'x'
     assert cubes[4].units == 'm'
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR allows the usage of the `multi_model_statistics` on cubes with identical `name()` and `units` but potentially different `var_name` and `long_name` (these will be set to `None` in these cases). Due to the way [`Cube.name()`](https://scitools-iris.readthedocs.io/en/latest/generated/api/iris/common/mixin.html#iris.common.mixin.CFVariableMixin.name) works, different `standard_names` will **NEVER** be merged (because the `name()` of these will always differ).

Similar to https://github.com/ESMValGroup/ESMValCore/pull/1813/, but for cube names instead of coordinate names.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Link to documentation: https://esmvaltool--1921.org.readthedocs.build/projects/ESMValCore/en/1921/api/esmvalcore.preprocessor.html?highlight=multi_model_stat#esmvalcore.preprocessor.multi_model_statistics

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
