### PR TITLE
Do not raise an exception if the requested version of a file is not available for all matching files on ESGF

### DIFF
--- a/esmvalcore/esgf/_search.py
+++ b/esmvalcore/esgf/_search.py
@@ -64,9 +64,8 @@ def select_latest_versions(files, versions):
         if versions:
             selection = [f for f in group if f.facets['version'] in versions]
             if not selection:
-                raise FileNotFoundError(
-                    f"Requested versions {', '.join(versions)} of file not "
-                    f"found. Available files: {group}")
+                # Skip the file if it is not the requested version(s).
+                continue
             group = selection
         latest_version = group[0]
         result.append(latest_version)

--- a/tests/unit/esgf/test_search.py
+++ b/tests/unit/esgf/test_search.py
@@ -304,8 +304,8 @@ def test_select_latest_versions_filenotfound(mocker):
     file.dataset = 'CMIP6.MODEL.v1'
     file.facets = {'version': 'v1'}
     file.__repr__ = lambda _: 'ESGFFile:CMIP6/MODEL/v1/ta.nc'
-    with pytest.raises(FileNotFoundError):
-        _search.select_latest_versions(files=[file], versions='v2')
+    result = _search.select_latest_versions(files=[file], versions='v2')
+    assert result == []
 
 
 @pytest.mark.parametrize('timerange,selection', [


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2104

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
