### PR TITLE
Ensure compatible zstandard and zstd versions for .conda support

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,7 @@ build:
   jobs:
     pre_create_environment:
       # update mamba just in case
+      - mamba install --yes --quiet --name=base zstandard
       - mamba update --yes --quiet --name=base mamba
       - mamba --version
     post_create_environment:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
   jobs:
     pre_create_environment:
       # update mamba just in case
-      - mamba install --yes --name=base zstandard
+      - mamba install --yes --name=base 'zstandard>=0.20'
       - mamba update --yes --name=base mamba
       - mamba --version
       - mamba list --name=base

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ build:
       # update mamba just in case
       - mamba install --yes --name=base 'zstandard>=0.20'
       - mamba list --name=base
-      - mamba update --yes --name=base mamba
+      - mamba update --yes --name=base mamba 'zstd=1.5.2'
       - mamba --version
       - mamba list --name=base
       - conda env export --name=base

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,7 @@ build:
       - mamba update --yes --name=base mamba
       - mamba --version
       - mamba list --name=base
+      - conda env export --name=base
       - mamba env create --name 2204-tst --file environment.yml
     post_create_environment:
       - conda run -n ${CONDA_DEFAULT_ENV} mamba list

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,10 +14,12 @@ build:
   jobs:
     pre_create_environment:
       # update mamba just in case
-      - mamba install --yes --quiet --name=base zstandard
-      - mamba update --yes --quiet --name=base mamba
+      - mamba install --yes --name=base zstandard
+      - mamba update --yes --name=base mamba
       - mamba --version
+      - mamba list --name=base
     post_create_environment:
+      - conda run -n ${CONDA_DEFAULT_ENV} mamba list
       # use conda run executable wrapper to have all env variables
       - conda run -n ${CONDA_DEFAULT_ENV} mamba --version
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,13 +14,9 @@ build:
   jobs:
     pre_create_environment:
       # update mamba just in case
-      - mamba install --yes --name=base 'zstandard>=0.20'
-      - mamba list --name=base
-      - mamba update --yes --name=base mamba 'zstd=1.5.2'
+      - mamba update --yes --quiet --name=base mamba 'zstd=1.5.2'
       - mamba --version
       - mamba list --name=base
-      - conda env export --name=base
-      - mamba env create --name 2204-tst --file environment.yml
     post_create_environment:
       - conda run -n ${CONDA_DEFAULT_ENV} mamba list
       # use conda run executable wrapper to have all env variables

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ build:
     pre_create_environment:
       # update mamba just in case
       - mamba install --yes --name=base 'zstandard>=0.20'
+      - mamba list --name=base
       - mamba update --yes --name=base mamba
       - mamba --version
       - mamba list --name=base

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,7 @@ build:
       - mamba update --yes --name=base mamba
       - mamba --version
       - mamba list --name=base
+      - mamba env create --name 2204-tst --file environment.yml
     post_create_environment:
       - conda run -n ${CONDA_DEFAULT_ENV} mamba list
       # use conda run executable wrapper to have all env variables


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

The library `zstd` and its Python binding `zstandard` must be installed in compatible versions. Proper pinning was added to the Conda-forge packages recently (see https://github.com/conda-forge/zstandard-feedstock/pull/48, https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/484), but for some reason that doesn't get picked up by our setup. As a stop-gap solution to get our builds running again, I am here adding a pin to the matching versions of the packages.

Closes #2203 


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
