### PR TITLE
Fix list formating in time range docs

### DIFF
--- a/doc/recipe/overview.rst
+++ b/doc/recipe/overview.rst
@@ -164,16 +164,19 @@ The same simplified syntax can be used to add multiple sub-experiment ids:
 When using the ``timerange`` tag to specify the start and end points, possible values can be as follows:
 
   - A start and end point specified with a resolution up to seconds (YYYYMMDDThhmmss)
+
     * ``timerange: '1980/1982'``. Spans from 01/01/1980 to 31/12/1980.
     * ``timerange: '198002/198205'``. Spans from 01/02/1980 to 31/05/1982.
     * ``timerange: '19800302/19820403'``. Spans from 02/03/1980 to 03/04/1982.
     * ``timerange: '19800504T100000/19800504T110000'``. Spans from 04/05/1980 at 10h to 11h.
 
   - A start point or end point, and a relative period with a resolution up to second (P[n]Y[n]M[n]DT[n]H[n]M[n]S).
+
     * ``timerange: '1980/P5Y'``. Starting from 01/01/1980, spans 5 years.
     * ``timerange: 'P2Y5M/198202``. Ending at 28/02/1982, spans 2 years and 5 months.
 
   - A wildcard to load all available years, the first available start point or the last available end point.
+
     * ``timerange: '*'``. Finds all available years.
     * ``timerange: '*/1982``. Finds first available point, spans to 31/12/1982.
     * ``timerange: '*/P6Y``. Finds first available point, spans 6 years from it.


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

This is a simple fix to improve the formatting of the time range docs. Follow the documentation link below and scroll to the timerange examples. In [the current version of the docs](https://docs.esmvaltool.org/projects/esmvalcore/en/latest/recipe/overview.html#recipe-section-datasets), the nested lists are not detected by Sphinx and the resulting documentation is hard to read. To make the nested lists appear correctly, an empty line needs to be inserted before every nested list, which this PR does.
An alternative version to fix the issue replaces the nested lists with an overview table, see #1940. Only one of #1940 and #1941 should be merged.

Closes #1939. Alternative implementation to #1940.

Link to documentation: https://esmvaltool--1941.org.readthedocs.build/projects/ESMValCore/en/1941/recipe/overview.html#recipe-section-datasets

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] ~[Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added~
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
