### PR TITLE
Add a feature to read facets from filenames

### DIFF
--- a/tests/unit/local/test_facets.py
+++ b/tests/unit/local/test_facets.py
@@ -1,21 +1,82 @@
 from pathlib import Path
 
-from esmvalcore.local import LocalFile, _path2facets
+import pytest
+
+from esmvalcore.local import LocalFile, _path2facets, _str2facets
+
+
+@pytest.mark.parametrize(
+    'path,template,facets',
+    [
+        (
+            "value1/value2",
+            "{facet1}/{facet2.lower}",
+            {
+                'facet1': 'value1',
+            },
+        ),
+        (
+            "Tier3/dataset1",
+            "Tier{tier}/{dataset}",
+            {
+                'tier': '3',
+                'dataset': 'dataset1',
+            },
+        ),
+        (
+            "value1/xyz/value2",
+            "{facet1}/xyz/{facet2}",
+            {
+                'facet1': 'value1',
+                'facet2': 'value2',
+            },
+        ),
+        ("value1/value2value3", "{facet1}/{facet2}{facet3}", {
+            'facet1': 'value1',
+        }),
+        (
+            "value1/value2",
+            "",
+            {},
+        ),
+        # Handling of the cases below can be made smarter if needed in the
+        # future.
+        (
+            "value1_value2.nc",
+            "{facet1}_{facet2}[_.]*nc",
+            {
+                'facet1': 'value1',
+            },
+        ),
+        (
+            "value1/value2/xyz/value3",
+            "{facet1}/{facet2}/*/{facet3}",
+            {
+                'facet1': 'value1',
+            },
+        ),
+        (
+            "value1/value2value3/value4",
+            "{facet1}/{facet2}{facet3}/{facet4}",
+            {
+                'facet1': 'value1',
+            },
+        ),
+    ])
+def test_str2facets(path, template, facets):
+    """Test `_str2facets."""
+    result = _str2facets(path, template)
+    assert result == facets
 
 
 def test_path2facets():
-    """Test `_path2facets1."""
-    filepath = Path("/climate_data/value1/value2/filename.nc")
-    drs = "{facet1}/{facet2.lower}"
-
-    expected = {
-        'facet1': 'value1',
-        'facet2': 'value2',
-    }
-
-    result = _path2facets(filepath, drs)
-
-    assert result == expected
+    file = Path('/climate_data/value1/value2/value2_2000-2001.nc')
+    facets = _path2facets(
+        file,
+        dirname_template='{facet1}/{facet2}',
+        filename_template='{facet2}_*.nc',
+    )
+    assert facets == {'facet1': 'value1', 'facet2': 'value2'}
 
 
 def test_localfile():


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Until now, facets can only be read from directory names. This adds a feature to read facets from filenames. It offers limited support for the combination with glob patterns in the filename template.

~Only merge this after https://github.com/ESMValGroup/ESMValTool/issues/3051 is resolved, to avoid reading the wrong version numbers from the filenames for the OBS and OBS6 project.~ -> Done

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
