### PR TITLE
Added new operators for statistics preprocesor (e.g., `percentile`) and allowed arbitrary kwargs

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -8,6 +8,7 @@ In this section, each of the preprocessor modules is described,
 roughly following the default order in which preprocessor functions are applied:
 
 * :ref:`Overview derivation`
+* :ref:`Statistical preprocessors`
 * :ref:`Variable derivation`
 * :ref:`CMOR check and dataset-specific fixes`
 * :ref:`preprocessors_using_supplementary_variables`
@@ -79,13 +80,6 @@ perform the statistical calculations.
 
 Some operators support weights for some preprocessors (see following table),
 which are used by default.
-
-.. warning::
-    The use of weights can be disabled by specifying ``operator_kwargs:
-    {weights: False}``.
-    This option need to be used with great care; we strongly recommend to
-    **not** use it!
-
 The following operators are currently fully supported; other operator might be
 supported too if proper `operator_kwargs` are specified:
 
@@ -117,6 +111,70 @@ supported too if proper `operator_kwargs` are specified:
     :ref:`preprocessors_using_supplementary_variables`);
     :ref:`axis_statistics`: weighted by corresponding coordinate bounds.
 .. [2] :class:`~iris.analysis.MEDIAN` is not lazy.
+
+Examples
+--------
+
+Calculate the global (weighted) mean:
+
+.. code-block:: yaml
+
+  preprocessors:
+    global_mean:
+      area_statistics:
+        operator: mean
+
+Calculate zonal maximum.
+
+.. code-block:: yaml
+
+  preprocessors:
+    zonal_max:
+      zonal_statistics:
+        operator: max
+
+Calculate the 95% percentile over each month separately (will result in 12 time
+steps, one for January, one for February, etc.):
+
+.. code-block:: yaml
+
+  preprocessors:
+    monthly_percentiles:
+      climate_statistics:
+        period: monthly
+        operator: percentile
+        operator_kwargs:
+          percent: 95.0
+
+Calculate multi-model median, 5%, and 95% percentiles:
+
+.. code-block:: yaml
+
+  preprocessors:
+    mm_stats:
+      multi_model_statistics:
+        span: overlap
+        statistics: [percentile, median, percentile]
+        statistics_kwargs:
+          - {percent: 5}   # keyword arguments for 1st percentile
+          - {}             # keyword arguments for median
+          - {percent: 95}  # keyword arguments for 2nd percentile
+
+Calculate the global non-weighted root mean square:
+
+.. code-block:: yaml
+
+  preprocessors:
+    global_mean:
+      area_statistics:
+        operator: rms
+        weighted: false
+
+.. warning::
+
+  The disabled of weights by specifying ``operator_kwargs: {weights: False}``
+  needs to be used with great care; we strongly recommend to
+  **not** use it!
 
 
 .. _Variable derivation:
@@ -1217,7 +1275,7 @@ and `ptop`) are always removed.
         multi_model_statistics:
           span: overlap
           statistics: [percentile, percentile]
-          operator_kwargs:
+          statistics_kwargs:
             - {percent: 5}
             - {percent: 95}
 

--- a/esmvalcore/_recipe/check.py
+++ b/esmvalcore/_recipe/check.py
@@ -414,16 +414,16 @@ def statistics_preprocessors(settings: dict) -> None:
     """Check options of statistics preprocessors."""
     mm_stats = (
         'multi_model_statistics',
-        'ensemble_model_statistics',
+        'ensemble_statistics',
     )
     for (step, step_settings) in settings.items():
 
         # For multi-model statistics, we need to check each entry of statistics
         # and statistcs_kwargs
         if step in mm_stats:
-            statistics = step_settings.get('statistcs', [])
+            statistics = step_settings.get('statistics', [])
             statistics_kwargs = step_settings.get(
-                'statistcs_kwargs', [None] * len(statistics)
+                'statistics_kwargs', [None] * len(statistics)
             )
             if len(statistics) != len(statistics_kwargs):
                 raise RecipeError(
@@ -447,7 +447,7 @@ def statistics_preprocessors(settings: dict) -> None:
                     f"Missing required argument 'operator' for preprocessor "
                     f"function {step}"
                 )
-            operator = step_settings.get['operator']
+            operator = step_settings['operator']
             operator_kwargs = step_settings.get('operator_kwargs')
             try:
                 get_iris_aggregator(operator, operator_kwargs)

--- a/esmvalcore/_recipe/check.py
+++ b/esmvalcore/_recipe/check.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import subprocess
 from pprint import pformat
 from shutil import which
@@ -15,7 +14,6 @@ import yamale
 from esmvalcore.exceptions import InputFilesNotFound, RecipeError
 from esmvalcore.local import _get_start_end_year, _parse_period
 from esmvalcore.preprocessor import TIME_PREPROCESSORS, PreprocessingTask
-from esmvalcore.preprocessor._multimodel import STATISTIC_MAPPING
 from esmvalcore.preprocessor._supplementary_vars import (
     PREPROCESSOR_SUPPLEMENTARIES,
 )
@@ -256,20 +254,6 @@ def extract_shape(settings):
                 "{}".format(', '.join(f"'{k}'".lower() for k in valid[key])))
 
 
-def _verify_statistics(statistics, step):
-    """Raise error if multi-model statistics cannot be verified."""
-    valid_names = ['std'] + list(STATISTIC_MAPPING.keys())
-    valid_patterns = [r"^(p\d{1,2})(\.\d*)?$"]
-
-    for statistic in statistics:
-        if not (statistic in valid_names
-                or re.match(r'|'.join(valid_patterns), statistic)):
-            raise RecipeError(
-                "Invalid value encountered for `statistic` in preprocessor "
-                f"{step}. Valid values are {valid_names} "
-                f"or patterns matching {valid_patterns}. Got '{statistic}'.")
-
-
 def _verify_span_value(span):
     """Raise error if span argument cannot be verified."""
     valid_names = ('overlap', 'full')
@@ -333,10 +317,6 @@ def multimodel_statistics_preproc(settings):
     if groupby:
         _verify_groupby(groupby)
 
-    statistics = settings.get('statistics', None)  # required
-    if statistics:
-        _verify_statistics(statistics, 'multi_model_statistics')
-
     keep_input_datasets = settings.get('keep_input_datasets', True)
     _verify_keep_input_datasets(keep_input_datasets)
 
@@ -356,10 +336,6 @@ def ensemble_statistics_preproc(settings):
     span = settings.get('span', 'overlap')  # optional, default: overlap
     if span:
         _verify_span_value(span)
