### PR TITLE
Removed deprecated configuration option `offline`

### DIFF
--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -337,7 +337,6 @@ class ESMValTool():
             max_datasets=None,
             max_years=None,
             skip_nonexistent=None,
-            offline=None,
             search_esgf=None,
             diagnostics=None,
             check_level=None,
@@ -365,15 +364,6 @@ class ESMValTool():
             Maximum number of years to use.
         skip_nonexistent: bool, optional
             If True, the run will not fail if some datasets are not available.
-        offline: bool, optional
-            If True, the tool will not download missing data from ESGF.
-
-            .. deprecated:: 2.8.0
-                This option has been deprecated in ESMValCore version 2.8.0 and
-                is scheduled for removal in version 2.10.0. Please use the
-                options `search_esgf=never` (for `offline=True`) or
-                `search_esgf=when_missing` (for `offline=False`). These are
-                exact replacements.
         search_esgf: str, optional
             If `never`, disable automatic download of data from the ESGF. If
             `when_missing`, enable the automatic download of files that are not
@@ -405,8 +395,6 @@ class ESMValTool():
             session['max_datasets'] = max_datasets
         if max_years is not None:
             session['max_years'] = max_years
-        if offline is not None:
-            session['offline'] = offline
         if search_esgf is not None:
             session['search_esgf'] = search_esgf
         if skip_nonexistent is not None:

--- a/esmvalcore/config/_config_validators.py
+++ b/esmvalcore/config/_config_validators.py
@@ -7,7 +7,7 @@ import warnings
 from collections.abc import Callable, Iterable
 from functools import lru_cache, partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import Any, Optional, Union
 
 from packaging import version
 
@@ -22,9 +22,6 @@ from esmvalcore.exceptions import (
     ESMValCoreDeprecationWarning,
     InvalidConfigParameter,
 )
