### PR TITLE
Allowed ignoring scalar coordinates in `multi_model_statistics`

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -1034,6 +1034,11 @@ calendars, (sub-)daily data with different calendars are not supported.
 The preprocessor saves both the input single model files as well as the multi-model
 results. In case you do not want to keep the single model files, set the
 parameter ``keep_input_datasets`` to ``false`` (default value is ``true``).
+To ignore different scalar coordinates in the input datasets, use the option
+``ignore_scalar_coords: true``.
+This is helpful if you encounter a ``ValueError: Multi-model statistics failed
+to merge input cubes into a single array`` with ``Coordinates in
+cube.aux_coords (scalar) differ``.
 
 .. code-block:: yaml
 
@@ -1049,6 +1054,7 @@ parameter ``keep_input_datasets`` to ``false`` (default value is ``true``).
           statistics: [mean, median]
           exclude: [NCEP-NCAR-R1]
           keep_input_datasets: false
+          ignore_scalar_coords: true
 
 Multi-model statistics also supports a ``groupby`` argument. You can group by
 any dataset key (``project``, ``experiment``, etc.) or a combination of keys in a list. You can

--- a/esmvalcore/_recipe/check.py
+++ b/esmvalcore/_recipe/check.py
@@ -251,6 +251,13 @@ def _verify_keep_input_datasets(keep_input_datasets):
             f"Must be defined as a boolean. Got {keep_input_datasets}.")
 
 
+def _verify_ignore_scalar_coords(ignore_scalar_coords):
+    if not isinstance(ignore_scalar_coords, bool):
+        raise RecipeError(
+            "Invalid value encountered for `ignore_scalar_coords`."
+            f"Must be defined as a boolean. Got {ignore_scalar_coords}.")
+
+
 def _verify_arguments(given, expected):
     """Raise error if arguments cannot be verified."""
     for key in given:
@@ -262,7 +269,13 @@ def _verify_arguments(given, expected):
 
 def multimodel_statistics_preproc(settings):
     """Check that the multi-model settings are valid."""
-    valid_keys = ['span', 'groupby', 'statistics', 'keep_input_datasets']
+    valid_keys = [
+        'groupby',
+        'ignore_scalar_coords',
+        'keep_input_datasets',
+        'span',
+        'statistics',
+    ]
     _verify_arguments(settings.keys(), valid_keys)
 
     span = settings.get('span', None)  # optional, default: overlap
@@ -280,10 +293,17 @@ def multimodel_statistics_preproc(settings):
     keep_input_datasets = settings.get('keep_input_datasets', True)
     _verify_keep_input_datasets(keep_input_datasets)
 
+    ignore_scalar_coords = settings.get('ignore_scalar_coords', False)
+    _verify_ignore_scalar_coords(ignore_scalar_coords)
+
 
 def ensemble_statistics_preproc(settings):
     """Check that the ensemble settings are valid."""
-    valid_keys = ['statistics', 'span']
+    valid_keys = [
+        'ignore_scalar_coords',
+        'span',
+        'statistics',
+    ]
     _verify_arguments(settings.keys(), valid_keys)
 
     span = settings.get('span', 'overlap')  # optional, default: overlap
@@ -293,6 +313,9 @@ def ensemble_statistics_preproc(settings):
     statistics = settings.get('statistics', None)
     if statistics:
         _verify_statistics(statistics, 'ensemble_statistics')
+
+    ignore_scalar_coords = settings.get('ignore_scalar_coords', False)
+    _verify_ignore_scalar_coords(ignore_scalar_coords)
 
 
 def _check_delimiter(timerange):

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -311,7 +311,7 @@ def _get_equal_coord_names_metadata(cubes, equal_coords_metadata):
     return equal_names_metadata
 
 
-def _equalise_coordinate_metadata(cubes):
+def _equalise_coordinate_metadata(cubes, ignore_scalar_coords=False):
     """Equalise coordinates in cubes (in-place)."""
     if not cubes:
         return
@@ -354,11 +354,16 @@ def _equalise_coordinate_metadata(cubes):
             # Note: remaining differences will raise an error at a later stage
             coord.long_name = None
 
-        # Additionally remove specific scalar coordinates which are not
-        # expected to be equal in the input cubes
-        scalar_coords_to_remove = ['p0', 'ptop']
+        # Remove scalar coordinates if desired. In addition, always remove
+        # specific scalar coordinates which are not expected to be equal in the
+        # input cubes.
+        scalar_coords_to_always_remove = ['p0', 'ptop']
         for scalar_coord in cube.coords(dimensions=()):
-            if scalar_coord.var_name in scalar_coords_to_remove:
+            remove_coord = (
+                ignore_scalar_coords or
+                scalar_coord.var_name in scalar_coords_to_always_remove
+            )
+            if remove_coord:
                 cube.remove_coord(scalar_coord)
 
 
