### PR TITLE
Add custom pytest marker: skip extract location tests in case of RequestTimeoutError from geolocator Nominatim

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - main
+      - skip_extract_location
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
       - main
-      - skip_extract_location
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -108,12 +108,12 @@ def patched_failing_datafinder(tmp_path, monkeypatch):
 def geolocator_httprequest():
     """Test connection to geolocator."""
     from geopy.geocoders import Nominatim
-    from geopy.exc import GeocoderUnavailable as geopyerr
+    from geopy.exc import GeocoderUnavailable
 
     try:
         geolocator = Nominatim(user_agent='esmvalcore')
         geolocator.geocode("Romania")
-    except geopyerr:
+    except GeocoderUnavailable:
         return "ReadTimeoutError"
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -108,12 +108,12 @@ def patched_failing_datafinder(tmp_path, monkeypatch):
 def geolocator_httprequest():
     """Test connection to geolocator."""
     from geopy.geocoders import Nominatim
-    from geopy.exc import GeocoderUnavailable
+    from geopy.exc import GeocoderUnavailable, GeocoderRateLimited
 
     try:
         geolocator = Nominatim(user_agent='esmvalcore')
         geolocator.geocode("Romania")
-    except GeocoderUnavailable:
+    except GeocoderUnavailable or GeocoderRateLimited:
         return "ReadTimeoutError"
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -108,10 +108,12 @@ def patched_failing_datafinder(tmp_path, monkeypatch):
 def geolocator_httprequest():
     """Test connection to geolocator."""
     from geopy.geocoders import Nominatim
+    from geopy.exc import GeocoderUnavailable as geopyerr
+
     try:
         geolocator = Nominatim(user_agent='esmvalcore')
-        geolocation = geolocator.geocode("Romania")
-    except ReadTimeoutError:
+        geolocator.geocode("Romania")
+    except geopyerr:
         return "ReadTimeoutError"
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -115,9 +115,10 @@ def geolocator_httprequest():
         geolocator = Nominatim(user_agent='esmvalcore')
         geolocator.geocode("Romania")
     except Exception as exc:
-        if exc in (GeocoderUnavailable,
-                   GeocoderRateLimited,
-                   AdapterHTTPError):
+        print("New geolocator exception", exc)
+        if isinstance(exc, (GeocoderUnavailable,
+                            GeocoderRateLimited,
+                            AdapterHTTPError)):
             return "ReadTimeoutError"
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -106,7 +106,16 @@ def patched_failing_datafinder(tmp_path, monkeypatch):
 
 @pytest.fixture
 def geolocator_httprequest():
-    """Test connection to geolocator."""
+    """
+    Test connection to geolocator.
+
+    This builds a custom condition for a custom pytest marker
+    called "skip_requesttimeout". This is needed for geopy since
+    the CI is running into very frequent HTTP timeout errors, and
+    these come in various forms from geopy. Note, however, that the
+    tests are skipped only after N retries happen, so these are taking
+    time, and prolong the test run time unnecessarily. 
+    """
     from geopy.geocoders import Nominatim
     from geopy.exc import GeocoderUnavailable, GeocoderRateLimited
     from geopy.adapters import AdapterHTTPError
@@ -124,6 +133,12 @@ def geolocator_httprequest():
 
 @pytest.fixture(autouse=True)
 def skip_by_httprequest(request, geolocator_httprequest):
+    """
+    Mark skipped test for custom reason - error from geopy.
+
+    Trigger skip on ReadTimeoutError returned
+    by geolocator_httprequest.
+    """
     if request.node.get_closest_marker('skip_requesttimeout'):
         marker = request.node.get_closest_marker('skip_requesttimeout')
         if marker.args[0] == geolocator_httprequest:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -114,7 +114,7 @@ def geolocator_httprequest():
     the CI is running into very frequent HTTP timeout errors, and
     these come in various forms from geopy. Note, however, that the
     tests are skipped only after N retries happen, so these are taking
