### PR TITLE
Add fix for EC-Earth3-Veg tos calendar

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/ec_earth3_veg.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ec_earth3_veg.py
@@ -1,11 +1,13 @@
 """Fixes for EC-Earth3-Veg model."""
-import numpy as np
 import cf_units
+import numpy as np
+
 from ..fix import Fix
 
 
 class Siconca(Fix):
     """Fixes for siconca."""
+
     def fix_data(self, cube):
         """Fix data.
 
@@ -24,7 +26,7 @@ class Siconca(Fix):
         return cube
 
 
-class Siconc(Fix):
+class CalendarFix(Fix):
     """Fixes for siconc variable."""
 
     def fix_metadata(self, cubes):
@@ -35,6 +37,14 @@ class Siconc(Fix):
                 time_coord.units = cf_units.Unit(time_coord.units.origin,
                                                  'proleptic_gregorian')
         return cubes
+
+
+class Siconc(CalendarFix):
+    """Fixes for siconc variable."""
+
+
+class Tos(CalendarFix):
+    """Fixes for tos."""
 
 
 class Tas(Fix):

--- a/esmvalcore/cmor/_fixes/cmip6/ec_earth3_veg.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ec_earth3_veg.py
@@ -27,7 +27,11 @@ class Siconca(Fix):
 
 
 class CalendarFix(Fix):
-    """Fixes for siconc variable."""
+    """Use the same calendar for all files.
+
+    The original files contain a mix of `gregorian` for the historical
+    experiment and `proleptic_gregorian` for the ssp experiments.
+    """
 
     def fix_metadata(self, cubes):
         """Fix metadata."""

--- a/tests/integration/cmor/_fixes/cmip6/test_ec_earth3_veg.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_ec_earth3_veg.py
@@ -8,13 +8,19 @@ import pytest
 from cf_units import Unit
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.cmip6.ec_earth3_veg import Siconc, Siconca, Tas
+from esmvalcore.cmor._fixes.cmip6.ec_earth3_veg import (
+    CalendarFix,
+    Siconc,
+    Siconca,
+    Tas,
+)
 from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
 
 class TestSiconca(unittest.TestCase):
     """Test sftof fixes."""
+
     def setUp(self):
         """Prepare tests."""
         self.cube = Cube([1.0], var_name='siconca', units='%')
@@ -34,9 +40,15 @@ class TestSiconca(unittest.TestCase):
 
 
 def test_get_siconc_fix():
-    """Test getting of fix."""
-    fix = Fix.get_fixes('CMIP6', 'EC-Earth3-Veg', 'SImon', 'siconc')
-    assert fix == [Siconc(None)]
+    """Test sinconc calendar is fixed."""
+    fix, = Fix.get_fixes('CMIP6', 'EC-Earth3-Veg', 'SImon', 'siconc')
+    assert isinstance(fix, CalendarFix)
+
+
+def test_get_tos_fix():
+    """Test tos calendar is fixed."""
+    fix, = Fix.get_fixes('CMIP6', 'EC-Earth3-Veg', 'Omon', 'tos')
+    assert isinstance(fix, CalendarFix)
 
 
 def test_siconc_fix_calendar():


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Converts the EC-Earth3-Veg tos calendar to `proleptic_gregorian` to make it possible to concatenate the historical experiment with the ssp126 experiment.

See #1731


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
