### PR TITLE
Fix automatic download of ICON grid file and make ICON UGRIDization optional (default: true)

### DIFF
--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -363,7 +363,7 @@ algorithm <https://earthsystemmodeling.org/regrid/#regridding-methods>`__:
            reference: esmf_regrid.experimental.unstructured_scheme:regrid_unstructured_to_rectilinear
            method: conservative
 
-This automatic UGRIDization is enabled by default, but can be switched of with
+This automatic UGRIDization is enabled by default, but can be switched off with
 the facet ``ugrid: false`` in the recipe or the extra facets (see below).
 This is useful for diagnostics that do not support input data in UGRID format
 (yet) like the :ref:`Psyplot diagnostic <esmvaltool:recipes_psyplot_diag>` or

--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -337,33 +337,7 @@ A variable-specific default for the facet ``var_type`` is given in the extra
 facets (see next paragraph) for many variables, but this can be overwritten in
 the recipe.
 
-Similar to any other fix, the ICON fix allows the use of :ref:`extra
-facets<extra_facets>`.
-By default, the file :download:`icon-mappings.yml
-</../esmvalcore/config/extra_facets/icon-mappings.yml>` is used for that
-purpose.
-For some variables, extra facets are necessary; otherwise ESMValTool cannot
-read them properly.
-Supported keys for extra facets are:
-
-============= ============================= =================================
-Key           Description                   Default value if not specified
-============= ============================= =================================
-``latitude``  Standard name of the latitude ``latitude``
-              coordinate in the raw input
-              file
-``longitude`` Standard name of the          ``longitude``
-              longitude coordinate in the
-              raw input file
-``raw_name``  Variable name of the          CMOR variable name of the
-              variable in the raw input     corresponding variable
-              file
-``var_type``  Variable type of the          No default (needs to be specified
-              variable in the raw input     in extra facets or recipe if
-              file                          default DRS is used)
-============= ============================= =================================
-
-ESMValCore automatically makes native ICON data `UGRID
+ESMValCore can automatically make native ICON data `UGRID
 <https://ugrid-conventions.github.io/ugrid-conventions/>`__-compliant when
 loading the data.
 The UGRID conventions provide a standardized format to store data on
@@ -388,6 +362,41 @@ algorithm <https://earthsystemmodeling.org/regrid/#regridding-methods>`__:
          scheme:
            reference: esmf_regrid.experimental.unstructured_scheme:regrid_unstructured_to_rectilinear
            method: conservative
+
+This automatic UGRIDization is enabled by default, but can be switched of with
+the facet ``ugrid: false`` in the recipe or the extra facets (see below).
+This is useful for diagnostics that do not support input data in UGRID format
+(yet) like the :ref:`Psyplot diagnostic <esmvaltool:recipes_psyplot_diag>` or
+if you want to use the built-in :ref:`unstructured_nearest scheme <built-in
+regridding schemes>` regridding scheme.
+
+Similar to any other fix, the ICON fix allows the use of :ref:`extra
+facets<extra_facets>`.
+By default, the file :download:`icon-mappings.yml
+</../esmvalcore/config/extra_facets/icon-mappings.yml>` is used for that
+purpose.
+For some variables, extra facets are necessary; otherwise ESMValTool cannot
+read them properly.
+Supported keys for extra facets are:
+
+============= ============================= =================================
+Key           Description                   Default value if not specified
+============= ============================= =================================
+``latitude``  Standard name of the latitude ``latitude``
+              coordinate in the raw input
+              file
+``longitude`` Standard name of the          ``longitude``
+              longitude coordinate in the
+              raw input file
+``raw_name``  Variable name of the          CMOR variable name of the
+              variable in the raw input     corresponding variable
+              file
+``ugrid``     Automatic UGRIDization of     ``True``
+              the input data
+``var_type``  Variable type of the          No default (needs to be specified
+              variable in the raw input     in extra facets or recipe if
+              file                          default DRS is used)
+============= ============================= =================================
 
 .. hint::
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - compilers
   - esgf-pyclient>=0.3.1
   - esmpy!=8.1.0,<8.4  # see github.com/ESMValGroup/ESMValCore/issues/1208