-    time, and prolong the test run time unnecessarily. 
+    time, and prolong the test run time unnecessarily.
     """
     from geopy.geocoders import Nominatim
     from geopy.exc import GeocoderUnavailable, GeocoderRateLimited

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -102,3 +102,15 @@ def patched_failing_datafinder(tmp_path, monkeypatch):
         return _get_filenames(tmp_path, filename, tracking_id)
 
     monkeypatch.setattr(esmvalcore.local, 'glob', glob)
+
+
+@pytest.fixture
+def httprequest():
+    return "ReadTimeoutError"
+
+@pytest.fixture(autouse=True)
+def skip_by_httprequest(request, httprequest):
+    if request.node.get_closest_marker('skip_requesttimeout'):
+        marker = request.node.get_closest_marker('skip_requesttimeout')
+        if marker.args[0] == httprequest:
+            pytest.skip('skipped because of {httprequest}')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -114,7 +114,7 @@ def geolocator_httprequest():
     try:
         geolocator = Nominatim(user_agent='esmvalcore')
         geolocator.geocode("Romania")
-    except exc:
+    except Exception as exc:
         if exc in (GeocoderUnavailable,
                    GeocoderRateLimited,
                    AdapterHTTPError):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,12 +105,19 @@ def patched_failing_datafinder(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def httprequest():
-    return "ReadTimeoutError"
+def geolocator_httprequest():
+    """Test connection to geolocator."""
+    from geopy.geocoders import Nominatim
+    try:
+        geolocator = Nominatim(user_agent='esmvalcore')
+        geolocation = geolocator.geocode("Romania")
+    except ReadTimeoutError:
+        return "ReadTimeoutError"
+
 
 @pytest.fixture(autouse=True)
-def skip_by_httprequest(request, httprequest):
+def skip_by_httprequest(request, geolocator_httprequest):
     if request.node.get_closest_marker('skip_requesttimeout'):
         marker = request.node.get_closest_marker('skip_requesttimeout')
-        if marker.args[0] == httprequest:
+        if marker.args[0] == geolocator_httprequest:
             pytest.skip('skipped because of {httprequest}')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -109,12 +109,16 @@ def geolocator_httprequest():
     """Test connection to geolocator."""
     from geopy.geocoders import Nominatim
     from geopy.exc import GeocoderUnavailable, GeocoderRateLimited
+    from geopy.adapters import AdapterHTTPError
 
     try:
         geolocator = Nominatim(user_agent='esmvalcore')
         geolocator.geocode("Romania")
-    except GeocoderUnavailable or GeocoderRateLimited:
-        return "ReadTimeoutError"
+    except exc:
+        if exc in (GeocoderUnavailable,
+                   GeocoderRateLimited,
+                   AdapterHTTPError):
+            return "ReadTimeoutError"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/preprocessor/_regrid/test_extract_location.py
+++ b/tests/integration/preprocessor/_regrid/test_extract_location.py
@@ -5,10 +5,12 @@ import iris.fileformats
 import numpy as np
 from iris.coords import CellMethod, DimCoord
 
+import pytest
 import tests
 from esmvalcore.preprocessor import extract_location
 
 
+@pytest.mark.skip_requesttimeout('ReadTimeoutError')
 class Test(tests.Test):
     def setUp(self):
         """Prepare tests."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

I have actually tested this by force-failing geolocator from within itself (nifty way they coded up their exceptions raisers), and there are 8 tests that get skippity-skipped, if a `GeocoderUnavailable` exception is raised (no matter what message - who cares).

A few notes about this implementation:

- the place where the custom marker is located is in conftest.py - so we can extend it to other related HTTP issues as @bouweandela suggested (am not even sure if that'd work if the marker sat in a given test module and not in the conftest top-level script)
- geopy's geolocator is terrible - it's either very busy, or very fragile, or both - and the connection drops VERY frequently when CI's run (not so much , at all actually, when I run locally); when too many retries with no cigar happen, it spits out a collection of error instances, sometimes different, for the same underlying reason
- I tried gather all the possible cases of error instances (I literally played a game of exceptions whack-a-mole), but am not 100% the collection is exhaustive
- skipping these tests when these errors happen offers us a more or less stable testing session, but it's very inefficient since the skip happens only after the darn thing tried a few times to connect

My take would be to get rid of this piece of unstable c**p

Closes #1982 


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