@@ -406,7 +411,7 @@ def _equalise_var_metadata(cubes):
             setattr(cube, attr, equal_names_metadata[cube_id][attr])
 
 
-def _combine(cubes):
+def _combine(cubes, ignore_scalar_coords=False):
     """Merge iris cubes into a single big cube with new dimension.
 
     This assumes that all input cubes have the same shape.
@@ -417,7 +422,9 @@ def _combine(cubes):
     equalise_attributes(cubes)
     _equalise_var_metadata(cubes)
     _equalise_cell_methods(cubes)
-    _equalise_coordinate_metadata(cubes)
+    _equalise_coordinate_metadata(
+        cubes, ignore_scalar_coords=ignore_scalar_coords
+    )
     _equalise_fx_variables(cubes)
 
     for i, cube in enumerate(cubes):
@@ -479,7 +486,7 @@ def _compute_slices(cubes):
 
 
 def _compute_eager(cubes: list, *, operator: iris.analysis.Aggregator,
-                   **kwargs):
+                   ignore_scalar_coords=False, **kwargs):
     """Compute statistics one slice at a time."""
     _ = [cube.data for cube in cubes]  # make sure the cubes' data are realized
 
@@ -489,7 +496,10 @@ def _compute_eager(cubes: list, *, operator: iris.analysis.Aggregator,
             single_model_slices = cubes  # scalar cubes
         else:
             single_model_slices = [cube[chunk] for cube in cubes]
-        combined_slice = _combine(single_model_slices)
+        combined_slice = _combine(
+            single_model_slices,
+            ignore_scalar_coords=ignore_scalar_coords,
+        )
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 'ignore',
@@ -542,7 +552,7 @@ def _compute_eager(cubes: list, *, operator: iris.analysis.Aggregator,
     return result_cube
 
 
-def _multicube_statistics(cubes, statistics, span):
+def _multicube_statistics(cubes, statistics, span, ignore_scalar_coords=False):
     """Compute statistics over multiple cubes.
 
     Can be used e.g. for ensemble or multi-model statistics.
@@ -580,6 +590,7 @@ def _multicube_statistics(cubes, statistics, span):
 
         result_cube = _compute_eager(aligned_cubes,
                                      operator=operator,
+                                     ignore_scalar_coords=ignore_scalar_coords,
                                      **kwargs)
         statistics_cubes[statistic] = result_cube
 
@@ -590,16 +601,20 @@ def _multiproduct_statistics(products,
                              statistics,
                              output_products,
                              span=None,
-                             keep_input_datasets=None):
+                             keep_input_datasets=None,
+                             ignore_scalar_coords=False):
     """Compute multi-cube statistics on ESMValCore products.
 
     Extract cubes from products, calculate multicube statistics and
     assign the resulting output cubes to the output_products.
     """
     cubes = [cube for product in products for cube in product.cubes]
-    statistics_cubes = _multicube_statistics(cubes=cubes,
-                                             statistics=statistics,
-                                             span=span)
+    statistics_cubes = _multicube_statistics(
+        cubes=cubes,
+        statistics=statistics,
+        span=span,
+        ignore_scalar_coords=ignore_scalar_coords,
+    )
     statistics_products = set()
     for statistic, cube in statistics_cubes.items():
         statistics_product = output_products[statistic]
