### PR TITLE
Remove deprecated callback argument from preprocessor ``load`` function

### DIFF
--- a/esmvalcore/_recipe/recipe.py
+++ b/esmvalcore/_recipe/recipe.py
@@ -213,9 +213,6 @@ def _get_default_settings(dataset):
 
     settings = {}
 
-    # Configure (deprecated, remove for v2.10.0) load callback
-    settings['load'] = {'callback': 'default'}
-
     if _derive_needed(dataset):
         settings['derive'] = {
             'short_name': facets['short_name'],

--- a/esmvalcore/dataset.py
+++ b/esmvalcore/dataset.py
@@ -677,19 +677,15 @@ class Dataset:
         iris.cube.Cube
             An :mod:`iris` cube with the data corresponding the the dataset.
         """
-        return self._load_with_callback(callback='default')
-
-    def _load_with_callback(self, callback):
-        # TODO: Remove the callback argument for v2.10.0.
         input_files = list(self.files)
         for supplementary_dataset in self.supplementaries:
             input_files.extend(supplementary_dataset.files)
         esgf.download(input_files, self.session['download_dir'])
 
-        cube = self._load(callback)
+        cube = self._load()
         supplementary_cubes = []
         for supplementary_dataset in self.supplementaries:
-            supplementary_cube = supplementary_dataset._load(callback)
+            supplementary_cube = supplementary_dataset._load()
             supplementary_cubes.append(supplementary_cube)
 
         output_file = _get_output_file(self.facets, self.session.preproc_dir)
@@ -704,7 +700,7 @@ class Dataset:
 
         return cubes[0]
 
-    def _load(self, callback) -> Cube:
+    def _load(self) -> Cube:
         """Load self.files into an iris cube and return it."""
         if not self.files:
             lines = [
@@ -731,7 +727,6 @@ class Dataset:
             **self.facets,
         }
         settings['load'] = {
-            'callback': callback,
             'ignore_warnings': get_ignored_warnings(
                 self.facets['project'], 'load'
             ),

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -478,10 +478,7 @@ class PreprocessorFile(TrackedFile):
     def cubes(self):
         """Cubes."""
         if self._cubes is None:
-            callback = self.settings.get('load', {}).get('callback')
-            self._cubes = [
-                ds._load_with_callback(callback) for ds in self.datasets
-            ]
+            self._cubes = [ds.load() for ds in self.datasets]
         return self._cubes
 
     @cubes.setter

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -96,7 +96,7 @@ def _get_attr_from_field_coord(ncfield, coord_name, attr):
     return None
 
 
-def concatenate_callback(raw_cube, field, _):
+def _load_callback(raw_cube, field, _):
     """Use this callback to fix anything Iris tries to break."""
     # Remove attributes that cause issues with merging and concatenation
     _delete_attributes(
@@ -122,7 +122,6 @@ def _delete_attributes(iris_object, atts):
 
 def load(
     file: str | Path,
-    callback: Optional[Callable] = None,
     ignore_warnings: Optional[list[dict]] = None,
 ) -> CubeList:
     """Load iris cubes from string or Path objects.
@@ -131,11 +130,6 @@ def load(
     ----------
     file:
         File to be loaded. Could be string or POSIX Path object.
-    callback:
-        Callback function passed to :func:`iris.load_raw`.
-
-        .. deprecated:: 2.8.0
-            This argument will be removed in 2.10.0.
     ignore_warnings:
         Keyword arguments passed to :func:`warnings.filterwarnings` used to
         ignore warnings issued by :func:`iris.load_raw`. Each list element
@@ -152,14 +146,6 @@ def load(
         Cubes are empty.
 
     """
-    if not (callback is None or callback == 'default'):
-        msg = ("The argument `callback` has been deprecated in "
-               "ESMValCore version 2.8.0 and is scheduled for removal in "
-               "version 2.10.0.")
-        warnings.warn(msg, ESMValCoreDeprecationWarning)
-    if callback == 'default':
-        callback = concatenate_callback
-
     file = Path(file)
     logger.debug("Loading:\n%s", file)
 
@@ -191,7 +177,7 @@ def load(
         # warnings.filterwarnings
         # (see https://github.com/SciTools/cf-units/issues/240)
         with suppress_errors():
-            raw_cubes = iris.load_raw(file, callback=callback)
+            raw_cubes = iris.load_raw(file, callback=_load_callback)
     logger.debug("Done with loading %s", file)
 
     if not raw_cubes:

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -6,7 +6,6 @@ import logging
 import os
 import shutil
 import warnings
-from collections.abc import Callable
 from itertools import groupby
 from pathlib import Path
 from typing import Optional

--- a/tests/integration/preprocessor/_io/test_load.py
+++ b/tests/integration/preprocessor/_io/test_load.py
@@ -10,7 +10,7 @@ import numpy as np
 from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
 
-from esmvalcore.preprocessor._io import concatenate_callback, load
+from esmvalcore.preprocessor._io import load
 
 
 def _create_sample_cube():
@@ -60,7 +60,7 @@ class TestLoad(unittest.TestCase):
                 cube.attributes[attr] = attr
             self._save_cube(cube)
         for temp_file in self.temp_files:
-            cubes = load(temp_file, callback='default')
+            cubes = load(temp_file)
             cube = cubes[0]
             self.assertEqual(1, len(cubes))
             self.assertTrue((cube.data == np.array([1, 2])).all())
@@ -79,7 +79,7 @@ class TestLoad(unittest.TestCase):
                     coord.attributes[attr] = attr
             self._save_cube(cube)
         for temp_file in self.temp_files:
-            cubes = load(temp_file, callback='default')
+            cubes = load(temp_file)
             cube = cubes[0]
             self.assertEqual(1, len(cubes))
             self.assertTrue((cube.data == np.array([1, 2])).all())
@@ -94,7 +94,7 @@ class TestLoad(unittest.TestCase):
         cube = _create_sample_cube()
         temp_file = self._save_cube(cube)
 
-        cubes = load(temp_file, callback=concatenate_callback)
+        cubes = load(temp_file)
         cube = cubes[0]
         self.assertEqual(1, len(cubes))
         self.assertTrue((cube.data == np.array([1, 2])).all())

--- a/tests/integration/preprocessor/test_preprocessing_task.py
+++ b/tests/integration/preprocessor/test_preprocessing_task.py
@@ -16,7 +16,7 @@ def test_load_save_task(tmp_path):
     iris.save(cube, in_file)
     dataset = Dataset(short_name='tas')
     dataset.files = [in_file]
-    dataset._load_with_callback = lambda _: cube.copy()
+    dataset.load = lambda: cube.copy()
 
     # Create task
     task = PreprocessingTask([
@@ -57,11 +57,11 @@ def test_load_save_and_other_task(tmp_path, monkeypatch):
 
     dataset1 = Dataset(short_name='tas', dataset='dataset1')
     dataset1.files = [file1]
-    dataset1._load_with_callback = lambda _: in_cube.copy()
+    dataset1.load = lambda: in_cube.copy()
 
     dataset2 = Dataset(short_name='tas', dataset='dataset1')
     dataset2.files = [file2]
-    dataset2._load_with_callback = lambda _: in_cube.copy()
+    dataset2.load = lambda: in_cube.copy()
 
     # Create some mock preprocessor functions and patch
     # `esmvalcore.preprocessor` so it uses them.

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -82,7 +82,6 @@ MANDATORY_SCRIPT_SETTINGS_KEYS = (
 )
 
 DEFAULT_PREPROCESSOR_STEPS = (
-    'load',
     'remove_supplementary_variables',
     'save',
 )
@@ -106,9 +105,6 @@ def create_test_file(filename, tracking_id=None):
 def _get_default_settings_for_chl(save_filename):
     """Get default preprocessor settings for chl."""
     defaults = {
-        'load': {
-            'callback': 'default'
-        },
         'remove_supplementary_variables': {},
         'save': {
             'compress': False,
@@ -557,9 +553,6 @@ def test_default_fx_preprocessor(tmp_path, patched_datafinder, session):
     assert preproc_dir.startswith(str(tmp_path))
 
     defaults = {
-        'load': {
-            'callback': 'default'
-        },
         'remove_supplementary_variables': {},
         'save': {
             'compress': False,

--- a/tests/unit/recipe/test_recipe.py
+++ b/tests/unit/recipe/test_recipe.py
@@ -541,7 +541,6 @@ def test_get_default_settings(mocker):
 
     settings = _recipe._get_default_settings(dataset)
     assert settings == {
-        'load': {'callback': 'default'},
         'remove_supplementary_variables': {},
         'save': {'compress': False, 'alias': 'sic'},
     }

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1684,7 +1684,6 @@ def test_load(mocker, session):
 
     load_args = {
         'load': {
-            'callback': 'default',
             'ignore_warnings': None,
         },
         'fix_file': {


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Remove the deprecated argument ``callback`` from the preprocessor function [``load``](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.load).

Upgrade instructions: use [`esmvalcore.dataset.Dataset.load()`](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.dataset.html#esmvalcore.dataset.Dataset.load) instead. 

Closes #1800

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] ~[🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
