### PR TITLE
Make time-related fixes work with time dimensions `time1`, `time2`, `time3`

### DIFF
--- a/esmvalcore/cmor/_fixes/cesm/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cesm/cesm2.py
@@ -68,7 +68,7 @@ class AllVars(NativeDatasetFix):
         """
         # Only modify time points if data contains a time dimension, is monthly
         # data, and does not describe point measurements.
-        if not self.vardef.has_dimension_that_startswith('time'):
+        if not self.vardef.has_coord_with_standard_name('time'):
             return
         if self.extra_facets['frequency'] != 'mon':
             return

--- a/esmvalcore/cmor/_fixes/cesm/cesm2.py
+++ b/esmvalcore/cmor/_fixes/cesm/cesm2.py
@@ -68,7 +68,7 @@ class AllVars(NativeDatasetFix):
         """
         # Only modify time points if data contains a time dimension, is monthly
         # data, and does not describe point measurements.
-        if 'time' not in self.vardef.dimensions:
+        if not self.vardef.has_dimension_that_startswith('time'):
             return
         if self.extra_facets['frequency'] != 'mon':
             return

--- a/esmvalcore/cmor/_fixes/emac/emac.py
+++ b/esmvalcore/cmor/_fixes/emac/emac.py
@@ -72,10 +72,8 @@ class AllVars(EmacFix):
         self.fix_regular_lon(cube)
 
         # Fix regular pressure levels (considers plev19, plev39, etc.)
-        for dim_name in self.vardef.dimensions:
-            if 'plev' in dim_name:
-                self._fix_plev(cube)
-                break
+        if self.vardef.has_dimension_that_startswith('plev'):
+            self._fix_plev(cube)
 
         # Fix hybrid pressure levels
         if 'alevel' in self.vardef.dimensions:

--- a/esmvalcore/cmor/_fixes/emac/emac.py
+++ b/esmvalcore/cmor/_fixes/emac/emac.py
@@ -72,7 +72,7 @@ class AllVars(EmacFix):
         self.fix_regular_lon(cube)
 
         # Fix regular pressure levels (considers plev19, plev39, etc.)
-        if self.vardef.has_dimension_that_startswith('plev'):
+        if self.vardef.has_coord_with_standard_name('air_pressure'):
             self._fix_plev(cube)
 
         # Fix hybrid pressure levels

--- a/esmvalcore/cmor/_fixes/icon/icon.py
+++ b/esmvalcore/cmor/_fixes/icon/icon.py
@@ -27,7 +27,7 @@ class AllVars(IconFix):
         cube = self.get_cube(cubes)
 
         # Fix time
-        if self.vardef.has_dimension_that_startswith('time'):
+        if self.vardef.has_coord_with_standard_name('time'):
             cube = self._fix_time(cube, cubes)
 
         # Fix height (note: cannot use "if 'height' in self.vardef.dimensions"
@@ -52,13 +52,13 @@ class AllVars(IconFix):
                 cube = self._fix_height(cube, cubes)
 
         # Fix latitude
-        if 'latitude' in self.vardef.dimensions:
+        if self.vardef.has_coord_with_standard_name('latitude'):
             lat_idx = self._fix_lat(cube)
         else:
             lat_idx = None
 
         # Fix longitude
-        if 'longitude' in self.vardef.dimensions:
+        if self.vardef.has_coord_with_standard_name('longitude'):
             lon_idx = self._fix_lon(cube)
         else:
             lon_idx = None

--- a/esmvalcore/cmor/_fixes/icon/icon.py
+++ b/esmvalcore/cmor/_fixes/icon/icon.py
@@ -27,7 +27,7 @@ class AllVars(IconFix):
         cube = self.get_cube(cubes)
 
         # Fix time
-        if 'time' in self.vardef.dimensions:
+        if self.vardef.has_dimension_that_startswith('time'):
             cube = self._fix_time(cube, cubes)
 
         # Fix height (note: cannot use "if 'height' in self.vardef.dimensions"

--- a/esmvalcore/cmor/_fixes/native_datasets.py
+++ b/esmvalcore/cmor/_fixes/native_datasets.py
@@ -123,7 +123,7 @@ class NativeDatasetFix(Fix):
             bounds.
 
         """
-        if not self.vardef.has_dimension_that_startswith('time'):
+        if not self.vardef.has_coord_with_standard_name('time'):
             return
         coord = self.fix_time_metadata(cube, coord)
         if guess_bounds:
@@ -144,7 +144,7 @@ class NativeDatasetFix(Fix):
             bounds.
 
         """