-
-if TYPE_CHECKING:
-    from ._validated_config import ValidatedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +285,6 @@ _validators = {
     'extra_facets_dir': validate_pathtuple,
     'log_level': validate_string,
     'max_parallel_tasks': validate_int_or_none,
-    'offline': validate_bool,
     'output_dir': validate_path,
     'output_file_type': validate_string,
     'profile_diagnostic': validate_bool,
@@ -339,44 +335,12 @@ def _handle_deprecation(
     warnings.warn(deprecation_msg, ESMValCoreDeprecationWarning)
 
 
-def deprecate_offline(
-    validated_config: ValidatedConfig,
-    value: Any,
-    validated_value: Any,
-) -> None:
-    """Deprecate ``offline`` option.
-
-    Parameters
-    ----------
-    validated_config: ValidatedConfig
-        ``ValidatedConfig`` instance which will be modified in place.
-    value: Any
-        Raw input value for ``offline`` option.
-    validated_value: Any
-        Validated value for ``offline`` option.
-
-    """
-    option = 'offline'
-    deprecated_version = '2.8.0'
-    remove_version = '2.10.0'
-    more_info = (
-        " Please use the options `search_esgf=never` (for `offline=True`) or "
-        "`search_esgf=when_missing` (for `offline=False`) instead. These are "
-        "exact replacements."
-    )
-    _handle_deprecation(option, deprecated_version, remove_version, more_info)
-    if validated_value:
-        validated_config['search_esgf'] = 'never'
-    else:
-        validated_config['search_esgf'] = 'when_missing'
-
-
-_deprecators: dict[str, Callable] = {
-    'offline': deprecate_offline,
-}
+# Example usage: see removed files in
+# https://github.com/ESMValGroup/ESMValCore/pull/2213
+_deprecators: dict[str, Callable] = {}
 
 
 # Default values for deprecated options
-_deprecated_options_defaults: dict[str, Any] = {
-    'offline': True,
-}
+# Example usage: see removed files in
+# https://github.com/ESMValGroup/ESMValCore/pull/2213
+_deprecated_options_defaults: dict[str, Any] = {}

--- a/tests/integration/test_deprecated_config.py
+++ b/tests/integration/test_deprecated_config.py
@@ -1,8 +1,6 @@
 import warnings
 from pathlib import Path
 
-import pytest
-
 import esmvalcore
 from esmvalcore.config import CFG, Config
 from esmvalcore.exceptions import ESMValCoreDeprecationWarning
@@ -24,77 +22,3 @@ def test_no_deprecation_user_cfg():
         cfg = Config(CFG.copy())
         cfg.load_from_file(config_file)
         cfg.start_session('my_session')
-
-
-def test_offline_default_cfg():
-    """Test that ``offline`` is added for backwards-compatibility."""
-    assert CFG['search_esgf'] == 'never'
-    assert CFG['offline'] is True
-
-
-def test_offline_user_cfg():
-    """Test that ``offline`` is added for backwards-compatibility."""
-    config_file = Path(esmvalcore.__file__).parent / 'config-user.yml'
-    cfg = Config(CFG.copy())
-    cfg.load_from_file(config_file)
-    assert cfg['search_esgf'] == 'never'
-    assert cfg['offline'] is True
-
-
-def test_offline_default_session():
-    """Test that ``offline`` is added for backwards-compatibility."""
-    session = CFG.start_session('my_session')
-    assert session['search_esgf'] == 'never'
-    assert session['offline'] is True
-
-
-def test_offline_user_session():
-    """Test that ``offline`` is added for backwards-compatibility."""
-    config_file = Path(esmvalcore.__file__).parent / 'config-user.yml'
-    cfg = Config(CFG.copy())
-    cfg.load_from_file(config_file)
-    session = cfg.start_session('my_session')
-    assert session['search_esgf'] == 'never'
-    assert session['offline'] is True
-
-
-def test_offline_deprecation_session_setitem():
-    """Test that the usage of offline is deprecated."""
-    msg = "offline"
-    session = CFG.start_session('my_session')
-    session.pop('search_esgf')  # test automatic addition of search_esgf
-    with pytest.warns(ESMValCoreDeprecationWarning, match=msg):
-        session['offline'] = True
-    assert session['offline'] is True
-    assert session['search_esgf'] == 'never'
-
-
-def test_offline_deprecation_session_update():
-    """Test that the usage of offline is deprecated."""
-    msg = "offline"
-    session = CFG.start_session('my_session')
-    session.pop('search_esgf')  # test automatic addition of search_esgf
-    with pytest.warns(ESMValCoreDeprecationWarning, match=msg):
-        session.update({'offline': False})
-    assert session['offline'] is False
-    assert session['search_esgf'] == 'when_missing'
-
-
-def test_offline_true_deprecation_config(monkeypatch):
-    """Test that the usage of offline is deprecated."""
-    msg = "offline"
-    monkeypatch.delitem(CFG, 'search_esgf')
-    with pytest.warns(ESMValCoreDeprecationWarning, match=msg):
-        monkeypatch.setitem(CFG, 'offline', True)
-    assert CFG['offline'] is True
-    assert CFG['search_esgf'] == 'never'
-
-
-def test_offline_false_deprecation_config(monkeypatch):
-    """Test that the usage of offline is deprecated."""
-    msg = "offline"
-    monkeypatch.delitem(CFG, 'search_esgf')
-    with pytest.warns(ESMValCoreDeprecationWarning, match=msg):
-        monkeypatch.setitem(CFG, 'offline', False)
-    assert CFG['offline'] is False
-    assert CFG['search_esgf'] == 'when_missing'

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -120,12 +120,6 @@ def test_run_with_max_datasets():
 
 
 @patch('esmvalcore._main.ESMValTool.run', new=wrapper(ESMValTool.run))
-def test_run_with_offline():
-    with arguments('esmvaltool', 'run', 'recipe.yml', '--offline'):
-        run()
-
-
-@patch('esmvalcore._main.ESMValTool.run', new=wrapper(ESMValTool.run))
 def test_run_with_search_esgf():
     with arguments('esmvaltool', 'run', 'recipe.yml', '--search_esgf=always'):
         run()


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR removes the deprecated configuration option `offline`.

Detailed upgrade instructions: https://github.com/ESMValGroup/ESMValCore/pull/1935


<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] ~~Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~~
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
