### PR TITLE
[Condalock] make sure mamba/conda are at latest version by forcing a pinned mamba install

### DIFF
--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Update and show conda config
         run: |
           conda update -n base -c conda-forge conda
+          conda install -c conda-forge conda>=23.5.0
           conda info
           conda list
           conda config --show-sources

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -45,7 +45,7 @@ jobs:
           which python
           python --version
       - name: Install conda-lock
-        run: mamba install -y conda-lock==2.1.0
+        run: mamba install -y -c conda-forge conda-lock==2.1.0
       - name: Check version of conda-lock
         run: conda-lock --version
       - name: Create conda lock file for linux-64

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -4,9 +4,9 @@ on:
   # Trigger on push on main or other branch for testing
   # NOTE that push: main will create the file very often
   # and hence lots of automated PRs
-  push:
-    branches:
-      - pin-condalock
+  # push:
+  #   branches:
+  #     - main
   schedule:
     - cron: '0 4 */10 * *'
 
@@ -48,7 +48,7 @@ jobs:
           which python
           python --version
       - name: Install conda-lock
-        run: mamba install -y -c conda-forge conda-lock  # >=2.1.0
+        run: mamba install -y -c conda-forge conda-lock
       - name: Check version of conda-lock
         run: conda-lock --version
       - name: Create conda lock file for linux-64

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -31,13 +31,14 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
-      - name: Show conda config
+      - name: Update and show conda config
         run: |
           conda update -n base -c conda-forge conda
           conda info
           conda list
           conda config --show-sources
           conda config --show
+          mamba --version
       - name: Gather Python info
         run: |
           which python

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -38,14 +38,17 @@ jobs:
           conda list
           conda config --show-sources
           conda config --show
+          # setup-miniconda@v2 installs an old conda and mamba
+          # forcing a modern mamba updates both mamba and conda
           conda install -c conda-forge mamba>=1.4.8
+          conda --version
           mamba --version
       - name: Gather Python info
         run: |
           which python
           python --version
       - name: Install conda-lock
-        run: mamba install -y -c conda-forge conda-lock==2.1.0
+        run: mamba install -y -c conda-forge conda-lock  # >=2.1.0
       - name: Check version of conda-lock
         run: conda-lock --version
       - name: Create conda lock file for linux-64

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -40,7 +40,7 @@ jobs:
           conda config --show
           # setup-miniconda@v2 installs an old conda and mamba
           # forcing a modern mamba updates both mamba and conda
-          conda install -c conda-forge mamba>=1.4.8
+          conda install -c conda-forge "mamba>=1.4.8"
           conda --version
           mamba --version
       - name: Gather Python info

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -45,7 +45,7 @@ jobs:
           which python
           python --version
       - name: Install conda-lock
-        run: mamba install -y conda-lock
+        run: mamba install -y conda-lock==2.1.0
       - name: Check version of conda-lock
         run: conda-lock --version
       - name: Create conda lock file for linux-64

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Update and show conda config
         run: |
           conda update -n base -c conda-forge conda
-          conda install -c conda-forge conda>=23.5.0
           conda info
           conda list
           conda config --show-sources
           conda config --show
+          conda install -c conda-forge mamba>=1.4.8
           mamba --version
       - name: Gather Python info
         run: |

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -45,8 +45,7 @@ jobs:
           which python
           python --version
       - name: Install conda-lock
-        # conda-lock==2.1.0 has issues building the lockfilr
-        run: mamba install -y conda-lock==2.0.0
+        run: mamba install -y conda-lock
       - name: Check version of conda-lock
         run: conda-lock --version
       - name: Create conda lock file for linux-64

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -4,9 +4,9 @@ on:
   # Trigger on push on main or other branch for testing
   # NOTE that push: main will create the file very often
   # and hence lots of automated PRs
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - pin-condalock
   schedule:
     - cron: '0 4 */10 * *'
 
@@ -43,7 +43,8 @@ jobs:
           which python
           python --version
       - name: Install conda-lock
-        run: mamba install -y conda-lock
+        # conda-lock==2.1.0 has issues building the lockfilr
+        run: mamba install -y conda-lock==2.0.0
       - name: Check version of conda-lock
         run: conda-lock --version
       - name: Create conda lock file for linux-64


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

~conda-lock=2.1.0 has issues building our lockfile, so interim solution is to pin it to 2.0.0 that is known to work well.~

This is a slightly more complex issue: conda/mamba as they get shipped via the setup-miniconda@v2 action are old (will have to do a thorough check for all our actions), so updating via conda update is not doing anything. Forcing a modern mamba updates conda too, and latest conda-lock==2.1.0 (or 2.1.1 as of today) then works well. The problem about conda/mamba being old is a persistent one, and endemic to all our GA tests that use the setup-miniconda@v2, I reported it in #2138 and I will have to do something about it.

For now, the solution here does the trick:
- update mamba manually right before installing conda-lock, that in turn, force-updates the base conda
- the [action](https://github.com/ESMValGroup/ESMValCore/actions/runs/5573921486/jobs/10181852205) now runs fine, builds the conda lock file, and installs correctly, tests too off it installed; I'll update the lock file manually in a separate PR

Closes #2132 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