-        if 'latitude' not in self.vardef.dimensions:
+        if not self.vardef.has_coord_with_standard_name('latitude'):
             return
         coord = self.fix_lat_metadata(cube, coord)
         if guess_bounds:
@@ -165,7 +165,7 @@ class NativeDatasetFix(Fix):
             bounds.
 
         """
-        if 'longitude' not in self.vardef.dimensions:
+        if not self.vardef.has_coord_with_standard_name('longitude'):
             return
         coord = self.fix_lon_metadata(cube, coord)
         if guess_bounds:

--- a/esmvalcore/cmor/_fixes/native_datasets.py
+++ b/esmvalcore/cmor/_fixes/native_datasets.py
@@ -123,7 +123,7 @@ class NativeDatasetFix(Fix):
             bounds.
 
         """
-        if 'time' not in self.vardef.dimensions:
+        if not self.vardef.has_dimension_that_startswith('time'):
             return
         coord = self.fix_time_metadata(cube, coord)
         if guess_bounds:

--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -639,31 +639,33 @@ class VariableInfo(JsonInfo):
 
         self.dimensions = self._read_json_variable('dimensions').split()
 
-    def has_dimension_that_startswith(self, pattern: str) -> bool:
-        """Check if a dimension exists whose name starts with a given pattern.
+    def has_coord_with_standard_name(self, standard_name: str) -> bool:
+        """Check if a coordinate with a given `standard_name` exists.
 
-        For some dimensions, multiple (slightly different) versions with
-        different names exist. For example, the CMIP6 tables provide 4
-        different `time` dimensions: `time`, `time1`, `time2`, and `time3`.
-        Other examples would be the CMIP6 pressure levels (`plev19`, `plev23`,
-        `plev27`, etc.) and the altitudes (`alt16`, `alt40`). This function can
-        be used to check for the existence of at least one of the different
-        names.
+        For some coordinates, multiple (slightly different) versions with
+        different dimension names but identical `standard_name` exist. For
+        example, the CMIP6 tables provide 4 different `time` dimensions:
+        `time`, `time1`, `time2`, and `time3`.  Other examples would be the
+        CMIP6 pressure levels (`plev19`, `plev23`, `plev27`, etc.) and the
+        altitudes (`alt16`, `alt40`).
+
+        This function can be used to check for the existence of specific
+        coordinate defined by its `standard_name`, not its dimension name.
 
         Parameters
         ----------
-        pattern: str
-            Pattern to be checked.
+        standard_name: str
+            Standard name to be checked.
 
         Returns
         -------
         bool
-            `True` if at least one dimension name starts with `pattern`,
-            `False` if not.
+            `True` if there is at least one coordinate with the given
+            `standard_name`, `False` if not.
 
         """
-        for dim_name in self.dimensions:
-            if dim_name.startswith(pattern):
+        for coord in self.coordinates.values():
+            if coord.standard_name == standard_name:
                 return True
         return False
 

--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -640,11 +640,11 @@ class VariableInfo(JsonInfo):
         self.dimensions = self._read_json_variable('dimensions').split()
 
     def has_dimension_that_startswith(self, pattern: str) -> bool:
-        """Check a dimension exists whose name starts with a given `pattern`.
+        """Check if a dimension exists whose name starts with a given pattern.
 
-        For some dimensions, multiple (slightly different) versions of them
-        with different names exist. For example, the CMIP6 tables provide 4
-        different `time` dimensions: `time`, `time1`, time2`, and `time3`.
+        For some dimensions, multiple (slightly different) versions with
+        different names exist. For example, the CMIP6 tables provide 4
+        different `time` dimensions: `time`, `time1`, `time2`, and `time3`.
         Other examples would be the CMIP6 pressure levels (`plev19`, `plev23`,
         `plev27`, etc.) and the altitudes (`alt16`, `alt40`). This function can
         be used to check for the existence of at least one of the different

--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -644,12 +644,13 @@ class VariableInfo(JsonInfo):
 
         For some coordinates, multiple (slightly different) versions with
         different dimension names but identical `standard_name` exist. For
-        example, the CMIP6 tables provide 4 different `time` dimensions:
-        `time`, `time1`, `time2`, and `time3`.  Other examples would be the
-        CMIP6 pressure levels (`plev19`, `plev23`, `plev27`, etc.) and the
-        altitudes (`alt16`, `alt40`).
+        example, the CMIP6 tables provide 4 different `standard_name=time`
+        dimensions: `time`, `time1`, `time2`, and `time3`. Other examples would
+        be the CMIP6 pressure levels (`plev19`, `plev23`, `plev27`, etc.  with
+        standard name `air_pressure`) and the altitudes (`alt16`, `alt40` with
+        standard name `altitude`).
 
-        This function can be used to check for the existence of specific
+        This function can be used to check for the existence of a specific
         coordinate defined by its `standard_name`, not its dimension name.
 
         Parameters

--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -568,7 +568,7 @@ class VariableInfo(JsonInfo):
         Parameters
         ----------
         short_name: str
-            variable's short name
+            Variable's short name.
         """
         super(VariableInfo, self).__init__()
         self.table_type = table_type
