### PR TITLE
[Github Actions] Update environment with latest mamba

### DIFF
--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -55,13 +55,14 @@ jobs:
           use-mamba: true
       - name: Update conda and mamba
         run: |
-          conda update -n base -c conda-forge conda
           # setup-miniconda@v2 installs an old conda and mamba
           # forcing a modern mamba updates both mamba and conda
+          # this and next step should be removed when updated upstream
+          conda update -n base -c conda-forge conda
           conda install -c conda-forge "mamba>=1.4.8"
           conda --version
           mamba --version
-      - name: Update environment
+      - name: Update environment with new mamba
         run: mamba update -c conda-forge -f environment.yml
       - run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
@@ -100,6 +101,17 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
+      - name: Update conda and mamba
+        run: |
+          # setup-miniconda@v2 installs an old conda and mamba
+          # forcing a modern mamba updates both mamba and conda
+          # this and next step should be removed when updated upstream
+          conda update -n base -c conda-forge conda
+          conda install -c conda-forge "mamba>=1.4.8"
+          conda --version
+          mamba --version
+      - name: Update environment with new mamba
+        run: mamba update -c conda-forge -f environment.yml
       - run: mkdir -p source_install_osx_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
         run: |

--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -62,7 +62,7 @@ jobs:
           conda --version
           mamba --version
       - name: Update environment
-        run: mamba update -n esmvalcore -f environment.yml
+        run: mamba update -n ${CONDA_DEFAULT_ENV} -f environment.yml
       - run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
         run: |

--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -62,7 +62,7 @@ jobs:
           conda --version
           mamba --version
       - name: Update environment
-        run: mamba update -f environment.yml
+        run: mamba update -c conda-forge -f environment.yml
       - run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
         run: |

--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -62,7 +62,7 @@ jobs:
           conda --version
           mamba --version
       - name: Update environment
-        run: mamba update -n ${CONDA_DEFAULT_ENV} -f environment.yml
+        run: mamba update -f environment.yml
       - run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
         run: |

--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - main
+      - GA_update_condamamba_adhoc
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:
@@ -52,6 +53,16 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
+      - name: Update conda and mamba
+        run: |
+          conda update -n base -c conda-forge conda
+          # setup-miniconda@v2 installs an old conda and mamba
+          # forcing a modern mamba updates both mamba and conda
+          conda install -c conda-forge "mamba>=1.4.8"
+          conda --version
+          mamba --version
+      - name: Update environment
+        run: mamba update -n esmvalcore -f environment.yml
       - run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,7 +64,7 @@ jobs:
           conda --version
           mamba --version
       - name: Update environment
-        run: mamba update -n esmvalcore -f environment.yml
+        run: mamba update -n ${CONDA_DEFAULT_ENV} -f environment.yml
       - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - run: python -V 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - main
+      - GA_update_condamamba_adhoc
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:
@@ -54,6 +55,16 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
+      - name: Update conda and mamba
+        run: |
+          conda update -n base -c conda-forge conda
+          # setup-miniconda@v2 installs an old conda and mamba
+          # forcing a modern mamba updates both mamba and conda
+          conda install -c conda-forge "mamba>=1.4.8"
+          conda --version
+          mamba --version
+      - name: Update environment
+        run: mamba update -n esmvalcore -f environment.yml
       - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - run: python -V 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,7 +64,7 @@ jobs:
           conda --version
           mamba --version
       - name: Update environment
-        run: mamba update -f environment.yml
+        run: mamba update -c conda-forge -f environment.yml
       - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - run: python -V 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,7 +64,7 @@ jobs:
           conda --version
           mamba --version
       - name: Update environment
-        run: mamba update -n ${CONDA_DEFAULT_ENV} -f environment.yml
+        run: mamba update -f environment.yml
       - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - run: python -V 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/python_version.txt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,13 +57,14 @@ jobs:
           use-mamba: true
       - name: Update conda and mamba
         run: |
-          conda update -n base -c conda-forge conda
           # setup-miniconda@v2 installs an old conda and mamba
           # forcing a modern mamba updates both mamba and conda
+          # this and next step should be removed when updated upstream
+          conda update -n base -c conda-forge conda
           conda install -c conda-forge "mamba>=1.4.8"
           conda --version
           mamba --version
-      - name: Update environment
+      - name: Update environment with new mamba
         run: mamba update -c conda-forge -f environment.yml
       - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
@@ -97,6 +98,17 @@ jobs:
           miniforge-version: "latest"
           miniforge-variant: Mambaforge
           use-mamba: true
+      - name: Update conda and mamba
+        run: |
+          # setup-miniconda@v2 installs an old conda and mamba
+          # forcing a modern mamba updates both mamba and conda
+          # this and next step should be removed when updated upstream
+          conda update -n base -c conda-forge conda
+          conda install -c conda-forge "mamba>=1.4.8"
+          conda --version
+          mamba --version
+      - name: Update environment with new mamba
+        run: mamba update -c conda-forge -f environment.yml
       - run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - run: python -V 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

In #2138 I raised the issue that our standard action setup-miniconda@v2 has not been updated in a while and is now starting to install fairly old conda and mamba versions - we are not yet hitting the issue we are face in Readthedocs builds (where the standards conda/mamba are really old) but I am adding an update to mamba and subsequently of the env for two of our more important Github Actions. We'll have to keep an eye on https://github.com/conda-incubator/setup-miniconda/issues/288 where I asked the folks upstream to update the Mambaforge version.

The two new steps added don't impact the time tests run (adding about 2 minutes); there is, however, a warning at mamba update stage: it's been debated in https://github.com/conda/conda-libmamba-solver/issues/145 and it doesn't seem to impact our env

Closes #2138 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