-
-    statistics = settings.get('statistics', None)
-    if statistics:
-        _verify_statistics(statistics, 'ensemble_statistics')
 
     ignore_scalar_coords = settings.get('ignore_scalar_coords', False)
     _verify_ignore_scalar_coords(ignore_scalar_coords)

--- a/esmvalcore/_recipe/recipe.py
+++ b/esmvalcore/_recipe/recipe.py
@@ -820,6 +820,7 @@ def _update_preproc_functions(settings, dataset, datasets, missing_vars):
     _update_regrid_time(dataset, settings)
     if dataset.facets.get('frequency') == 'fx':
         check.check_for_temporal_preprocs(settings)
+    check.statistics_preprocessors(settings)
 
 
 def _get_preprocessor_task(datasets, profiles, task_name):

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -21,9 +21,9 @@ from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateMultiDimError, CoordinateNotFoundError
 
 from ._shared import (
-    get_iris_analysis_operation,
+    aggregator_accept_weights,
+    get_iris_aggregator,
     guess_bounds,
-    operator_accept_weights,
 )
 from ._supplementary_vars import (
     add_ancillary_variable,
@@ -189,7 +189,11 @@ def _extract_irregular_region(cube, start_longitude, end_longitude,
     return cube
 
 
-def zonal_statistics(cube: Cube, operator: str) -> Cube:
+def zonal_statistics(
+    cube: Cube,
+    operator: str,
+    operator_kwargs: Optional[dict] = None,
+) -> Cube:
     """Compute zonal statistics.
 
     Parameters
@@ -197,8 +201,12 @@ def zonal_statistics(cube: Cube, operator: str) -> Cube:
     cube:
         Input cube.
     operator:
-        The operation. Allowed options: `mean`, `median`, `min`, `max`,
-        `std_dev`, `sum`, `variance`, `rms`.
+        The operation. Used to determine the :class:`iris.analysis.Aggregator`
+        object used to calculate the statistics. Allowed options are given in
+        :ref:`this table <supported_stat_operator>`.
+    operator_kwargs:
+        Optional keyword arguments for the :class:`iris.analysis.Aggregator`
+        object defined by `operator`.
 
     Returns
     -------
@@ -212,16 +220,21 @@ def zonal_statistics(cube: Cube, operator: str) -> Cube:
         Zonal statistics not yet implemented for irregular grids.
 
     """
-    if cube.coord('longitude').points.ndim < 2:
-        operation = get_iris_analysis_operation(operator)
-        cube = cube.collapsed('longitude', operation)
-        cube.data = cube.core_data().astype(np.float32, casting='same_kind')
-        return cube
-    msg = ("Zonal statistics on irregular grids not yet implemnted")
-    raise ValueError(msg)
+    if cube.coord('longitude').points.ndim >= 2:
+        raise ValueError(
+            "Zonal statistics on irregular grids not yet implemented"
+        )
+    (agg, agg_kwargs) = get_iris_aggregator(operator, operator_kwargs)
+    cube = cube.collapsed('longitude', agg, **agg_kwargs)
+    cube.data = cube.core_data().astype(np.float32, casting='same_kind')
+    return cube
 
 
-def meridional_statistics(cube: Cube, operator: str) -> Cube:
+def meridional_statistics(
+    cube: Cube,
+    operator: str,
+    operator_kwargs: Optional[dict] = None,
+) -> Cube:
     """Compute meridional statistics.
 
     Parameters
@@ -229,8 +242,12 @@ def meridional_statistics(cube: Cube, operator: str) -> Cube:
     cube:
         Input cube.
     operator:
-        The operation. Allowed options: `mean`, `median`, `min`, `max`,
-        `std_dev`, `sum`, `variance`, `rms`.
+        The operation. Used to determine the :class:`iris.analysis.Aggregator`
+        object used to calculate the statistics. Allowed options are given in
+        :ref:`this table <supported_stat_operator>`.
+    operator_kwargs:
+        Optional keyword arguments for the :class:`iris.analysis.Aggregator`
+        object defined by `operator`.
 
     Returns
     -------
@@ -244,13 +261,14 @@ def meridional_statistics(cube: Cube, operator: str) -> Cube:
         Zonal statistics not yet implemented for irregular grids.
 
     """
-    if cube.coord('latitude').points.ndim < 2:
-        operation = get_iris_analysis_operation(operator)
-        cube = cube.collapsed('latitude', operation)
-        cube.data = cube.core_data().astype(np.float32, casting='same_kind')
-        return cube
-    msg = ("Meridional statistics on irregular grids not yet implemented")
-    raise ValueError(msg)
+    if cube.coord('latitude').points.ndim >= 2:
+        raise ValueError(
+            "Meridional statistics on irregular grids not yet implemented"
+        )
+    (agg, agg_kwargs) = get_iris_aggregator(operator, operator_kwargs)
+    cube = cube.collapsed('latitude', agg, **agg_kwargs)
+    cube.data = cube.core_data().astype(np.float32, casting='same_kind')
+    return cube
 
 
 def compute_area_weights(cube):
@@ -331,35 +349,19 @@ def _try_adding_calculated_cell_area(cube: Cube) -> None:
     variables=['areacella', 'areacello'],
     required='prefer_at_least_one',
 )
-def area_statistics(cube: Cube, operator: str) -> Cube:
+def area_statistics(
+    cube: Cube,
+    operator: str,
+    operator_kwargs: Optional[dict] = None,
+) -> Cube:
     """Apply a statistical operator in the horizontal plane.
 
     We assume that the horizontal directions are ['longitude', 'latitude'].
 
-    This function can be used to apply several different operations in the
-    horizontal plane: mean, standard deviation, median variance, minimum and
-    maximum. The following options for `operator` are allowed:
-
-    +------------+--------------------------------------------------+
-    | `mean`     | Area weighted mean                               |
-    +------------+--------------------------------------------------+
-    | `median`   | Median (not area weighted)                       |
-    +------------+--------------------------------------------------+
-    | `std_dev`  | Standard Deviation (not area weighted)           |
-    +------------+--------------------------------------------------+
-    | `sum`      | Area weighted sum                                |
-    +------------+--------------------------------------------------+
-    | `variance` | Variance (not area weighted)                     |
-    +------------+--------------------------------------------------+
-    | `min`      | Minimum value                                    |
-    +------------+--------------------------------------------------+
-    | `max`      | Maximum value                                    |
-    +------------+--------------------------------------------------+
-    | `rms`      | Area weighted root mean square                   |
-    +------------+--------------------------------------------------+
-
-    Note that for area-weighted sums, the units of the resulting cube will be
-    multiplied by m :math:`^2`.
+    :ref:`This table <supported_stat_operator>` shows a list of supported
+    operators. All operators that support weights are by default weighted with
+    the grid cell areas. Note that for area-weighted sums, the units of the
+    resulting cube will be multiplied by m :math:`^2`.
 
     Parameters
     ----------
@@ -369,8 +371,12 @@ def area_statistics(cube: Cube, operator: str) -> Cube:
         regular 1D latitude and longitude coordinates so the cell areas can be
         computed using :func:`iris.analysis.cartography.area_weights`.
     operator:
-        The operation. Allowed options: `mean`, `median`, `min`, `max`,
-        `std_dev`, `sum`, `variance`, `rms`.
+        The operation. Used to determine the :class:`iris.analysis.Aggregator`
+        object used to calculate the statistics. Allowed options are given in
+        :ref:`this table <supported_stat_operator>`.
+    operator_kwargs:
+        Optional keyword arguments for the :class:`iris.analysis.Aggregator`
+        object defined by `operator`.
 
     Returns
     -------
@@ -385,21 +391,19 @@ def area_statistics(cube: Cube, operator: str) -> Cube:
 
     """
     original_dtype = cube.dtype
-    operation = get_iris_analysis_operation(operator)
-    coord_names = ['longitude', 'latitude']
 
-    # Calculate (weighted) statistics
-    if operator_accept_weights(operator):
+    # Get aggregator and correct kwargs
+    (agg, agg_kwargs) = get_iris_aggregator(operator, operator_kwargs)
+    if aggregator_accept_weights(agg) and agg_kwargs.get('weights', True):
         # If necessary, try to calculate cell_area (this only works for regular
         # grids and certain irregular grids, and fails for others)
         if not cube.cell_measures('cell_area'):
             _try_adding_calculated_cell_area(cube)
-        result = cube.collapsed(coord_names, operation, weights='cell_area')
+        agg_kwargs['weights'] = 'cell_area'
     else:
-        # Many IRIS analysis functions do not accept weights arguments.
-        # TODO: implement weighted stdev, median, var when available in iris.
-        # See iris issue: https://github.com/SciTools/iris/issues/3208
-        result = cube.collapsed(coord_names, operation)
+        agg_kwargs.pop('weights', None)
+
+    result = cube.collapsed(['latitude', 'longitude'], agg, **agg_kwargs)
 
     # Make sure to preserve dtype
     new_dtype = result.dtype

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -735,7 +735,7 @@ def multi_model_statistics(
     statistics:
         Statistical metrics to be computed, e.g. [``mean``, ``max``]. Allowed
         options are given in :ref:`this table <supported_stat_operator>`.
-    output_products:
+    output_products: dict
         For internal use only. A dict with statistics names as keys and
         preprocessorfiles as values. If products are passed as input, the
         statistics cubes will be assigned to these output products.
@@ -812,9 +812,14 @@ def multi_model_statistics(
     )
 
 
-def ensemble_statistics(products, statistics,
-                        output_products, span='overlap',
-                        ignore_scalar_coords=False):
+def ensemble_statistics(
+    products: set[PreprocessorFile] | Iterable[Cube],
+    statistics: list[str],
+    output_products,
+    span: str = 'overlap',
+    ignore_scalar_coords: bool = False,
+    statistics_kwargs: Optional[list[dict] | list[None]] = None,
+):
     """Entry point for ensemble statistics.
 
     An ensemble grouping is performed on the input products.
@@ -824,9 +829,9 @@ def ensemble_statistics(products, statistics,
 
     Parameters
     ----------
-    products: list
+    products:
         Cubes (or products) over which the statistics will be computed.
-    statistics: list
+    statistics:
         Statistical metrics to be computed, e.g. [``mean``, ``max``]. Choose
         from the operators listed in the iris.analysis package. Percentiles can
         be specified like ``pXX.YY``.
@@ -834,17 +839,20 @@ def ensemble_statistics(products, statistics,
         For internal use only. A dict with statistics names as keys and
         preprocessorfiles as values. If products are passed as input, the
         statistics cubes will be assigned to these output products.
-    span: str (default: 'overlap')
+    span:
         Overlap or full; if overlap, statitstics are computed on common time-
         span; if full, statistics are computed on full time spans, ignoring
         missing data.
-    ignore_scalar_coords: bool
+    ignore_scalar_coords:
         If True, remove any scalar coordinate in the input datasets before
         merging the input cubes into the multi-dataset cube. The resulting
         multi-dataset cube will have no scalar coordinates (the actual input
         datasets will remain unchanged). If False, scalar coordinates will
         remain in the input datasets, which might lead to merge conflicts in
         case the input datasets have different scalar coordinates.
+    statistics_kwargs:
+        Optional keyword arguments for the :class:`iris.analysis.Aggregator`
+        objects defined by `statistics`.
 
     Returns
     -------
@@ -865,4 +873,5 @@ def ensemble_statistics(products, statistics,
         groupby=ensemble_grouping,
         keep_input_datasets=False,
         ignore_scalar_coords=ignore_scalar_coords,
+        statistics_kwargs=statistics_kwargs,
     )

--- a/esmvalcore/preprocessor/_rolling_window.py
+++ b/esmvalcore/preprocessor/_rolling_window.py
@@ -1,26 +1,38 @@
 """Rolling-window operations on data cubes."""
 
 import logging
+from typing import Optional
 
-from ._shared import get_iris_analysis_operation
+from iris.cube import Cube
+
+from ._shared import get_iris_aggregator
 
 logger = logging.getLogger(__name__)
 
 
-def rolling_window_statistics(cube, coordinate, operator, window_length):
+def rolling_window_statistics(
+    cube: Cube,
+    coordinate: str,
+    operator: str,
+    window_length: int,
+    operator_kwargs: Optional[dict] = None,
+):
     """Compute rolling-window statistics over a coordinate.
 
     Parameters
     ----------
-    cube : iris.cube.Cube
+    cube:
         Input cube.
-    coordinate : str
+    coordinate:
         Coordinate over which the rolling-window statistics is calculated.
-    operator : str
-        Select operator to apply. Available operators: ``'mean'``,
-        ``'median'``, ``'std_dev'``, ``'sum'``, ``'variance'``, ``'min'``,
-        ``'max'``.
-    window_length : int
+    operator:
+        The operation. Used to determine the :class:`iris.analysis.Aggregator`
+        object used to calculate the statistics. Allowed options are given in
+        :ref:`this table <supported_stat_operator>`.
+    operator_kwargs:
+        Optional keyword arguments for the :class:`iris.analysis.Aggregator`
+        object defined by `operator`.
+    window_length:
         Size of the window to use.
 
     Returns
@@ -28,15 +40,8 @@ def rolling_window_statistics(cube, coordinate, operator, window_length):
     iris.cube.Cube
         Rolling-window statistics cube.
 
-    Raises
-    ------
-    iris.exceptions.CoordinateNotFoundError:
-        Cube does not have time coordinate.
-    ValueError:
-        Invalid ``'operator'`` given.
     """
-    operation = get_iris_analysis_operation(operator)
-    # applying rolling wondow
-    cube = cube.rolling_window(coordinate, operation, window_length)
+    (agg, agg_kwargs) = get_iris_aggregator(operator, operator_kwargs)
+    cube = cube.rolling_window(coordinate, agg, window_length, *agg_kwargs)
 
     return cube

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -117,8 +117,12 @@ def get_iris_aggregator(
     # Use dummy cube to check if aggregator_kwargs are valid
     cube = Cube([0], dim_coords_and_dims=[(DimCoord([0], var_name='x'), 0)])
     test_kwargs = dict(aggregator_kwargs)
-    if test_kwargs.get('weights'):
+
+    if (aggregator_accept_weights(aggregator) and
+            test_kwargs.get('weights', True)):
         test_kwargs['weights'] = np.array([1.0])
+    else:
+        test_kwargs.pop('weights', None)
     try:
         cube.collapsed('x', aggregator, **test_kwargs)
     except (ValueError, TypeError) as exc:

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -4,9 +4,16 @@ Shared functions for preprocessor.
 Utility functions that can be used for multiple preprocessor steps
 """
 import logging
+import re
+import warnings
+from typing import Optional
 
-import iris
 import iris.analysis
+import numpy as np
+from iris.coords import DimCoord
+from iris.cube import Cube
+
+from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 
 logger = logging.getLogger(__name__)
 
@@ -21,54 +28,123 @@ def guess_bounds(cube, coords):
     return cube
 
 
-def get_iris_analysis_operation(operator: str) -> iris.analysis.Aggregator:
-    """Determine the iris analysis operator from a :obj:`str`.
+def get_iris_aggregator(
+    operator: str,
+    operator_kwargs: Optional[dict] = None,
+) -> tuple[iris.analysis.Aggregator, dict]:
+    """Get :class:`iris.analysis.Aggregator` and keyword arguments.
 
-    Map string to functional operator.
+    Supports all available aggregators in :mod:`iris.analysis`.
 
     Parameters
     ----------
     operator:
-        A named operator.
+        A named operator that is used to search for aggregators. Will be
+        capitalized before searching for aggregators, i.e., `MEAN` **and**
+        `mean` will find :const:`iris.analysis.MEAN`.
+    operator_kwargs:
+        Optional keyword arguments for the aggregator.
 
     Returns
     -------
-    iris.analysis.Aggregator
+    tuple[iris.analysis.Aggregator, dict]
         Object that can be used within :meth:`iris.cube.Cube.collapsed`,
         :meth:`iris.cube.Cube.aggregated_by`, or
-        :meth:`iris.cube.Cube.rolling_window`.
+        :meth:`iris.cube.Cube.rolling_window` and the corresponding keyword
+        arguments.
 
     Raises
     ------
     ValueError
-        An invalid operator is specified. Allowed options: `mean`, `median`,
-        `std_dev`, `sum`, `variance`, `min`, `max`, `rms`.
+        An invalid `operator` is specified, i.e., it is not found in
+        :mod:`iris.analysis` or the returned object is not an
+        :class:`iris.analysis.Aggregator`.
+
     """
-    operators = [
-        'mean', 'median', 'std_dev', 'sum', 'variance', 'min', 'max', 'rms',
-    ]
-    operator = operator.lower()
-    if operator not in operators:
-        raise ValueError(
-            f"operator '{operator}' not recognised. Accepted values are: "
-            f"{', '.join(operators)}."
+    cap_operator = operator.upper()
+    if operator_kwargs is None:
+        operator_kwargs = {}
+    aggregator_kwargs = dict(operator_kwargs)
+
+    # Deprecations
+    if cap_operator == 'STD':
+        msg = (
+            f"The operator '{operator}' for computing the standard deviation "
+            f"has been deprecated in ESMValCore version 2.10.0 and is "
+            f"scheduled for removal in version 2.12.0. Please use 'std_dev' "
+            f"instead. This is an exact replacement."
         )
-    operation = getattr(iris.analysis, operator.upper())
-    return operation
+        warnings.warn(msg, ESMValCoreDeprecationWarning)
+        operator = 'std_dev'
+        cap_operator = 'STD_DEV'
+    elif re.match(r"^(P\d{1,2})(\.\d*)?$", cap_operator):
+        msg = (
+            f"Specifying percentile operators with the syntax 'pXX.YY' (here: "
+            f"'{operator}') has been deprecated in ESMValCore version 2.10.0 "
+            f"and is scheduled for removal in version 2.12.0. Please use "
+            f"`operator='percentile'` with `operator_kwargs: "
+            "{'percent': XX.YY}` instead. This is an exact replacement."
+        )
+        warnings.warn(msg, ESMValCoreDeprecationWarning)
+        aggregator_kwargs['percent'] = float(operator[1:])
+        operator = 'percentile'
+        cap_operator = 'PERCENTILE'
+
+    # Check if valid aggregator is found
+    if not hasattr(iris.analysis, cap_operator):
+        raise ValueError(
+            f"Aggregator '{operator}' not found in iris.analysis module"
+        )
+    aggregator = getattr(iris.analysis, cap_operator)
+    if not hasattr(aggregator, 'aggregate'):
+        raise ValueError(
+            f"Aggregator {aggregator} found by '{operator}' is not a valid "
+            f"iris.analysis.Aggregator"
+        )
+
+    # Since iris.analysis.MEDIAN is not lazy, use iris.analysis.PERCENTILE
+    # instead
+    if cap_operator == 'MEDIAN':
+        if aggregator_kwargs:
+            logger.warning(
+                "operator_kwargs are ignored for operator '%s', use operator "
+                "'percentile' instead",
+                operator,
+            )
+        aggregator = iris.analysis.PERCENTILE
+        aggregator_kwargs = {'percent': 50.0}
+
+    # Use dummy cube to check if aggregator_kwargs are valid
+    cube = Cube([0], dim_coords_and_dims=[(DimCoord([0], var_name='x'), 0)])
+    test_kwargs = dict(aggregator_kwargs)
+    if test_kwargs.get('weights'):
+        test_kwargs['weights'] = np.array([1.0])
+    try:
+        cube.collapsed('x', aggregator, **test_kwargs)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            f"Invalid operator_kwargs for operator '{operator}': {str(exc)}"
+        )
+
+    return (aggregator, aggregator_kwargs)
 
 
-def operator_accept_weights(operator: str) -> bool:
-    """Get if operator support weights.
+def aggregator_accept_weights(aggregator: iris.analysis.Aggregator) -> bool:
+    """Check if aggregator support weights.
 
     Parameters
     ----------
-    operator:
-        A named operator.
+    aggregator:
+        Aggregator to check.
 
     Returns
     -------
     bool
-        ``True`` if operator support weights, ``False`` otherwise.
+        ``True`` if aggregator support weights, ``False`` otherwise.
 
     """
-    return operator.lower() in ('mean', 'sum', 'rms')
+    weighted_aggregators_cls = (
+        iris.analysis.WeightedAggregator,
+        iris.analysis.WeightedPercentileAggregator,
+    )
+    return isinstance(aggregator, weighted_aggregators_cls)

--- a/tests/integration/recipe/test_check.py
+++ b/tests/integration/recipe/test_check.py
@@ -322,14 +322,6 @@ def test_invalid_multi_model_settings():
         "'span', 'statistics'].")
 
 
-def test_invalid_multi_model_statistics():
-    msg = (r"Invalid value encountered for `statistic` in preprocessor "
-           r"multi_model_statistics. Valid values are .* Got 'wrong'.")
-    with pytest.raises(RecipeError, match=msg):
-        check._verify_statistics(
-            INVALID_MM_SETTINGS['statistics'], 'multi_model_statistics')
-
-
 def test_invalid_multi_model_span():
     with pytest.raises(RecipeError) as rec_err:
         check._verify_span_value(INVALID_MM_SETTINGS['span'])
@@ -366,10 +358,3 @@ def test_invalid_multi_model_ignore_scalar_coords():
     assert str(rec_err.value) == (
         'Invalid value encountered for `ignore_scalar_coords`.'
         'Must be defined as a boolean (true or false). Got wrong.')
-
-
-def test_invalid_ensemble_statistics():
-    msg = (r"Invalid value encountered for `statistic` in preprocessor "
-           r"ensemble_statistics. Valid values are .* Got 'wrong'.")
-    with pytest.raises(RecipeError, match=msg):
-        check._verify_statistics(['wrong'], 'ensemble_statistics')

--- a/tests/integration/recipe/test_check.py
+++ b/tests/integration/recipe/test_check.py
@@ -305,23 +305,6 @@ INVALID_MM_SETTINGS = {
     }
 
 
-def test_invalid_multi_model_settings():
-    valid_keys = [
-        'groupby',
-        'ignore_scalar_coords',
-        'keep_input_datasets',
-        'span',
-        'statistics',
-    ]
-    with pytest.raises(RecipeError) as rec_err:
-        check._verify_arguments(INVALID_MM_SETTINGS, valid_keys)
-    assert str(rec_err.value) == (
-        "Unexpected keyword argument encountered: wrong_parametre. "
-        "Valid keywords are: "
-        "['groupby', 'ignore_scalar_coords', 'keep_input_datasets', "
-        "'span', 'statistics'].")
-
-
 def test_invalid_multi_model_span():
     with pytest.raises(RecipeError) as rec_err:
         check._verify_span_value(INVALID_MM_SETTINGS['span'])

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -3363,3 +3363,75 @@ def test_diag_selection(tmp_path, patched_datafinder, session, diags_to_run,
     task_names = {task.name for task in recipe.tasks.flatten()}
 
     assert tasks_run == task_names
+
+
+def test_mm_stats_invalid_arg(tmp_path, patched_datafinder, session):
+    content = dedent("""
+        preprocessors:
+          test:
+            multi_model_statistics:
+              span: overlap
+              statistics: [mean]
+              invalid_argument: 1
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              chl_default:
+                short_name: chl
+                mip: Oyr
+                preprocessor: test
+                timerange: '2000/2010'
+                additional_datasets:
+                  - {project: CMIP5, dataset: CanESM2, exp: historical,
+                     ensemble: r1i1p1}
+            scripts: null
+        """)
+    with pytest.raises(ValueError):
+        get_recipe(tmp_path, content, session)
+
+
+def test_mm_stats_missing_arg(tmp_path, patched_datafinder, session):
+    content = dedent("""
+        preprocessors:
+          test:
+            multi_model_statistics:
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              chl_default:
+                short_name: chl
+                mip: Oyr
+                preprocessor: test
+                timerange: '2000/2010'
+                additional_datasets:
+                  - {project: CMIP5, dataset: CanESM2, exp: historical,
+                     ensemble: r1i1p1}
+            scripts: null
+        """)
+    with pytest.raises(ValueError):
+        get_recipe(tmp_path, content, session)
+
+
+def test_area_statistics_invalid_args(tmp_path, patched_datafinder, session):
+    content = dedent("""
+        preprocessors:
+          test:
+            area_statistics:
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              chl_default:
+                short_name: chl
+                mip: Oyr
+                preprocessor: test
+                timerange: '2000/2010'
+                additional_datasets:
+                  - {project: CMIP5, dataset: CanESM2, exp: historical,
+                     ensemble: r1i1p1}
+            scripts: null
+        """)
+    with pytest.raises(ValueError):
+        get_recipe(tmp_path, content, session)

--- a/tests/unit/preprocessor/_area/test_area.py
+++ b/tests/unit/preprocessor/_area/test_area.py
@@ -125,7 +125,7 @@ class Test(tests.Test):
     def test_area_statistics_median(self):
         """Test for area average of a 2D field."""
         result = area_statistics(self.grid, 'median')
-        expected = np.ma.array([1., 1.], dtype=np.float32)
+        expected = np.array([1., 1.], dtype=np.float32)
         self.assert_array_equal(result.data, expected)
         self.assertEqual(result.units, 'kg m-2 s-1')
 

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -392,8 +392,8 @@ def test_lazy_data_inconsistent_times(span):
 VALIDATION_DATA_FAIL = (
     ('percentile', ValueError),
     ('wpercentile', ValueError),
-    ('count', TypeError),
-    ('proportion', TypeError),
+    ('count', ValueError),
+    ('proportion', ValueError),
 )
 
 
@@ -420,7 +420,7 @@ def test_get_consistent_time_unit(calendar1, calendar2, expected):
     """Test same calendar returned or default if calendars differ.
 
     Expected behaviour: If the calendars are the same, return that one.
-    If the calendars are not the same, return 'standard'.
+    If the calendars are not the same, return 'stanfdard'.
     """
     cubes = (
         generate_cube_from_dates('monthly', calendar=calendar1),

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -2156,5 +2156,65 @@ class TestResampleTime(tests.Test):
             resample_time(cube, day=16)
 
 
+@pytest.fixture
+def easy_2d_cube():
+    """Create easy 2D cube to test statistical operators."""
+    time = iris.coords.DimCoord(
+        [2.0, 3.0],
+        bounds=[[-0.5, 2.5], [2.5, 3.5]],
+        standard_name='time',
+        units='days since 2000-01-01',
+    )
+    lat = iris.coords.DimCoord(
+        [0.0, 1.0], standard_name='latitude', units='degrees'
+    )
+    cube = Cube(
+        np.arange(4, dtype=np.float32).reshape(2, 2),
+        standard_name='air_temperature',
+        units='K',
+        dim_coords_and_dims=[(time, 0), (lat, 1)],
+    )
+    return cube
+
+
+@pytest.mark.parametrize(
+    'operator,kwargs,expected_data,expected_units',
+    [
+        ('gmean', {}, [0.0, 1.7320509], 'K'),
+        ('hmean', {}, [0.0, 1.5], 'K'),
+        ('max', {}, [2.0, 3.0], 'K'),
+        ('mean', {}, [0.5, 1.5], 'K'),
+        ('mean', {'weights': False}, [1.0, 2.0], 'K'),
+        ('median', {}, [1.0, 2.0], 'K'),
+        ('min', {}, [0.0, 1.0], 'K'),
+        ('peak', {}, [2.0, 3.0], 'K'),
+        ('percentile', {'percent': 0.0}, [0.0, 1.0], 'K'),
+        ('rms', {}, [1.0, 1.7320509], 'K'),
+        ('rms', {'weights': False}, [1.414214, 2.236068], 'K'),
+        ('std_dev', {}, [1.414214, 1.414214], 'K'),
+        ('std_dev', {'ddof': 0}, [1.0, 1.0], 'K'),
+        ('sum', {}, [2.0, 6.0], 'K day'),
+        ('sum', {'weights': False}, [2.0, 4.0], 'K'),
+        ('variance', {}, [2.0, 2.0], 'K2'),
+        ('variance', {'ddof': 0}, [1.0, 1.0], 'K2'),
+        ('wpercentile', {'percent': 50.0}, [0.5, 1.5], 'K'),
+    ]
+)
+def test_statistical_operators(
+    operator, kwargs, expected_data, expected_units, easy_2d_cube
+):
+    """Test ``climate_statistics`` with different operators."""
+    res = climate_statistics(easy_2d_cube, operator, operator_kwargs=kwargs)
+
+    assert res.var_name == easy_2d_cube.var_name
+    assert res.long_name == easy_2d_cube.long_name
+    assert res.standard_name == easy_2d_cube.standard_name
+    assert res.attributes == easy_2d_cube.attributes
+    assert res.units == expected_units
+    assert res.coord('latitude') == easy_2d_cube.coord('latitude')
+    assert res.coord('time').shape == (1, )
+    np.testing.assert_allclose(res.data, expected_data, atol=1e-6, rtol=1e-6)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/preprocessor/test_shared.py
+++ b/tests/unit/preprocessor/test_shared.py
@@ -1,0 +1,189 @@
+"""Unit tests for `esmvalcore.preprocessor._shared`."""
+import warnings
+import iris.analysis
+import pytest
+from esmvalcore.exceptions import ESMValCoreDeprecationWarning
+
+from esmvalcore.preprocessor._shared import (
+    aggregator_accept_weights,
+    get_iris_aggregator,
+)
+
+
+@pytest.mark.parametrize('operator', ['gmean', 'GmEaN', 'GMEAN'])
+def test_get_iris_aggregator_gmean(operator):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator)
+    assert agg == iris.analysis.GMEAN
+    assert agg_kwargs == {}
+
+
+@pytest.mark.parametrize('operator', ['hmean', 'hMeAn', 'HMEAN'])
+def test_get_iris_aggregator_hmean(operator):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator)
+    assert agg == iris.analysis.HMEAN
+    assert agg_kwargs == {}
+
+
+@pytest.mark.parametrize('operator', ['max', 'mAx', 'MAX'])
+def test_get_iris_aggregator_max(operator):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator)
+    assert agg == iris.analysis.MAX
+    assert agg_kwargs == {}
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'weights': True}])
+@pytest.mark.parametrize('operator', ['mean', 'mEaN', 'MEAN'])
+def test_get_iris_aggregator_mean(operator, kwargs):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    assert agg == iris.analysis.MEAN
+    assert agg_kwargs == kwargs
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'weights': True}])
+@pytest.mark.parametrize('operator', ['median', 'mEdIaN', 'MEDIAN'])
+def test_get_iris_aggregator_median(operator, kwargs, caplog):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    assert agg == iris.analysis.PERCENTILE
+    assert agg_kwargs == {'percent': 50.0}
+    if kwargs:
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == 'WARNING'
+    else:
+        assert len(caplog.records) == 0
+
+
+@pytest.mark.parametrize('operator', ['min', 'MiN', 'MIN'])
+def test_get_iris_aggregator_min(operator):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator)
+    assert agg == iris.analysis.MIN
+    assert agg_kwargs == {}
+
+
+@pytest.mark.parametrize('operator', ['peak', 'pEaK', 'PEAK'])
+def test_get_iris_aggregator_peak(operator):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator)
+    assert agg == iris.analysis.PEAK
+    assert agg_kwargs == {}
+
+
+@pytest.mark.parametrize('kwargs', [{'percent': 80.0, 'alphap': 0.5}])
+@pytest.mark.parametrize('operator', ['percentile', 'PERCENTILE'])
+def test_get_iris_aggregator_percentile(operator, kwargs):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    assert agg == iris.analysis.PERCENTILE
+    assert agg_kwargs == kwargs
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'alphap': 0.5}])
+@pytest.mark.parametrize('operator', ['p10', 'P10.5'])
+def test_get_iris_aggregator_pxxyy(operator, kwargs):
+    """Test ``get_iris_aggregator``."""
+    with pytest.warns(ESMValCoreDeprecationWarning):
+        (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    assert agg == iris.analysis.PERCENTILE
+    assert agg_kwargs == {'percent': float(operator[1:]), **kwargs}
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'weights': True}])
+@pytest.mark.parametrize('operator', ['rms', 'rMs', 'RMS'])
+def test_get_iris_aggregator_rms(operator, kwargs):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    assert agg == iris.analysis.RMS
+    assert agg_kwargs == kwargs
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'ddof': 1}])
+@pytest.mark.parametrize('operator', ['std', 'STD', 'std_dev', 'STD_DEV'])
+def test_get_iris_aggregator_std(operator, kwargs):
+    """Test ``get_iris_aggregator``."""
+    if operator.lower() == 'std':
+        with pytest.warns(ESMValCoreDeprecationWarning):
+            (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter(
+                'error', category=ESMValCoreDeprecationWarning
+            )
+            (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    assert agg == iris.analysis.STD_DEV
+    assert agg_kwargs == kwargs
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'weights': True}])
+@pytest.mark.parametrize('operator', ['sum', 'SuM', 'SUM'])
+def test_get_iris_aggregator_sum(operator, kwargs):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    assert agg == iris.analysis.SUM
+    assert agg_kwargs == kwargs
+
+
+@pytest.mark.parametrize('operator', ['variance', 'vArIaNcE', 'VARIANCE'])
+def test_get_iris_aggregator_variance(operator):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator)
+    assert agg == iris.analysis.VARIANCE
+    assert agg_kwargs == {}
+
+
+@pytest.mark.parametrize('kwargs', [{'percent': 10, 'weights': True}])
+@pytest.mark.parametrize('operator', ['wpercentile', 'WPERCENTILE'])
+def test_get_iris_aggregator_wpercentile(operator, kwargs):
+    """Test ``get_iris_aggregator``."""
+    (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
+    assert agg == iris.analysis.WPERCENTILE
+    assert agg_kwargs == kwargs
+
+
+
+@pytest.mark.parametrize('operator', ['invalid', 'iNvAliD', 'INVALID'])
+def test_get_iris_aggregator_invalid_operator_fail(operator):
+    """Test ``get_iris_aggregator``."""
+    with pytest.raises(ValueError):
+        get_iris_aggregator(operator)
+
+
+@pytest.mark.parametrize('operator', ['mean', 'mEaN', 'MEAN'])
+def test_get_iris_aggregator_no_aggregator_fail(operator, monkeypatch):
+    """Test ``get_iris_aggregator``."""
+    monkeypatch.setattr(iris.analysis, 'MEAN', 1)
+    with pytest.raises(ValueError):
+        get_iris_aggregator(operator)
+
+
+def test_get_iris_aggregator_invalid_kwarg():
+    """Test ``get_iris_aggregator``."""
+    with pytest.raises(ValueError):
+        get_iris_aggregator('max', {'INVALID_KWARG': 1})
+
+
+def test_get_iris_aggregator_missing_kwarg():
+    """Test ``get_iris_aggregator``."""
+    with pytest.raises(ValueError):
+        get_iris_aggregator('percentile')
+
+
+@pytest.mark.parametrize(
+    'aggregator,result',
+    [
+        (iris.analysis.MEAN, True),
+        (iris.analysis.SUM, True),
+        (iris.analysis.RMS, True),
+        (iris.analysis.WPERCENTILE, True),
+        (iris.analysis.MAX, False),
+        (iris.analysis.MIN, False),
+        (iris.analysis.PERCENTILE, False),
+    ],
+)
+def test_aggregator_accept_weights(aggregator, result):
+    """Test ``aggregator_accept_weights``."""
+    assert aggregator_accept_weights(aggregator) == result

--- a/tests/unit/preprocessor/test_shared.py
+++ b/tests/unit/preprocessor/test_shared.py
@@ -1,9 +1,10 @@
 """Unit tests for `esmvalcore.preprocessor._shared`."""
 import warnings
+
 import iris.analysis
 import pytest
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 
+from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 from esmvalcore.preprocessor._shared import (
     aggregator_accept_weights,
     get_iris_aggregator,
@@ -34,7 +35,7 @@ def test_get_iris_aggregator_max(operator):
     assert agg_kwargs == {}
 
 
-@pytest.mark.parametrize('kwargs', [{}, {'weights': True}])
+@pytest.mark.parametrize('kwargs', [{}, {'weights': True}, {'weights': False}])
 @pytest.mark.parametrize('operator', ['mean', 'mEaN', 'MEAN'])
 def test_get_iris_aggregator_mean(operator, kwargs):
     """Test ``get_iris_aggregator``."""
@@ -142,7 +143,6 @@ def test_get_iris_aggregator_wpercentile(operator, kwargs):
     (agg, agg_kwargs) = get_iris_aggregator(operator, kwargs)
     assert agg == iris.analysis.WPERCENTILE
     assert agg_kwargs == kwargs
-
 
 
 @pytest.mark.parametrize('operator', ['invalid', 'iNvAliD', 'INVALID'])

--- a/tests/unit/recipe/test_recipe.py
+++ b/tests/unit/recipe/test_recipe.py
@@ -332,6 +332,95 @@ def test_update_multiproduct_multi_model_statistics():
     assert 'MultiModelStd_Dev' in str(stats['std_dev'].filename)
 
 
+def test_update_multiproduct_multi_model_statistics_percentile():
+    """Test ``_update_multiproduct``."""
+    settings = {
+        'multi_model_statistics': {
+            'statistics': ['percentile', 'percentile'],
+            'statistics_kwargs': [{'percent': 5.0}, {'percent': 95.0}],
+        },
+    }
+    common_attributes = {
+        'project': 'CMIP6',
+        'diagnostic': 'd',
+        'variable_group': 'var',
+    }
+    cube = iris.cube.Cube(np.array([1]))
+    products = [
+        PreprocessorFile(cube, 'A',
+                         attributes={'dataset': 'a',
+                                     'timerange': '2000/2005',
+                                     **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'B',
+                         attributes={'dataset': 'b',
+                                     'timerange': '2001/2004',
+                                     **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'C',
+                         attributes={'dataset': 'c',
+                                     'timerange': '1999/2004',
+                                     **common_attributes},
+                         settings=settings),
+        PreprocessorFile(cube, 'D',
+                         attributes={'dataset': 'd',
+                                     'timerange': '2002/2010',
+                                     **common_attributes},
+                         settings=settings),
+    ]
+    order = ('load', 'multi_model_statistics', 'save')
+    preproc_dir = '/preproc'
+    step = 'multi_model_statistics'
+    output, settings = _recipe._update_multiproduct(
+        products, order, preproc_dir, step)
+
+    assert len(output) == 2
+
+    filenames = [p.filename for p in output]
+    assert (
+        Path('/preproc/d/var/CMIP6_MultiModelPercentile5-0_2002-2004.nc') in
+        filenames
+    )
+    assert (
+        Path('/preproc/d/var/CMIP6_MultiModelPercentile95-0_2002-2004.nc') in
+        filenames
+    )
+
+    for product in output:
+        for attr in common_attributes:
+            assert attr in product.attributes
+            assert product.attributes[attr] == common_attributes[attr]
+            assert 'alias' in product.attributes
+            assert 'dataset' in product.attributes
+            assert 'multi_model_statistics' in product.attributes
+            assert 'timerange' in product.attributes
+            assert product.attributes['timerange'] == '2002/2004'
+            assert 'start_year' in product.attributes
+            assert product.attributes['start_year'] == 2002
+            assert 'end_year' in product.attributes
+            assert product.attributes['end_year'] == 2004
+        if 'MultiModelPercentile5-0' in str(product.filename):
+            assert product.attributes['alias'] == 'MultiModelPercentile5-0'
+            assert product.attributes['dataset'] == 'MultiModelPercentile5-0'
+            assert (product.attributes['multi_model_statistics'] ==
+                    'MultiModelPercentile5-0')
+        elif 'MultiModelPercentile95-0' in str(product.filename):
+            assert product.attributes['alias'] == 'MultiModelPercentile95-0'
+            assert product.attributes['dataset'] == 'MultiModelPercentile95-0'
+            assert (product.attributes['multi_model_statistics'] ==
+                    'MultiModelPercentile95-0')
+
+    assert len(settings) == 1
+    output_products = settings['output_products']
+    assert len(output_products) == 1
+    stats = output_products['']
+    assert len(stats) == 2
+    assert 'percentile5-0' in stats
+    assert 'percentile95-0' in stats
+    assert 'MultiModelPercentile5-0' in str(stats['percentile5-0'].filename)
+    assert 'MultiModelPercentile95-0' in str(stats['percentile95-0'].filename)
+
+
 def test_update_multiproduct_ensemble_statistics():
     """Test ``_update_multiproduct``."""
     settings = {'ensemble_statistics': {'statistics': ['median'],
@@ -391,6 +480,75 @@ def test_update_multiproduct_ensemble_statistics():
     assert 'median' in stats
     assert stats['median'].filename == Path(
         '/preproc/d/var/CMIP6_CanESM2_EnsembleMedian_2000-2000.nc')
+
+
+def test_update_multiproduct_ensemble_statistics_percentile():
+    """Test ``_update_multiproduct``."""
+    settings = {
+        'ensemble_statistics': {
+            'statistics': ['percentile', 'percentile'],
+            'statistics_kwargs': [{'percent': 5}],
+            'span': 'full',
+        },
+    }
+
+    common_attributes = {
+        'dataset': 'CanESM2',
+        'project': 'CMIP6',
+        'timerange': '2000/2000',
+        'diagnostic': 'd',
+        'variable_group': 'var',
+    }
+    cube = iris.cube.Cube(np.array([1]))
+    products = [
+        PreprocessorFile(cube, 'A',
+                         attributes=common_attributes,
+                         settings=settings),
+        PreprocessorFile(cube, 'B',
+                         attributes=common_attributes,
+                         settings=settings),
+        PreprocessorFile(cube, 'C',
+                         attributes=common_attributes,
+                         settings=settings),
+        PreprocessorFile(cube, 'D',
+                         attributes=common_attributes,
+                         settings=settings),
+    ]
+    order = ('load', 'ensemble_statistics', 'save')
+    preproc_dir = '/preproc'
+    step = 'ensemble_statistics'
+    output, settings = _recipe._update_multiproduct(
+        products, order, preproc_dir, step)
+
+    assert len(output) == 1
+    product = list(output)[0]
+    assert product.filename == Path(
+        '/preproc/d/var/CMIP6_CanESM2_EnsemblePercentile5_2000-2000.nc')
+
+    for attr in common_attributes:
+        assert attr in product.attributes
+        assert product.attributes[attr] == common_attributes[attr]
+        assert 'alias' in product.attributes
+        assert product.attributes['alias'] == 'EnsemblePercentile5'
+        assert 'dataset' in product.attributes
+        assert product.attributes['dataset'] == 'CanESM2'
+        assert 'ensemble_statistics' in product.attributes
+        assert product.attributes['ensemble_statistics'] == (
+            'EnsemblePercentile5'
+        )
+        assert 'start_year' in product.attributes
+        assert product.attributes['start_year'] == 2000
+        assert 'end_year' in product.attributes
+        assert product.attributes['end_year'] == 2000
+
+    assert len(settings) == 1
+    output_products = settings['output_products']
+    assert len(output_products) == 1
+    stats = output_products['CMIP6_CanESM2']
+    assert len(stats) == 1
+    assert 'percentile5' in stats
+    assert stats['percentile5'].filename == Path(
+        '/preproc/d/var/CMIP6_CanESM2_EnsemblePercentile5_2000-2000.nc')
 
 
 def test_update_multiproduct_no_product():


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR unifies all statistics preprocessors. Now, all statistics prepreprocessors support the same operators and have a common documentation. In additon, arbitrary keyword arguments are now supported through `operator_kwargs`.

### Examples:

```yaml
  preprocessors:
    monthly_percentiles:
      climate_statistics:
        period: monthly
        operator: percentile
        operator_kwargs:
          percent: 95.0

  preprocessors:
    mm_stats:
      multi_model_statistics:
        span: overlap
        statistics: [percentile, median, percentile]
        statistics_kwargs:
          - {percent: 5}   # keyword arguments for 1st percentile
          - {}             # keyword arguments for median
          - {percent: 95}  # keyword arguments for 2nd percentile
```

### Deprecation

Prior to this PR, the only preprocessors that supported percentiles were `multi_model_statistics` and `ensemble_statistics`. The syntax was for example `statistics: [p50.0]`, which can now be specified by using `statistics: [percentile]` in combination with `statistics_kwargs: [{percent: 50.0}]`. The following example shows how to modify existing recipes:

Old:

```yaml
  preprocessors:
    mm_stats:
      multi_model_statistics:
        span: overlap
        statistics: [p5, p95]
```

New:

```yaml
  preprocessors:
    mm_stats:
      multi_model_statistics:
        span: overlap
        statistics: [percentile, percentile]
        statistics_kwargs:
          - {percent: 5}   # keyword arguments for 1st percentile
          - {percent: 95}  # keyword arguments for 2nd percentile
```

The old syntax will be deprecated with version 2.10 and removed with version 2.12.


<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

Closes #1617
Closes #1249
Closes #1851

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] ~[🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~ One deprecation, see above
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