@@ -608,7 +608,7 @@ class VariableInfo(JsonInfo):
         Returns
         -------
         VariableInfo
-           Shallow copy of this object
+           Shallow copy of this object.
         """
         return copy.copy(self)
 
@@ -620,11 +620,10 @@ class VariableInfo(JsonInfo):
         Parameters
         ----------
         json_data: dict
-            dictionary created by the json reader containing
-            variable information
-
+            Dictionary created by the json reader containing variable
+            information.
         default_freq: str
-            Default frequency to use if it is not defined at variable level
+            Default frequency to use if it is not defined at variable level.
         """
         self._json_data = json_data
 
@@ -639,6 +638,34 @@ class VariableInfo(JsonInfo):
         self.frequency = self._read_json_variable('frequency', default_freq)
 
         self.dimensions = self._read_json_variable('dimensions').split()
+
+    def has_dimension_that_startswith(self, pattern: str) -> bool:
+        """Check a dimension exists whose name starts with a given `pattern`.
+
+        For some dimensions, multiple (slightly different) versions of them
+        with different names exist. For example, the CMIP6 tables provide 4
+        different `time` dimensions: `time`, `time1`, time2`, and `time3`.
+        Other examples would be the CMIP6 pressure levels (`plev19`, `plev23`,
+        `plev27`, etc.) and the altitudes (`alt16`, `alt40`). This function can
+        be used to check for the existence of at least one of the different
+        names.
+
+        Parameters
+        ----------
+        pattern: str
+            Pattern to be checked.
+
+        Returns
+        -------
+        bool
+            `True` if at least one dimension name starts with `pattern`,
+            `False` if not.
+
+        """
+        for dim_name in self.dimensions:
+            if dim_name.startswith(pattern):
+                return True
+        return False
 
 
 class CoordinateInfo(JsonInfo):

--- a/tests/integration/cmor/_fixes/cesm/test_cesm2.py
+++ b/tests/integration/cmor/_fixes/cesm/test_cesm2.py
@@ -294,6 +294,18 @@ def test_fix_time_mon(cube_1d_time):
     np.testing.assert_array_equal(time_coord.bounds, [[0, 2], [2, 4], [4, 6]])
 
 
+def test_fix_time1_mon(cube_1d_time, monkeypatch):
+    """Test `_fix_time``."""
+    fix = get_allvars_fix('Amon', 'mon', 'tas')
+    monkeypatch.setattr(
+        fix.vardef, 'dimensions', ['time1', 'latitude', 'longitude']
+    )
+    fix._fix_time(cube_1d_time)
+    time_coord = cube_1d_time.coord('time')
+    np.testing.assert_array_equal(time_coord.points, [1, 3, 5])
+    np.testing.assert_array_equal(time_coord.bounds, [[0, 2], [2, 4], [4, 6]])
+
+
 def test_fix_time_mon_point(cube_1d_time):
     """Test `_fix_time``."""
     cube_1d_time.add_cell_method(CellMethod('point', 'time'))

--- a/tests/integration/cmor/_fixes/cesm/test_cesm2.py
+++ b/tests/integration/cmor/_fixes/cesm/test_cesm2.py
@@ -8,7 +8,7 @@ from iris.cube import Cube, CubeList
 
 import esmvalcore.cmor._fixes.cesm.cesm2
 from esmvalcore.cmor.fix import Fix