+  - filelock
   - fiona
   - fire
   - geopy

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -8,7 +8,10 @@ from shutil import copyfileobj
 from urllib.parse import urlparse
 
 import iris
+import numpy as np
 import requests
+from iris import NameConstraint
+from iris.experimental.ugrid import Connectivity, Mesh
 
 from ..native_datasets import NativeDatasetFix
 
@@ -27,9 +30,124 @@ class IconFix(NativeDatasetFix):
         """Initialize ICON fix."""
         super().__init__(*args, **kwargs)
         self._horizontal_grids = {}
+        self._meshes = {}
+
+    def _create_mesh(self, cube):
+        """Create mesh from horizontal grid file.
+
+        Note
+        ----
+        This functions creates a new :class:`iris.experimental.ugrid.Mesh` from
+        the ``clat`` (already present in the cube), ``clon`` (already present
+        in the cube), ``vertex_index``, ``vertex_of_cell``, ``vlat``, and
+        ``vlon`` variables of the horizontal grid file.
+
+        We do not use :func:`iris.experimental.ugrid.Mesh.from_coords` with the
+        existing latitude and longitude coordinates here because this would
+        produce lots of duplicated entries for the node coordinates. The reason
+        for this is that the node coordinates are constructed from the bounds;
+        since each node is contained 6 times in the bounds array (each node is
+        shared by 6 neighboring cells) the number of nodes is 6 times higher
+        with :func:`iris.experimental.ugrid.Mesh.from_coords` compared to using
+        the information already present in the horizontal grid file.
+
+        """
+        horizontal_grid = self.get_horizontal_grid(cube)
+
+        # Extract connectivity (i.e., the mapping cell faces -> cell nodes)
+        # from the the horizontal grid file (in ICON jargon called
+        # 'vertex_of_cell'; since UGRID expects a different dimension ordering
+        # we transpose the cube here)
+        vertex_of_cell = horizontal_grid.extract_cube(
+            NameConstraint(var_name='vertex_of_cell'))
+        vertex_of_cell.transpose()
+
+        # Extract start index used to name nodes from the the horizontal grid
+        # file
+        start_index = self._get_start_index(horizontal_grid)
+
+        # Extract face coordinates from cube (in ICON jargon called 'cell
+        # latitude' and 'cell longitude')
+        face_lat = cube.coord('latitude')
+        face_lon = cube.coord('longitude')
+
+        # Extract node coordinates from horizontal grid
+        (node_lat, node_lon) = self._get_node_coords(horizontal_grid)
+
+        # The bounds given by the face coordinates slightly differ from the
+        # bounds determined by the connectivity. We arbitrarily assume here
+        # that the information given by the connectivity is correct.
+        conn_node_inds = vertex_of_cell.data - start_index
+
+        # Latitude: there might be slight numerical differences (-> check that
+        # the differences are very small before fixing it)
+        close_kwargs = {'rtol': 1e-3, 'atol': 1e-5}
+        if not np.allclose(
+                face_lat.bounds,
+                node_lat.points[conn_node_inds],
+                **close_kwargs,
+        ):
+            logger.warning(
+                "Latitude bounds of the face coordinate ('clat_vertices' in "
+                "the grid file) differ from the corresponding values "
+                "calculated from the connectivity ('vertex_of_cell') and the "
+                "node coordinate ('vlat'). Using bounds defined by "
+                "connectivity."
+            )
+        face_lat.bounds = node_lat.points[conn_node_inds]
+
+        # Longitude: there might be differences at the poles, where the
+        # longitude information does not matter (-> check that the only large
+        # differences are located at the poles). In addition, values might
+        # differ by 360°, which is also okay.
+        face_lon_bounds_to_check = face_lon.bounds % 360
+        node_lon_conn_to_check = node_lon.points[conn_node_inds] % 360
+        idx_notclose = ~np.isclose(
+            face_lon_bounds_to_check,
+            node_lon_conn_to_check,
+            **close_kwargs,
+        )
+        if not np.allclose(np.abs(face_lat.bounds[idx_notclose]), 90.0):
+            logger.warning(
+                "Longitude bounds of the face coordinate ('clon_vertices' in "
+                "the grid file) differ from the corresponding values "
+                "calculated from the connectivity ('vertex_of_cell') and the "
+                "node coordinate ('vlon'). Note that these values are allowed "
+                "to differ by 360° or at the poles of the grid. Using bounds "
+                "defined by connectivity."
+            )
+        face_lon.bounds = node_lon.points[conn_node_inds]
+
+        # Create mesh
+        connectivity = Connectivity(
+            indices=vertex_of_cell.data,
+            cf_role='face_node_connectivity',
+            start_index=start_index,
+            location_axis=0,
+        )
+        mesh = Mesh(
+            topology_dimension=2,
+            node_coords_and_axes=[(node_lat, 'y'), (node_lon, 'x')],
+            connectivities=[connectivity],
+            face_coords_and_axes=[(face_lat, 'y'), (face_lon, 'x')],
+        )
+
+        return mesh
+
+    def _get_grid_url(self, cube):
+        """Get ICON grid URL from cube."""
+        if self.GRID_FILE_ATTR not in cube.attributes:
+            raise ValueError(
+                f"Cube does not contain the attribute '{self.GRID_FILE_ATTR}' "
+                f"necessary to download the ICON horizontal grid file:\n"
+                f"{cube}")
+        grid_url = cube.attributes[self.GRID_FILE_ATTR]
+        parsed_url = urlparse(grid_url)
+        grid_name = Path(parsed_url.path).name
+        return (grid_url, grid_name)
 
     def get_horizontal_grid(self, cube):
