### PR TITLE
ERA5 on-the-fly CMORizer: changed sign of `evspsbl` and `evspsblpot`

### DIFF
--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -121,6 +121,16 @@ ERA5
 - Supported variables: ``cl``, ``clt``, ``evspsbl``, ``evspsblpot``, ``mrro``, ``pr``, ``prsn``, ``ps``, ``psl``, ``ptype``, ``rls``, ``rlds``, ``rsds``, ``rsdt``, ``rss``, ``uas``, ``vas``, ``tas``, ``tasmax``, ``tasmin``, ``tdps``, ``ts``, ``tsn`` (``E1hr``/``Amon``), ``orog`` (``fx``)
 - Tier: 3
 
+.. note:: According to the description of Evapotranspiration and potential Evapotranspiration on the Copernicus page 
+  (https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels-monthly-means?tab=overview):
+  "The ECMWF Integrated Forecasting System (IFS) convention is that downward fluxes are positive. 
+  Therefore, negative values indicate evaporation and positive values indicate condensation."
+  
+  In the CMOR table, these fluxes are defined as positive, if they go from the surface into the atmosphere:
+  "Evaporation at surface (also known as evapotranspiration): flux of water into the atmosphere due to conversion 
+  of both liquid and solid phases to vapor (from underlying surface and vegetation)."
+  Therefore the fix to cmorize the ERA5 (and ERA5-Land) switches their sign to be comparable to the CMIP models.
+
 .. _read_native_mswep:
 
 MSWEP

--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -129,7 +129,7 @@ ERA5
   In the CMOR table, these fluxes are defined as positive, if they go from the surface into the atmosphere:
   "Evaporation at surface (also known as evapotranspiration): flux of water into the atmosphere due to conversion 
   of both liquid and solid phases to vapor (from underlying surface and vegetation)."
-  Therefore, the ERA5 (and ERA5-Land) CMORizer switches the signs of ``evspsbl`` and ``evspsblpot`` to be comparable to the CMIP models.
+  Therefore, the ERA5 (and ERA5-Land) CMORizer switches the signs of ``evspsbl`` and ``evspsblpot`` to be compatible with the CMOR standard used e.g. by the CMIP models.
 
 .. _read_native_mswep:
 

--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -129,7 +129,7 @@ ERA5
   In the CMOR table, these fluxes are defined as positive, if they go from the surface into the atmosphere:
   "Evaporation at surface (also known as evapotranspiration): flux of water into the atmosphere due to conversion 
   of both liquid and solid phases to vapor (from underlying surface and vegetation)."
-  Therefore the fix to cmorize the ERA5 (and ERA5-Land) switches their sign to be comparable to the CMIP models.
+  Therefore, the ERA5 (and ERA5-Land) CMORizer switches the signs of ``evspsbl`` and ``evspsblpot`` to be comparable to the CMIP models.
 
 .. _read_native_mswep:
 

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -110,6 +110,7 @@ class Evspsbl(Fix):
             fix_hourly_time_coordinate(cube)
             fix_accumulated_units(cube)
             multiply_with_density(cube)
+            # Correct sign to align with CMOR standards
             cube.data = cube.core_data() * -1.0
 
         return cubes
@@ -126,6 +127,7 @@ class Evspsblpot(Fix):
             fix_hourly_time_coordinate(cube)
             fix_accumulated_units(cube)
             multiply_with_density(cube)
+            # Correct sign to align with CMOR standards
             cube.data = cube.core_data() * -1.0
 
         return cubes

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 def get_frequency(cube):
     """Determine time frequency of input cube."""
-
     try:
         time = cube.coord(axis='T')
     except iris.exceptions.CoordinateNotFoundError:
@@ -111,6 +110,7 @@ class Evspsbl(Fix):
             fix_hourly_time_coordinate(cube)
             fix_accumulated_units(cube)
             multiply_with_density(cube)
+            cube.data = cube.core_data() * -1.0
 
         return cubes
 
@@ -126,6 +126,7 @@ class Evspsblpot(Fix):
             fix_hourly_time_coordinate(cube)
             fix_accumulated_units(cube)
             multiply_with_density(cube)
+            cube.data = cube.core_data() * -1.0
 
         return cubes
 
@@ -315,6 +316,7 @@ class Tasmax(Fix):
     """Fixes for tasmax."""
 
     def fix_metadata(self, cubes):
+        """Fix metadata."""
         for cube in cubes:
             fix_hourly_time_coordinate(cube)
         return cubes
@@ -324,6 +326,7 @@ class Tasmin(Fix):
     """Fixes for tasmin."""
 
     def fix_metadata(self, cubes):
+        """Fix metadata."""
         for cube in cubes:
             fix_hourly_time_coordinate(cube)
         return cubes

--- a/esmvalcore/cmor/_fixes/native6/era5_land.py
+++ b/esmvalcore/cmor/_fixes/native6/era5_land.py
@@ -2,10 +2,14 @@
 import logging
 
 from esmvalcore.cmor._fixes.native6.era5 import (Pr,
+                                                 Evspsbl,
+                                                 Evspsblpot,
                                                  AllVars)
 
 
 logger = logging.getLogger(__name__)
 logger.info("Load classes from era5.py")
 logger.info(Pr)
+logger.info(Evspsbl)
+logger.info(Evspsblpot)
 logger.info(AllVars)

--- a/tests/integration/cmor/_fixes/native6/test_era5.py
+++ b/tests/integration/cmor/_fixes/native6/test_era5.py
@@ -300,7 +300,7 @@ def clt_cmor_e1hr():
 def evspsbl_era5_hourly():
     time = _era5_time('hourly')
     cube = iris.cube.Cube(
-        _era5_data('hourly'),
+        _era5_data('hourly') * -1.,
         long_name='total evapotranspiration',
         var_name='e',
         units='unknown',
@@ -337,7 +337,7 @@ def evspsbl_cmor_e1hr():
 def evspsblpot_era5_hourly():
     time = _era5_time('hourly')
     cube = iris.cube.Cube(
-        _era5_data('hourly'),
+        _era5_data('hourly') * -1.,
         long_name='potential evapotranspiration',
         var_name='epot',
         units='unknown',


### PR DESCRIPTION
Change sign of evspsbl and evspsblpot to have the same direction as CMIP models. Added both variables for ERA5_land.

<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description
For ERA5 evapotranspiration and potential evapotranspiration are negative, if they go from the surface into the atmosphere for CMIP models they are positive:

According to the description of Evapotranspiration on the Copernicus page (https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels-monthly-means?tab=overview): 
> The ECMWF Integrated Forecasting System (IFS) convention is that downward fluxes are positive. Therefore, negative values indicate evaporation and positive values indicate condensation.

In the CMOR table, these fluxes are defined as positive, if they go from the surface into the atmosphere:
>  Evaporation at surface (also known as evapotranspiration): flux of water into the atmosphere due to conversion of both liquid and solid phases to vapor (from underlying surface and vegetation)

Therefore the fix to cmorize the ERA5 (and ERA5-Land) data needs to switch their sign.

Note that the sign of these variables would change, everywhere where they are used. So far, I did not find any plot or calculation based on these variables from ERA5, but they are included in 
ESMValTool/esmvaltool/recipes/cmorizers/recipe_daily_era5.yml
and
ESMValTool/esmvaltool/recipes/examples/recipe_check_obs.yml
and could have been used to create data to use outside ESMValTool diagnostics.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2116

Link to documentation: https://github.com/ESMValGroup/ESMValCore/blob/fix_era5_evspsbl/doc/quickstart/find_data.rst

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