-from esmvalcore.cmor.table import get_var_info
+from esmvalcore.cmor.table import CoordinateInfo, get_var_info
 from esmvalcore.config._config import get_extra_facets
 from esmvalcore.dataset import Dataset
 
@@ -170,7 +170,9 @@ def test_only_time(monkeypatch):
     # CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of tas to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['time'])
+    coord_info = CoordinateInfo('time')
+    coord_info.standard_name = 'time'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'time': coord_info})
 
     # Create cube with only a single dimension
     time_coord = DimCoord([0.0, 1.0], var_name='time', standard_name='time',
@@ -210,7 +212,9 @@ def test_only_latitude(monkeypatch):
     # CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of tas to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['latitude'])
+    coord_info = CoordinateInfo('latitude')
+    coord_info.standard_name = 'latitude'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'latitude': coord_info})
 
     # Create cube with only a single dimension
     lat_coord = DimCoord([0.0, 10.0], var_name='lat', standard_name='latitude',
@@ -250,7 +254,9 @@ def test_only_longitude(monkeypatch):
     # CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of tas to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['longitude'])
+    coord_info = CoordinateInfo('longitude')
+    coord_info.standard_name = 'longitude'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'longitude': coord_info})
 
     # Create cube with only a single dimension
     lon_coord = DimCoord([0.0, 180.0], var_name='lon',
@@ -294,12 +300,10 @@ def test_fix_time_mon(cube_1d_time):
     np.testing.assert_array_equal(time_coord.bounds, [[0, 2], [2, 4], [4, 6]])
 
 
-def test_fix_time1_mon(cube_1d_time, monkeypatch):
+def test_fix_time2_mon(cube_1d_time):
     """Test `_fix_time``."""
-    fix = get_allvars_fix('Amon', 'mon', 'tas')
-    monkeypatch.setattr(
-        fix.vardef, 'dimensions', ['time1', 'latitude', 'longitude']
-    )
+    # ch4Clim has dimensions [longitude, latitude, plev19, time2]
+    fix = get_allvars_fix('Amon', 'mon', 'ch4Clim')
     fix._fix_time(cube_1d_time)
     time_coord = cube_1d_time.coord('time')
     np.testing.assert_array_equal(time_coord.points, [1, 3, 5])

--- a/tests/integration/cmor/_fixes/emac/test_emac.py
+++ b/tests/integration/cmor/_fixes/emac/test_emac.py
@@ -42,7 +42,7 @@ from esmvalcore.cmor._fixes.emac.emac import (
     Zg,
 )
 from esmvalcore.cmor.fix import Fix
-from esmvalcore.cmor.table import get_var_info
+from esmvalcore.cmor.table import CoordinateInfo, get_var_info
 from esmvalcore.config._config import get_extra_facets
 from esmvalcore.dataset import Dataset
 
@@ -569,7 +569,9 @@ def test_only_time(monkeypatch):
     # EMAC CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of ta to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['time'])
+    coord_info = CoordinateInfo('time')
+    coord_info.standard_name = 'time'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'time': coord_info})
 
     # Create cube with only a single dimension
     time_coord = DimCoord([0.0, 1.0],
@@ -613,7 +615,9 @@ def test_only_plev(monkeypatch):
     # EMAC CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of ta to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['plev19'])
+    coord_info = CoordinateInfo('plev19')
+    coord_info.standard_name = 'air_pressure'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'plev19': coord_info})
 
     # Create cube with only a single dimension
     plev_coord = DimCoord([1000.0, 900.0],
@@ -656,7 +660,9 @@ def test_only_latitude(monkeypatch):
     # EMAC CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of ta to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['latitude'])
+    coord_info = CoordinateInfo('latitude')
+    coord_info.standard_name = 'latitude'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'latitude': coord_info})
 
     # Create cube with only a single dimension
     lat_coord = DimCoord([0.0, 10.0],
@@ -699,7 +705,9 @@ def test_only_longitude(monkeypatch):
     # EMAC CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of ta to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['longitude'])
+    coord_info = CoordinateInfo('longitude')
+    coord_info.standard_name = 'longitude'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'longitude': coord_info})
 
     # Create cube with only a single dimension
     lon_coord = DimCoord([0.0, 180.0],

--- a/tests/integration/cmor/_fixes/icon/test_icon.py
+++ b/tests/integration/cmor/_fixes/icon/test_icon.py
@@ -790,6 +790,22 @@ def test_tas_no_mesh(cubes_2d):
     check_heightxm(cube, 2.0)
 
 
+def test_tas_with_time1_dimensions(cubes_2d, monkeypatch):
+    """Test fix."""
+    fix = get_allvars_fix('Amon', 'tas')
+    monkeypatch.setattr(
+        fix.vardef,
+        'dimensions',
+        ['time1', 'height2m', 'latitude', 'longitude'],
+    )
+    fixed_cubes = fix.fix_metadata(cubes_2d)
+
+    cube = check_tas_metadata(fixed_cubes)
+    check_time(cube)
+    check_lat_lon(cube)
+    check_heightxm(cube, 2.0)
+
+
 # Test uas (for height10m coordinate)
 
 

--- a/tests/integration/cmor/_fixes/icon/test_icon.py
+++ b/tests/integration/cmor/_fixes/icon/test_icon.py
@@ -13,7 +13,7 @@ import esmvalcore.cmor._fixes.icon.icon
 from esmvalcore.cmor._fixes.icon._base_fixes import IconFix
 from esmvalcore.cmor._fixes.icon.icon import AllVars, Clwvi, Siconc, Siconca
 from esmvalcore.cmor.fix import Fix
-from esmvalcore.cmor.table import get_var_info
+from esmvalcore.cmor.table import CoordinateInfo, get_var_info
 from esmvalcore.config._config import get_extra_facets
 from esmvalcore.dataset import Dataset
 
@@ -790,22 +790,6 @@ def test_tas_no_mesh(cubes_2d):
     check_heightxm(cube, 2.0)
 
 
-def test_tas_with_time1_dimensions(cubes_2d, monkeypatch):
-    """Test fix."""
-    fix = get_allvars_fix('Amon', 'tas')
-    monkeypatch.setattr(
-        fix.vardef,
-        'dimensions',
-        ['time1', 'height2m', 'latitude', 'longitude'],
-    )
-    fixed_cubes = fix.fix_metadata(cubes_2d)
-
-    cube = check_tas_metadata(fixed_cubes)
-    check_time(cube)
-    check_lat_lon(cube)
-    check_heightxm(cube, 2.0)
-
-
 # Test uas (for height10m coordinate)
 
 
@@ -901,6 +885,47 @@ def test_2d_lat_lon_grid_fix(cubes_2d_lat_lon_grid):
     assert cube.coords('latitude', dim_coords=False, dimensions=(1, 2))
     assert cube.coords('longitude', dim_coords=False, dimensions=(1, 2))
     assert cube.coords('height', dim_coords=False, dimensions=())
+
+
+# Test ch4Clim (for time dimension time2)
+
+
+def test_get_ch4clim_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes('ICON', 'ICON', 'Amon', 'ch4Clim')
+    assert fix == [AllVars(None)]
+
+
+def test_ch4clim_fix(cubes_regular_grid):
+    """Test fix."""
+    cube = cubes_regular_grid[0]
+    cube.var_name = 'ch4Clim'
+    cube.units = 'mol mol-1'
+    cube.coord('time').units = 'no_unit'
+    cube.coord('time').attributes['invalid_units'] = 'day as %Y%m%d.%f'
+    cube.coord('time').points = [18500104.0]
+    cube.coord('time').long_name = 'wrong_time_name'
+
+    fix = get_allvars_fix('Amon', 'ch4Clim')
+    fixed_cubes = fix.fix_metadata(cubes_regular_grid)
+
+    assert len(fixed_cubes) == 1
+    cube = fixed_cubes[0]
+    assert cube.var_name == 'ch4Clim'
+    assert cube.standard_name == 'mole_fraction_of_methane_in_air'
+    assert cube.long_name == 'Mole Fraction of CH4'
+    assert cube.units == 'mol mol-1'
+    assert 'positive' not in cube.attributes
+
+    time_coord = cube.coord('time')
+    assert time_coord.var_name == 'time'
+    assert time_coord.standard_name == 'time'
+    assert time_coord.long_name == 'time'
+    assert time_coord.units == Unit(
+        'days since 1850-01-01', calendar='proleptic_gregorian'
+    )
+    np.testing.assert_allclose(time_coord.points, [3.0])
+    assert time_coord.bounds is None
 
 
 # Test fix with empty standard_name
@@ -1162,7 +1187,9 @@ def test_only_time(monkeypatch):
     # ICON CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of ta to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['time'])
+    coord_info = CoordinateInfo('time')
+    coord_info.standard_name = 'time'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'time': coord_info})
 
     # Create cube with only a single dimension
     time_coord = DimCoord([0.0, 1.0],
@@ -1207,7 +1234,9 @@ def test_only_height(monkeypatch):
     # ICON CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of ta to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['plev19'])
+    coord_info = CoordinateInfo('plev19')
+    coord_info.standard_name = 'air_pressure'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'plev19': coord_info})
 
     # Create cube with only a single dimension
     height_coord = DimCoord([1000.0, 100.0],
@@ -1240,6 +1269,9 @@ def test_only_height(monkeypatch):
     np.testing.assert_allclose(new_height_coord.points, [1.0, 10.0])
     assert new_height_coord.bounds is None
 
+    # Check that no air_pressure coordinate has been created
+    assert not cube.coords('air_pressure')
+
     # Check that no mesh has been created
     assert cube.mesh is None
 
@@ -1251,7 +1283,9 @@ def test_only_latitude(monkeypatch):
     # ICON CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of ta to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['latitude'])
+    coord_info = CoordinateInfo('latitude')
+    coord_info.standard_name = 'latitude'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'latitude': coord_info})
 
     # Create cube with only a single dimension
     lat_coord = DimCoord([0.0, 10.0],
@@ -1294,7 +1328,9 @@ def test_only_longitude(monkeypatch):
     # ICON CMORizer is designed to check for the presence of each dimension
     # individually. To test this, remove all but one dimension of ta to create
     # an artificial, but realistic test case.
-    monkeypatch.setattr(fix.vardef, 'dimensions', ['longitude'])
+    coord_info = CoordinateInfo('longitude')
+    coord_info.standard_name = 'longitude'
+    monkeypatch.setattr(fix.vardef, 'coordinates', {'longitude': coord_info})
 
     # Create cube with only a single dimension
     lon_coord = DimCoord([0.0, 180.0],

--- a/tests/integration/cmor/_fixes/test_native_datasets.py
+++ b/tests/integration/cmor/_fixes/test_native_datasets.py
@@ -197,6 +197,9 @@ def test_get_cube_fail(cubes, fix):
     'coord,coord_name,func_name',
     [
         ('time', 'time', 'fix_regular_time'),
+        ('time1', 'time', 'fix_regular_time'),
+        ('time2', 'time', 'fix_regular_time'),
+        ('time3', 'time', 'fix_regular_time'),
         ('latitude', 'latitude', 'fix_regular_lat'),
         ('longitude', 'longitude', 'fix_regular_lon'),
     ]
@@ -220,6 +223,9 @@ def test_fix_regular_coords_from_cube(monkeypatch, sample_cube, fix, coord,
     'coord,coord_name,func_name',
     [
         ('time', 'time', 'fix_regular_time'),
+        ('time1', 'time', 'fix_regular_time'),
+        ('time2', 'time', 'fix_regular_time'),
+        ('time3', 'time', 'fix_regular_time'),
         ('latitude', 'latitude', 'fix_regular_lat'),
         ('longitude', 'longitude', 'fix_regular_lon'),
     ]

--- a/tests/integration/cmor/_fixes/test_native_datasets.py
+++ b/tests/integration/cmor/_fixes/test_native_datasets.py
@@ -8,7 +8,7 @@ from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube, CubeList
 
 from esmvalcore.cmor._fixes.native_datasets import NativeDatasetFix
-from esmvalcore.cmor.table import get_var_info
+from esmvalcore.cmor.table import CoordinateInfo, get_var_info
 
 
 @pytest.fixture
@@ -207,7 +207,9 @@ def test_get_cube_fail(cubes, fix):
 def test_fix_regular_coords_from_cube(monkeypatch, sample_cube, fix, coord,
                                       coord_name, func_name):
     """Test fixing of regular coords from cube."""
-    monkeypatch.setattr(fix.vardef, 'dimensions', [coord])
+    coord_info = CoordinateInfo(coord)
+    coord_info.standard_name = coord_name
+    monkeypatch.setattr(fix.vardef, 'coordinates', {coord: coord_info})
 
     func = getattr(fix, func_name)
     func(sample_cube)
@@ -233,7 +235,9 @@ def test_fix_regular_coords_from_cube(monkeypatch, sample_cube, fix, coord,
 def test_fix_regular_coords_from_str(monkeypatch, sample_cube, fix, coord,
                                      coord_name, func_name):
     """Test fixing of regular coords from string."""
-    monkeypatch.setattr(fix.vardef, 'dimensions', [coord])
+    coord_info = CoordinateInfo(coord)
+    coord_info.standard_name = coord_name
+    monkeypatch.setattr(fix.vardef, 'coordinates', {coord: coord_info})
 
     func = getattr(fix, func_name)
     func(sample_cube, coord=coord_name)

--- a/tests/unit/cmor/test_table.py
+++ b/tests/unit/cmor/test_table.py
@@ -12,6 +12,11 @@ class TestVariableInfo(unittest.TestCase):
         """Prepare for testing."""
         self.info = VariableInfo('table_type', 'var')
         self.value = 'value'
+        self.coords = {
+            'dim0': CoordinateInfo('dim0'),
+            'dim1': CoordinateInfo('dim1'),
+            'dim2': CoordinateInfo('dim2'),
+        }
 
     def test_constructor(self):
         """Test basic constructor."""
@@ -63,24 +68,27 @@ class TestVariableInfo(unittest.TestCase):
         self.info.read_json({}, self.value)
         self.assertEqual(self.info.frequency, self.value)
 
-    def test_has_dimension_that_startswith_empty_dim(self):
-        """Test `has_dimension_that_startswith`."""
-        assert self.info.has_dimension_that_startswith('time') is False
+    def test_has_coord_with_standard_name_empty(self):
+        """Test `has_coord_with_standard_name`."""
+        assert self.info.has_coord_with_standard_name('time') is False
 
-    def test_has_dimension_that_startswith_false(self):
-        """Test `has_dimension_that_startswith`."""
-        self.info.dimensions = ['test', 'not_time', 'TIME', '_time_']
-        assert self.info.has_dimension_that_startswith('time') is False
+    def test_has_coord_with_standard_name_false(self):
+        """Test `has_coord_with_standard_name`."""
+        self.info.coordinates = self.coords
+        assert self.info.has_coord_with_standard_name('time') is False
 
-    def test_has_dimension_that_startswith_true(self):
-        """Test `has_dimension_that_startswith`."""
-        self.info.dimensions = ['test', 'time1']
-        assert self.info.has_dimension_that_startswith('time') is True
+    def test_has_coord_with_standard_name_true(self):
+        """Test `has_coord_with_standard_name`."""
+        self.info.coordinates = self.coords
+        self.info.coordinates['dim0'].standard_name = 'time'
+        assert self.info.has_coord_with_standard_name('time') is True
 
-    def test_has_dimension_that_startswith_multiple(self):
-        """Test `has_dimension_that_startswith`."""
-        self.info.dimensions = ['test', 'time1', 'time', 'time2']
-        assert self.info.has_dimension_that_startswith('time') is True
+    def test_has_coord_with_standard_name_multiple(self):
+        """Test `has_coord_with_standard_name`."""
+        self.info.coordinates = self.coords
+        self.info.coordinates['dim1'].standard_name = 'time'
+        self.info.coordinates['dim2'].standard_name = 'time'
+        assert self.info.has_coord_with_standard_name('time') is True
 
 
 class TestCoordinateInfo(unittest.TestCase):

--- a/tests/unit/cmor/test_table.py
+++ b/tests/unit/cmor/test_table.py
@@ -10,67 +10,77 @@ class TestVariableInfo(unittest.TestCase):
 
     def setUp(self):
         """Prepare for testing."""
+        self.info = VariableInfo('table_type', 'var')
         self.value = 'value'
 
     def test_constructor(self):
         """Test basic constructor."""
-        info = VariableInfo('table_type', 'var')
-        self.assertEqual('table_type', info.table_type)
-        self.assertEqual('var', info.short_name)
+        self.assertEqual('table_type', self.info.table_type)
+        self.assertEqual('var', self.info.short_name)
 
     def test_read_empty_dictionary(self):
         """Test read empty dict."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({}, '')
-        self.assertEqual('', info.standard_name)
+        self.info.read_json({}, '')
+        self.assertEqual('', self.info.standard_name)
 
     def test_read_standard_name(self):
         """Test standard_name."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({'standard_name': self.value}, '')
-        self.assertEqual(info.standard_name, self.value)
+        self.info.read_json({'standard_name': self.value}, '')
+        self.assertEqual(self.info.standard_name, self.value)
 
     def test_read_long_name(self):
         """Test long_name."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({'long_name': self.value}, '')
-        self.assertEqual(info.long_name, self.value)
+        self.info.read_json({'long_name': self.value}, '')
+        self.assertEqual(self.info.long_name, self.value)
 
     def test_read_units(self):
         """Test units."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({'units': self.value}, '')
-        self.assertEqual(info.units, self.value)
+        self.info.read_json({'units': self.value}, '')
+        self.assertEqual(self.info.units, self.value)
 
     def test_read_valid_min(self):
         """Test valid_min."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({'valid_min': self.value}, '')
-        self.assertEqual(info.valid_min, self.value)
+        self.info.read_json({'valid_min': self.value}, '')
+        self.assertEqual(self.info.valid_min, self.value)
 
     def test_read_valid_max(self):
         """Test valid_max."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({'valid_max': self.value}, '')
-        self.assertEqual(info.valid_max, self.value)
+        self.info.read_json({'valid_max': self.value}, '')
+        self.assertEqual(self.info.valid_max, self.value)
 
     def test_read_positive(self):
         """Test positive."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({'positive': self.value}, '')
-        self.assertEqual(info.positive, self.value)
+        self.info.read_json({'positive': self.value}, '')
+        self.assertEqual(self.info.positive, self.value)
 
     def test_read_frequency(self):
-        """Test positive."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({'frequency': self.value}, '')
-        self.assertEqual(info.frequency, self.value)
+        """Test frequency."""
+        self.info.read_json({'frequency': self.value}, '')
+        self.assertEqual(self.info.frequency, self.value)
 
     def test_read_default_frequency(self):
-        """Test positive."""
-        info = VariableInfo('table_type', 'var')
-        info.read_json({}, self.value)
-        self.assertEqual(info.frequency, self.value)
+        """Test frequency."""
+        self.info.read_json({}, self.value)
+        self.assertEqual(self.info.frequency, self.value)
+
+    def test_has_dimension_that_startswith_empty_dim(self):
+        """Test `has_dimension_that_startswith`."""
+        assert self.info.has_dimension_that_startswith('time') is False
+
+    def test_has_dimension_that_startswith_false(self):
+        """Test `has_dimension_that_startswith`."""
+        self.info.dimensions = ['test', 'not_time', 'TIME', '_time_']
+        assert self.info.has_dimension_that_startswith('time') is False
+
+    def test_has_dimension_that_startswith_true(self):
+        """Test `has_dimension_that_startswith`."""
+        self.info.dimensions = ['test', 'time1']
+        assert self.info.has_dimension_that_startswith('time') is True
+
+    def test_has_dimension_that_startswith_multiple(self):
+        """Test `has_dimension_that_startswith`."""
+        self.info.dimensions = ['test', 'time1', 'time', 'time2']
+        assert self.info.has_dimension_that_startswith('time') is True
 
 
 class TestCoordinateInfo(unittest.TestCase):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

CMIP6 provides [multiple](https://github.com/ESMValGroup/ESMValCore/blob/576a5bb3a57678ec8c9a5fcf89fc62d5d1ef9c4b/esmvalcore/cmor/tables/cmip6/Tables/CMIP6_coordinate.json#L2213) time dimensions, e.g., `time`, `time1`, etc. They all have the common standard name `time`.

Currently, we are using the dimension name (`time`, `time1`, ...) to identify coordinates in fixes. This PR introduces a convenience method `VariableInfo.has_coord_with_standard_name` to identify coordinates through their `standard_name`.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #1969 

Link to documentation: https://esmvaltool--1971.org.readthedocs.build/projects/ESMValCore/en/1971/api/esmvalcore.cmor.html?highlight=has_dimension#esmvalcore.cmor.table.VariableInfo.has_coord_with_standard_name

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