@@ -622,7 +637,8 @@ def multi_model_statistics(products,
                            statistics,
                            output_products=None,
                            groupby=None,
-                           keep_input_datasets=True):
+                           keep_input_datasets=True,
+                           ignore_scalar_coords=False):
     """Compute multi-model statistics.
 
     This function computes multi-model statistics on a list of ``products``,
@@ -667,10 +683,12 @@ def multi_model_statistics(products,
       :attr:`~iris.coords.DimCoord.circular` is set to ``False``. For all other
       coordinates, :attr:`~iris.coords.Coord.long_name` is removed,
       :attr:`~iris.coords.Coord.attributes` deleted and
-      :attr:`~iris.coords.DimCoord.circular` is set to ``False``. Please note
-      that some special scalar coordinates which are expected to differe across
-      cubes(ancillary coordinates for derived coordinates like `p0` and `ptop`)
-      are removed as well.
+      :attr:`~iris.coords.DimCoord.circular` is set to ``False``. Differing
+      scalar coordinates can be ignored with the option
+      ``ignore_scalar_coords``. Please note that some special scalar
+      coordinates which are expected to differe across cubes(ancillary
+      coordinates for derived coordinates like `p0` and `ptop`) are always
+      removed.
 
     Notes
     -----
@@ -701,6 +719,13 @@ def multi_model_statistics(products,
     keep_input_datasets: bool
         If True, the output will include the input datasets.
         If False, only the computed statistics will be returned.
+    ignore_scalar_coords: bool
+        If True, remove any scalar coordinate in the input datasets before
+        merging the input cubes into the multi-dataset cube. The resulting
+        multi-model-statistics cube will have no scalar coordinates (the input
+        datasets will remain unchanged). If False, scalar coordinates will
+        remain in the merged cube, which might lead to merge conflicts in case
+        the input datasets have different scalar coordinates.
 
     Returns
     -------
@@ -719,6 +744,7 @@ def multi_model_statistics(products,
             cubes=products,
             statistics=statistics,
             span=span,
+            ignore_scalar_coords=ignore_scalar_coords,
         )
     if all(type(p).__name__ == 'PreprocessorFile' for p in products):
         # Avoid circular input: https://stackoverflow.com/q/16964467
@@ -732,7 +758,8 @@ def multi_model_statistics(products,
                 statistics=statistics,
                 output_products=sub_output_products,
                 span=span,
-                keep_input_datasets=keep_input_datasets
+                keep_input_datasets=keep_input_datasets,
+                ignore_scalar_coords=ignore_scalar_coords,
             )
 
             statistics_products |= group_statistics
@@ -746,7 +773,8 @@ def multi_model_statistics(products,
 
 
 def ensemble_statistics(products, statistics,
-                        output_products, span='overlap'):
+                        output_products, span='overlap',
+                        ignore_scalar_coords=False):
     """Entry point for ensemble statistics.
 
     An ensemble grouping is performed on the input products.
@@ -770,6 +798,13 @@ def ensemble_statistics(products, statistics,
         Overlap or full; if overlap, statitstics are computed on common time-
         span; if full, statistics are computed on full time spans, ignoring
         missing data.
+    ignore_scalar_coords: bool
+        If True, remove any scalar coordinate in the input datasets before
+        merging the input cubes into the multi-dataset cube. The resulting
+        multi-model-statistics cube will have no scalar coordinates (the input
+        datasets will remain unchanged). If False, scalar coordinates will
+        remain in the merged cube, which might lead to merge conflicts in case
+        the input datasets have different scalar coordinates.
 
     Returns
     -------
@@ -788,5 +823,6 @@ def ensemble_statistics(products, statistics,
         statistics=statistics,
         output_products=output_products,
         groupby=ensemble_grouping,
-        keep_input_datasets=False
+        keep_input_datasets=False,
+        ignore_scalar_coords=ignore_scalar_coords,
     )

--- a/tests/integration/recipe/test_check.py
+++ b/tests/integration/recipe/test_check.py
@@ -259,18 +259,26 @@ INVALID_MM_SETTINGS = {
         'statistics': ['wrong'],
         'span': 'wrong',
         'groupby': 'wrong',
-        'keep_input_datasets': 'wrong'
+        'keep_input_datasets': 'wrong',
+        'ignore_scalar_coords': 'wrong',
     }
 
 
 def test_invalid_multi_model_settings():
-    valid_keys = ['span', 'groupby', 'statistics', 'keep_input_datasets']
+    valid_keys = [
+        'groupby',
+        'ignore_scalar_coords',
+        'keep_input_datasets',
+        'span',
+        'statistics',
+    ]
     with pytest.raises(RecipeError) as rec_err:
         check._verify_arguments(INVALID_MM_SETTINGS, valid_keys)
     assert str(rec_err.value) == (
         "Unexpected keyword argument encountered: wrong_parametre. "
         "Valid keywords are: "
-        "['span', 'groupby', 'statistics', 'keep_input_datasets'].")
+        "['groupby', 'ignore_scalar_coords', 'keep_input_datasets', "
+        "'span', 'statistics'].")
 
 
 def test_invalid_multi_model_statistics():
@@ -307,6 +315,15 @@ def test_invalid_multi_model_keep_input():
             INVALID_MM_SETTINGS['keep_input_datasets'])
     assert str(rec_err.value) == (
         'Invalid value encountered for `keep_input_datasets`.'
+        'Must be defined as a boolean. Got wrong.')
+
+
+def test_invalid_multi_model_ignore_scalar_coords():
+    with pytest.raises(RecipeError) as rec_err:
+        check._verify_ignore_scalar_coords(
+            INVALID_MM_SETTINGS['ignore_scalar_coords'])
+    assert str(rec_err.value) == (
+        'Invalid value encountered for `ignore_scalar_coords`.'
         'Must be defined as a boolean. Got wrong.')
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR allows the optional keyword `ignore_scalar_coords` for the `multi_model_statistics` and `ensemble_statistics` preprocessors. With this setting enabled, different scalar coords in the input cubes are ignored and do not raise merge `MergeError`s.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1606
-->

Closes #1606

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
