### PR TITLE
Fix sorting of ensemble members in `esmvalcore.dataset.datasets_to_recipe`

### DIFF
--- a/esmvalcore/_recipe/from_datasets.py
+++ b/esmvalcore/_recipe/from_datasets.py
@@ -171,6 +171,7 @@ def _group_ensemble_members(dataset_facets: Iterable[Facets]) -> list[Facets]:
         return tuple((k, facets[k]) for k in sorted(facets) if k != 'ensemble')
 
     result = []
+    dataset_facets = sorted(dataset_facets, key=grouper)
     for group_facets, group in itertools.groupby(dataset_facets, key=grouper):
         ensembles = [f['ensemble'] for f in group if 'ensemble' in f]
         if not ensembles:

--- a/tests/unit/recipe/test_from_datasets.py
+++ b/tests/unit/recipe/test_from_datasets.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from esmvalcore._recipe.from_datasets import (
+    _group_ensemble_members,
     _group_ensemble_names,
     _group_identical_facets,
     _move_one_level_up,
@@ -209,6 +210,40 @@ def test_group_identical_facets():
     }
 
     assert result == expected
+
+
+def test_group_ensemble_members():
+    datasets = [
+        Dataset(
+            dataset='dataset1',
+            ensemble='r1i1p1f1',
+            grid='gn',
+        ),
+        Dataset(
+            dataset='dataset1',
+            ensemble='r1i1p1f1',
+            grid='gr1',
+        ),
+        Dataset(
+            dataset='dataset1',
+            ensemble='r2i1p1f1',
+            grid='gn',
+        ),
+    ]
+    result = _group_ensemble_members(ds.facets for ds in datasets)
+    print(result)
+    assert result == [
+        {
+            'dataset': 'dataset1',
+            'ensemble': 'r(1:2)i1p1f1',
+            'grid': 'gn',
+        },
+        {
+            'dataset': 'dataset1',
+            'ensemble': 'r1i1p1f1',
+            'grid': 'gr1',
+        },
+    ]
 
 
 def test_group_ensembles_cmip5():


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2093

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
