### PR TITLE
Include `-` in allowed characters for bibtex references

### DIFF
--- a/esmvalcore/_citation.py
+++ b/esmvalcore/_citation.py
@@ -137,7 +137,7 @@ def _extract_tags(tags):
     For example, a single entry in the list `tags` could be the string
     "['acknow_project', 'acknow_author']".
     """
-    pattern = re.compile(r'\w+')
+    pattern = re.compile(r'[\w-]+')
     return set(pattern.findall(str(tags)))
 
 

--- a/tests/unit/test_citation.py
+++ b/tests/unit/test_citation.py
@@ -1,0 +1,7 @@
+from esmvalcore import _citation
+
+
+def test_extract_tags():
+    tags = "['example1', 'example_2', 'example-3]"
+    result = _citation._extract_tags(tags)
+    assert result == {'example1', 'example_2', 'example-3'}

--- a/tests/unit/test_citation.py
+++ b/tests/unit/test_citation.py
@@ -2,6 +2,6 @@ from esmvalcore import _citation
 
 
 def test_extract_tags():
-    tags = "['example1', 'example_2', 'example-3]"
+    tags = "['example1', 'example_2', 'example-3']"
     result = _citation._extract_tags(tags)
     assert result == {'example1', 'example_2', 'example-3'}


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Very small change that correctly handles bibtex references that include `-`, as is the case for many bibtex files in `esmvaltool/references`.
Closes #2092 
Required to fix warnings arising from https://github.com/ESMValGroup/ESMValTool/pull/3197#issuecomment-1589813326

Link to documentation: https://esmvaltool--2097.org.readthedocs.build/projects/ESMValCore/en/2097/ (no change)

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] ~~Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~~
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
