### PR TITLE
Enhancement: Proposal to implement the download of esgf using a request.Session object

### DIFF
--- a/esmvalcore/esgf/_download.py
+++ b/esmvalcore/esgf/_download.py
@@ -40,6 +40,31 @@ class DownloadError(Exception):
     """An error occurred while downloading."""
 
 
+class UniqueSession(requests.Session):
+    """Implements singleton design pattern around requests.Session"""
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super().__new__(cls, *args, **kwargs)
+            cls._instance.stream = True
+            cls._instance.params = {'timeout': TIMEOUT}
+            cls._instance.cert = get_credentials()
+            logging.info("requests Session opened")
+        return cls._instance
+
+
+# def create_session():
+#     """Creates the session object for all requests."""
+#     global SESSION
+#     s = requests.Session()
+#     s.stream = True
+#     s.params = {'timeout': TIMEOUT}
+#     s.cert = get_credentials()
+#     logging.info("requests Session opened")
+#     SESSION = s
+
+
 def compute_speed(size, duration):
     """Compute download speed in MB/s."""
     if duration != 0:
@@ -396,7 +421,7 @@ class ESGFFile:
         file.facets = self.facets
         return file
 
-    def download(self, dest_folder, session):
+    def download(self, dest_folder):
         """Download the file.
 
         Arguments
@@ -424,7 +449,7 @@ class ESGFFile:
         errors = {}
         for url in sort_hosts(self.urls):
             try:
-                self._download(local_file, session, url)
+                self._download(local_file, url)
             except (DownloadError,
                     requests.exceptions.RequestException) as error:
                 logger.debug("Not able to download %s. Error message: %s", url,
@@ -447,7 +472,7 @@ class ESGFFile:
         with NamedTemporaryFile(prefix=f"{local_file}.") as tmp_file:
             return Path(tmp_file.name)
 
-    def _download(self, local_file, session, url):
+    def _download(self, local_file, url):
         """Download file from a single url."""
         idx = self.urls.index(url)
         checksum_type, checksum = self._checksums[idx]
@@ -460,7 +485,10 @@ class ESGFFile:
 
         logger.debug("Downloading %s to %s", url, tmp_file)
         start_time = datetime.datetime.now()
-        response = session.get(url)
+        response = UniqueSession().get(url)
+        # stream=True,
+        # timeout=TIMEOUT,
+        # cert=get_credentials()
         response.raise_for_status()
         with tmp_file.open("wb") as file:
             for chunk in response.iter_content(chunk_size=None):
@@ -536,9 +564,9 @@ def download(files, dest_folder, n_jobs=4):
     files = sorted(files)
     logger.info(get_download_message(files))
 
-    def _download(session: requests.Session, file: ESGFFile):
+    def _download(file: ESGFFile):
         """Download file to dest_folder."""
-        file.download(dest_folder, session)
+        file.download(dest_folder)
 
     total_size = 0
     start_time = datetime.datetime.now()
@@ -546,15 +574,10 @@ def download(files, dest_folder, n_jobs=4):
     errors = []
     random.shuffle(files)
     with concurrent.futures.ThreadPoolExecutor(max_workers=n_jobs) as executor:
-        with requests.Session() as session:
-            session.stream = True
-            session.params = {'timeout': TIMEOUT}
-            session.cert = get_credentials()
-
-            future_to_file = {
-                executor.submit(_download, session, file): file
-                for file in files
-            }
+        future_to_file = {
+            executor.submit(_download, file): file
+            for file in files
+        }
 
         for future in concurrent.futures.as_completed(future_to_file):
             file = future_to_file[future]

--- a/esmvalcore/esgf/_download.py
+++ b/esmvalcore/esgf/_download.py
@@ -41,7 +41,7 @@ class DownloadError(Exception):
 
 
 class UniqueSession(requests.Session):
-    """Implements singleton design pattern around requests.Session"""
+    """Implements singleton design pattern around requests.Session."""
 
     _instance = None
 

--- a/esmvalcore/esgf/_download.py
+++ b/esmvalcore/esgf/_download.py
@@ -54,17 +54,6 @@ class UniqueSession(requests.Session):
         return cls._instance
 
 
-# def create_session():
-#     """Creates the session object for all requests."""
-#     global SESSION
-#     s = requests.Session()
-#     s.stream = True
-#     s.params = {'timeout': TIMEOUT}
-#     s.cert = get_credentials()
-#     logging.info("requests Session opened")
-#     SESSION = s
-
-
 def compute_speed(size, duration):
     """Compute download speed in MB/s."""
     if duration != 0:

--- a/esmvalcore/esgf/_download.py
+++ b/esmvalcore/esgf/_download.py
@@ -477,9 +477,6 @@ class ESGFFile:
         logger.debug("Downloading %s to %s", url, tmp_file)
         start_time = datetime.datetime.now()
         response = UniqueSession().get(url)
-        # stream=True,
-        # timeout=TIMEOUT,
-        # cert=get_credentials()
         response.raise_for_status()
         with tmp_file.open("wb") as file:
             for chunk in response.iter_content(chunk_size=None):

--- a/esmvalcore/esgf/_download.py
+++ b/esmvalcore/esgf/_download.py
@@ -42,9 +42,11 @@ class DownloadError(Exception):
 
 class UniqueSession(requests.Session):
     """Implements singleton design pattern around requests.Session"""
+
     _instance = None
 
     def __new__(cls, *args, **kwargs):
+        """Create the instance if it does not exists, then returns it."""
         if not cls._instance:
             cls._instance = super().__new__(cls, *args, **kwargs)
             cls._instance.stream = True

--- a/tests/unit/esgf/test_download.py
+++ b/tests/unit/esgf/test_download.py
@@ -455,7 +455,7 @@ def test_single_download(mocker, tmp_path, checksum):
     # File was downloaded only once
     get.assert_called_once()
     # From the correct URL
-    get.assert_called_with(url, stream=True, timeout=300, cert=credentials)
+    get.assert_called_with(_download.UniqueSession(), url)
     # We checked for a valid response
     response.raise_for_status.assert_called_once()
     # And requested a reasonable chunk size

--- a/tests/unit/esgf/test_download.py
+++ b/tests/unit/esgf/test_download.py
@@ -409,7 +409,7 @@ def test_single_download(mocker, tmp_path, checksum):
                                       spec_set=True,
                                       instance=True)
     response.iter_content.return_value = [b'chunk1', b'chunk2']
-    get = mocker.patch.object(_download.requests,
+    get = mocker.patch.object(_download.requests.Session,
                               'get',
                               autospec=True,
                               return_value=response)
@@ -497,7 +497,7 @@ def test_single_download_fail(mocker, tmp_path):
                                       instance=True)
     response.raise_for_status.side_effect = (
         requests.exceptions.RequestException("test error"))
-    mocker.patch.object(_download.requests,
+    mocker.patch.object(_download.requests.Session,
                         'get',
                         autospec=True,
                         return_value=response)


### PR DESCRIPTION
## Description

Changes the call to `requests.get()` in the download process by a `requests.Session.get()` and the passing around the `requests.Session` object in the function calls.

### Motivation
- each call to the `requests.get()` method is creating an instance of `requests.Session` under the hood (see source of the  [API](https://github.com/psf/requests/blob/main/requests/api.py))
- by creating this `requests.Session` object once and use it as a "requests launcher" for all downloads of the run, we avoid this
  - This object can hold all the arguments that we are passing to `get`

Closes: https://github.com/ESMValGroup/ESMValCore/issues/1925