### PR TITLE
remove `with_mypy` or `with-mypy` extension/optional tool for prospector

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ REQUIREMENTS = {
         'docformatter',
         'isort',
         'pre-commit',
-        'prospector[with_pyroma]>=1.9.0',
+        'prospector[with_pyroma, with-mypy]>=1.9.0',
         'vprof',
         'yamllint',
         'yapf',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ REQUIREMENTS = {
         'docformatter',
         'isort',
         'pre-commit',
-        'prospector[with_pyroma,with_mypy]>=1.9.0',
+        'prospector[with_pyroma]>=1.9.0',
         'vprof',
         'yamllint',
         'yapf',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ REQUIREMENTS = {
         'docformatter',
         'isort',
         'pre-commit',
-        'prospector[with_pyroma, with-mypy]>=1.9.0',
+        'prospector[with_pyroma]>=1.9.0',
         'vprof',
         'yamllint',
         'yapf',


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

~There is an issue with prospector=1.10.2 at the moment and installing it with `with_mypy` makes it not work at all, so I am removing this extra tool for now, so we have some functionality out of it, rather than a complete shutdown;~

~Nevermind, `prospectpr=1.10.2` needs `with-mypy` instead of `with_mypy` due to `poetry` changing version, and @carlio (the prospector main dev) tells me this may change in the future again, depending how poetry wakes up in the morning (what version it is one)~

@bouweandela suggested we remove the extra tool option altogether since we run the mypy tests separately anyway :+1: 

See https://github.com/landscapeio/prospector/issues/624

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