-        """Get ICON horizontal grid from global attribute of cube.
+        """Get copy of ICON horizontal grid from global attribute of cube.
 
         Note
         ----
@@ -48,7 +166,7 @@ class IconFix(NativeDatasetFix):
         Returns
         -------
         iris.cube.CubeList
-            ICON horizontal grid.
+            Copy of ICON horizontal grid.
 
         Raises
         ------
@@ -58,18 +176,11 @@ class IconFix(NativeDatasetFix):
             ``self.GRID_FILE_ATTR``).
 
         """
-        if self.GRID_FILE_ATTR not in cube.attributes:
-            raise ValueError(
-                f"Cube does not contain the attribute '{self.GRID_FILE_ATTR}' "
-                f"necessary to download the ICON horizontal grid file:\n"
-                f"{cube}")
-        grid_url = cube.attributes[self.GRID_FILE_ATTR]
+        (grid_url, grid_name) = self._get_grid_url(cube)
 
         # If already loaded, return the horizontal grid (cube)
-        parsed_url = urlparse(grid_url)
-        grid_name = Path(parsed_url.path).name
         if grid_name in self._horizontal_grids:
-            return self._horizontal_grids[grid_name]
+            return self._horizontal_grids[grid_name].copy()
 
         # Check if grid file has recently been downloaded and load it if
         # possible
@@ -81,7 +192,7 @@ class IconFix(NativeDatasetFix):
             if age < self.CACHE_VALIDITY:
                 logger.debug("Using cached ICON grid file '%s'", grid_path)
                 self._horizontal_grids[grid_name] = self._load_cubes(grid_path)
-                return self._horizontal_grids[grid_name]
+                return self._horizontal_grids[grid_name].copy()
             logger.debug("Existing cached ICON grid file '%s' is outdated",
                          grid_path)
 
@@ -98,7 +209,42 @@ class IconFix(NativeDatasetFix):
                     grid_url, grid_path)
 
         self._horizontal_grids[grid_name] = self._load_cubes(grid_path)
-        return self._horizontal_grids[grid_name]
+        return self._horizontal_grids[grid_name].copy()
+
+    def get_mesh(self, cube):
+        """Get mesh.
+
+        Note
+        ----
+        If possible, this function uses a cached version of the mesh to save
+        time.
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Cube for which the mesh is retrieved. This cube needs to have a
+            global attribute that specifies the download location of the ICON
+            horizontal grid file (see ``self.GRID_FILE_ATTR``).
+
+        Returns
+        -------
+        iris.experimental.ugrid.Mesh
+            Mesh.
+
+        Raises
+        ------
+        ValueError
+            Input cube does not contain the necessary attribute that specifies
+            the the ICON horizontal grid file (see ``self.GRID_FILE_ATTR``).
+
+        """
+        (_, grid_name) = self._get_grid_url(cube)
+        if grid_name in self._meshes:
+            logger.debug("Reusing ICON mesh for grid %s", grid_name)
+        else:
+            logger.debug("Creating ICON mesh for grid %s", grid_name)
+            self._meshes[grid_name] = self._create_mesh(cube)
+        return self._meshes[grid_name]
 
     @staticmethod
     def _load_cubes(path):

--- a/esmvalcore/cmor/_fixes/icon/icon.py
+++ b/esmvalcore/cmor/_fixes/icon/icon.py
@@ -296,29 +296,14 @@ class AllVars(IconFix):
         )
         cube.add_dim_coord(index_coord, mesh_idx)
 
-        # Get mesh and replace the original latitude and longitude coordinates
-        # with their new mesh versions
-        mesh = self.get_mesh(cube)
-        cube.remove_coord('latitude')
-        cube.remove_coord('longitude')
-        for mesh_coord in mesh.to_MeshCoords('face'):
-            cube.add_aux_coord(mesh_coord, mesh_idx)
-
-    @staticmethod
-    def _get_start_index(horizontal_grid):
-        """Get start index used to name nodes from horizontal grid.
-
-        Extract start index used to name nodes from the the horizontal grid
-        file (in ICON jargon called 'vertex_index').
-
-        Note
-        ----
-        UGRID expects this to be a int32.
-
-        """
-        vertex_index = horizontal_grid.extract_cube(
-            NameConstraint(var_name='vertex_index'))
-        return np.int32(np.min(vertex_index.data))
+        # If desired, get mesh and replace the original latitude and longitude
+        # coordinates with their new mesh versions
+        if self.extra_facets.get('ugrid', True):
+            mesh = self.get_mesh(cube)
+            cube.remove_coord('latitude')
+            cube.remove_coord('longitude')
+            for mesh_coord in mesh.to_MeshCoords('face'):
+                cube.add_aux_coord(mesh_coord, mesh_idx)
 
     @staticmethod
     def _is_unstructured_grid(lat_idx, lon_idx):

--- a/esmvalcore/cmor/_fixes/icon/icon.py
+++ b/esmvalcore/cmor/_fixes/icon/icon.py
@@ -279,37 +279,6 @@ class AllVars(IconFix):
 
         return cube
 
-    def _get_node_coords(self, horizontal_grid):
-        """Get node coordinates from horizontal grid.
-
-        Extract node coordinates from dummy variable 'dual_area' in horizontal
-        grid file (in ICON jargon called 'vertex latitude' and 'vertex
-        longitude'), remove their bounds (not accepted by UGRID), and adapt
-        metadata.
-
-        """
-        dual_area_cube = horizontal_grid.extract_cube(
-            NameConstraint(var_name='dual_area'))
-        node_lat = dual_area_cube.coord(var_name='vlat')
-        node_lon = dual_area_cube.coord(var_name='vlon')
-
-        # Fix metadata
-        node_lat.bounds = None
-        node_lon.bounds = None
-        node_lat.var_name = 'nlat'
-        node_lon.var_name = 'nlon'
-        node_lat.standard_name = 'latitude'
-        node_lon.standard_name = 'longitude'
-        node_lat.long_name = 'node latitude'
-        node_lon.long_name = 'node longitude'
-        node_lat.convert_units('degrees_north')
-        node_lon.convert_units('degrees_east')
-
-        # Convert longitude to [0, 360]
-        self._set_range_in_0_360(node_lon)
-
-        return (node_lat, node_lon)
-
     def _fix_mesh(self, cube, mesh_idx):
         """Fix mesh."""
         # Remove any already-present dimensional coordinate describing the mesh
@@ -372,13 +341,6 @@ class AllVars(IconFix):
             return False
 
         return True
-
-    @staticmethod
-    def _set_range_in_0_360(lon_coord):
-        """Convert longitude coordinate to [0, 360]."""
-        lon_coord.points = (lon_coord.points + 360.0) % 360.0
-        if lon_coord.bounds is not None:
-            lon_coord.bounds = (lon_coord.bounds + 360.0) % 360.0
 
 
 class Clwvi(IconFix):

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ REQUIREMENTS = {
         'esmf-regrid',
         # see github.com/ESMValGroup/ESMValCore/issues/1208
         'esmpy!=8.1.0,<8.4',
+        'filelock',
         'fiona',
         'fire',
         'geopy',

--- a/tests/integration/cmor/_fixes/icon/test_icon.py
+++ b/tests/integration/cmor/_fixes/icon/test_icon.py
@@ -729,7 +729,38 @@ def test_tas_scalar_height2m_already_present(cubes_2d):
     check_heightxm(cube, 2.0)
 
 
-def test_tas_dim_height2m_already_present(cubes_2d):
+def test_tas_dim_height2m_already_present(cubes_2d, monkeypatch):
+    """Test fix."""
+    fix = get_allvars_fix('Amon', 'tas')
+    monkeypatch.setitem(fix.extra_facets, 'ugrid', False)
+    fixed_cubes = fix.fix_metadata(cubes_2d)
+
+    cube = check_tas_metadata(fixed_cubes)
+
+    assert cube.mesh is None
+
+    assert cube.coords('first spatial index for variables stored on an '
+                       'unstructured grid', dim_coords=True)
+    i_coord = cube.coord('first spatial index for variables stored on an '
+                         'unstructured grid', dim_coords=True)
+    assert i_coord.var_name == 'i'
+    assert i_coord.standard_name is None
+    assert i_coord.long_name == ('first spatial index for variables stored on '
+                                 'an unstructured grid')
+    assert i_coord.units == '1'
+    np.testing.assert_allclose(i_coord.points, [0, 1, 2, 3, 4, 5, 6, 7])
+    assert i_coord.bounds is None
+
+    assert cube.coords('latitude', dim_coords=False)
+    assert cube.coords('longitude', dim_coords=False)
+    lat = cube.coord('latitude', dim_coords=False)
+    lon = cube.coord('longitude', dim_coords=False)
+    assert len(cube.coord_dims(lat)) == 1
+    assert cube.coord_dims(lat) == cube.coord_dims(lon)
+    assert cube.coord_dims(lat) == cube.coord_dims(i_coord)
+
+
+def test_tas_no_mesh(cubes_2d):
     """Test fix."""
     fix = get_allvars_fix('Amon', 'tas')
 

--- a/tests/integration/cmor/_fixes/icon/test_icon.py
+++ b/tests/integration/cmor/_fixes/icon/test_icon.py
@@ -1043,11 +1043,13 @@ def test_add_coord_from_grid_fail_two_unnamed_dims(cubes_2d):
 def test_get_horizontal_grid_cached_in_dict(mock_requests):
     """Test fix."""
     cube = Cube(0, attributes={'grid_file_uri': 'cached_grid_url.nc'})
+    grid_cube = Cube(0)
     fix = get_allvars_fix('Amon', 'tas')
-    fix._horizontal_grids['cached_grid_url.nc'] = mock.sentinel.grid
+    fix._horizontal_grids['cached_grid_url.nc'] = grid_cube
 
     grid = fix.get_horizontal_grid(cube)
-    assert grid == mock.sentinel.grid
+    assert grid == grid_cube
+    assert grid is not grid_cube
     assert mock_requests.mock_calls == []
 
 
@@ -1299,10 +1301,11 @@ def test_invalid_time_units(cubes_2d):
         fix.fix_metadata(cubes_2d)
 
 
-# Test mesh creation fails because bounds do not match vertices
+# Test mesh creation raises warning because bounds do not match vertices
 
 
-def test_get_mesh_fail_invalid_clat_bounds(cubes_2d):
+@mock.patch('esmvalcore.cmor._fixes.icon._base_fixes.logger', autospec=True)
+def test_get_mesh_fail_invalid_clat_bounds(mock_logger, cubes_2d):
     """Test fix."""
     # Slightly modify latitude bounds from tas cube to make mesh creation fail
     tas_cube = cubes_2d.extract_cube(NameConstraint(var_name='tas'))
@@ -1312,13 +1315,21 @@ def test_get_mesh_fail_invalid_clat_bounds(cubes_2d):
     cubes = CubeList([tas_cube])
     fix = get_allvars_fix('Amon', 'tas')
 
-    msg = ("Cannot create mesh from horizontal grid file: latitude bounds of "
-           "the face coordinate")
-    with pytest.raises(ValueError, match=msg):
-        fix.fix_metadata(cubes)
+    fixed_cubes = fix.fix_metadata(cubes)
+    cube = check_tas_metadata(fixed_cubes)
+
+    assert cube.coord('latitude').bounds[0, 0] != 40.0
+    mock_logger.warning.assert_called_once_with(
+        "Latitude bounds of the face coordinate ('clat_vertices' in "
+        "the grid file) differ from the corresponding values "
+        "calculated from the connectivity ('vertex_of_cell') and the "
+        "node coordinate ('vlat'). Using bounds defined by "
+        "connectivity."
+    )
 
 
-def test_get_mesh_fail_invalid_clon_bounds(cubes_2d):
+@mock.patch('esmvalcore.cmor._fixes.icon._base_fixes.logger', autospec=True)
+def test_get_mesh_fail_invalid_clon_bounds(mock_logger, cubes_2d):
     """Test fix."""
     # Slightly modify longitude bounds from tas cube to make mesh creation fail
     tas_cube = cubes_2d.extract_cube(NameConstraint(var_name='tas'))
@@ -1328,7 +1339,60 @@ def test_get_mesh_fail_invalid_clon_bounds(cubes_2d):
     cubes = CubeList([tas_cube])
     fix = get_allvars_fix('Amon', 'tas')
 
-    msg = ("Cannot create mesh from horizontal grid file: longitude bounds "
-           "of the face coordinate")
+    fixed_cubes = fix.fix_metadata(cubes)
+    cube = check_tas_metadata(fixed_cubes)
+
+    assert cube.coord('longitude').bounds[0, 1] != 40.0
+    mock_logger.warning.assert_called_once_with(
+        "Longitude bounds of the face coordinate ('clon_vertices' in "
+        "the grid file) differ from the corresponding values "
+        "calculated from the connectivity ('vertex_of_cell') and the "
+        "node coordinate ('vlon'). Note that these values are allowed "
+        "to differ by 360° or at the poles of the grid. Using bounds "
+        "defined by connectivity."
+    )
+
+
+# Test _get_grid_url
+
+
+def test_get_grid_url():
+    """Test fix."""
+    cube = Cube(0, attributes={'grid_file_uri': TEST_GRID_FILE_URI})
+    fix = get_allvars_fix('Amon', 'tas')
+    (grid_url, grid_name) = fix._get_grid_url(cube)
+    assert grid_url == TEST_GRID_FILE_URI
+    assert grid_name == TEST_GRID_FILE_NAME
+
+
+def test_get_grid_url_fail():
+    """Test fix."""
+    cube = Cube(0)
+    fix = get_allvars_fix('Amon', 'tas')
+    msg = ("Cube does not contain the attribute 'grid_file_uri' necessary to "
+           "download the ICON horizontal grid file")
     with pytest.raises(ValueError, match=msg):
-        fix.fix_metadata(cubes)
+        fix._get_grid_url(cube)
+
+
+# Test get_mesh
+
+
+def test_get_mesh_cached(monkeypatch):
+    """Test fix."""
+    cube = Cube(0, attributes={'grid_file_uri': TEST_GRID_FILE_URI})
+    fix = get_allvars_fix('Amon', 'tas')
+    monkeypatch.setattr(fix, '_create_mesh', mock.Mock())
+    fix._meshes[TEST_GRID_FILE_NAME] = mock.sentinel.mesh
+    mesh = fix.get_mesh(cube)
+    assert mesh == mock.sentinel.mesh
+    fix._create_mesh.assert_not_called()
+
+
+def test_get_mesh_not_cached(monkeypatch):
+    """Test fix."""
+    cube = Cube(0, attributes={'grid_file_uri': TEST_GRID_FILE_URI})
+    fix = get_allvars_fix('Amon', 'tas')
+    monkeypatch.setattr(fix, '_create_mesh', mock.Mock())
+    fix.get_mesh(cube)
+    fix._create_mesh.assert_called_once_with(cube)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

After extensive testing of the ICON on-the-fly CMORizer with the new UGRIDization (thanks @Paulinebonnet111!!) we discovered two issues with this:

1. The automatic download of the grid file can lead to corrupted nc files when initiated from multiple processes (this happens with `max_parellel_tasks` > 1) at the same time.
2. Some diagnostics cannot handle UGRID data (yet). An example is the [Psyplot diagnostic](https://docs.esmvaltool.org/en/latest/api/esmvaltool.diag_scripts.psyplot_diag.html?highlight=psyplot#module-esmvaltool.diag_scripts.psyplot_diag).

This PR fixes these issues by

1. introducing a [`filelock`](https://py-filelock.readthedocs.io/en/latest/index.html) before attempting to download the grid file. I also added a smarter caching of the mesh to the CMORizer, which reduces the number of times the lock is actually blocking processes to a minimum (I couldn't see any performance drops with ~100 ICON datasets).
2. making the UGRIDization optional with a new facet `ugrid` (can be used in the extra facets or in the recipe). The default option for this is `True`.

Sorry, the diff of this PR is really large because I copied code from `esmvalcore/cmor/_fixes/icon/icon.py` to `esmvalcore/cmor/_fixes/icon/_base_fixes.py` so that the cached mesh is also available in the base class. The three main changes are:

- Optional UGRIDization: https://github.com/ESMValGroup/ESMValCore/blob/a40c3a3ddeaed101bbf134bdec7ad220d71d7d1c/esmvalcore/cmor/_fixes/icon/icon.py#L299-L306
- Caching of meshes: https://github.com/ESMValGroup/ESMValCore/blob/a40c3a3ddeaed101bbf134bdec7ad220d71d7d1c/esmvalcore/cmor/_fixes/icon/_base_fixes.py#L287-L293
- Lock for downloading: https://github.com/ESMValGroup/ESMValCore/blob/a40c3a3ddeaed101bbf134bdec7ad220d71d7d1c/esmvalcore/cmor/_fixes/icon/_base_fixes.py#L211-L225

`filelock` was already in our environment (through other packages), but I added it anyway to make sure we get it.

Doc: https://esmvaltool--1922.org.readthedocs.build/projects/ESMValCore/en/1922/quickstart/find_data.html#icon


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
