### PR TITLE
Fix for FGOALS-f3-L clt

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/fgoals_f3_l.py
+++ b/esmvalcore/cmor/_fixes/cmip6/fgoals_f3_l.py
@@ -55,8 +55,9 @@ class AllVars(Fix):
         return cubes
 
 
-class Sftlf(Fix):
-    """Fixes for sftlf."""
+class Clt(Fix):
+    """Fixes for clt."""
+
     def fix_data(self, cube):
         """Fix data.
 
@@ -75,3 +76,6 @@ class Sftlf(Fix):
         if cube.units == "%" and da.max(cube.core_data()).compute() <= 1.:
             cube.data = cube.core_data() * 100.
         return cube
+
+
+Sftlf = Clt

--- a/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
@@ -94,3 +94,28 @@ def test_allvars_fix_metadata(cubes):
 def test_tos_fix():
     """Test fix for ``tos``."""
     assert Tos is OceanFixGrid
+
+
+def test_get_clt_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'FGOALS-f3-l', 'Amon', 'clt')
+    assert fix == [Clt(None)]
+
+
+@pytest.fixture
+def clt_cube():
+    """``clt`` cube."""
+    cube = iris.cube.Cube(
+        [1.0],
+        var_name='clt',
+        standard_name='cloud_area_fraction',
+        units='%',
+    )
+    return cube
+
+
+def test_clt_fix_data(clt_cube):
+    """Test ``fix_data`` for ``clt``."""
+    fix = Clt(None)
+    out_cube = fix.fix_data(clt_cube)
+    assert out_cube.data == [100.0]

--- a/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
@@ -5,7 +5,12 @@ import iris
 import pytest
 from cf_units import Unit
 
-from esmvalcore.cmor._fixes.cmip6.fgoals_f3_l import AllVars, Clt, Tos
+from esmvalcore.cmor._fixes.cmip6.fgoals_f3_l import (
+    AllVars,
+    Clt,
+    Sftlf,
+    Tos,
+)
 from esmvalcore.cmor._fixes.common import OceanFixGrid
 from esmvalcore.cmor.fix import Fix
 
@@ -119,3 +124,14 @@ def test_clt_fix_data(clt_cube):
     fix = Clt(None)
     out_cube = fix.fix_data(clt_cube)
     assert out_cube.data == [100.0]
+
+
+def test_get_sftlf_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('CMIP6', 'FGOALS-f3-l', 'Amon', 'sftlf')
+    assert fix == [Sftlf(None), AllVars(None)]
+
+
+def test_sftlf_fix():
+    """Test fix for ``sftlf``."""
+    assert Sftlf is Clt

--- a/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
@@ -5,7 +5,7 @@ import iris
 import pytest
 from cf_units import Unit
 
-from esmvalcore.cmor._fixes.cmip6.fgoals_f3_l import AllVars, Tos
+from esmvalcore.cmor._fixes.cmip6.fgoals_f3_l import AllVars, Clt, Tos
 from esmvalcore.cmor._fixes.common import OceanFixGrid
 from esmvalcore.cmor.fix import Fix
 

--- a/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fgoals_f3_l.py
@@ -99,7 +99,7 @@ def test_tos_fix():
 def test_get_clt_fix():
     """Test getting of fix."""
     fix = Fix.get_fixes('CMIP6', 'FGOALS-f3-l', 'Amon', 'clt')
-    assert fix == [Clt(None)]
+    assert fix == [Clt(None), AllVars(None)]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

FGOALS-f3-L clt has unit %, values are <= 1 in ssp585 simulation.

Closes #1927 

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
~~- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~~
~~- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date~~
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

