### PR TITLE
Added `get_time_bounds` and `get_next_month` to public API

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/iitm_esm.py
+++ b/esmvalcore/cmor/_fixes/cmip6/iitm_esm.py
@@ -3,7 +3,7 @@ import logging
 
 import numpy as np
 
-from esmvalcore.cmor._fixes.fix import get_time_bounds
+from esmvalcore.cmor.fixes import get_time_bounds
 
 from ..common import OceanFixGrid
 from ..fix import Fix

--- a/esmvalcore/cmor/_fixes/cmip6/kace_1_0_g.py
+++ b/esmvalcore/cmor/_fixes/cmip6/kace_1_0_g.py
@@ -3,7 +3,7 @@ import logging
 
 import numpy as np
 
-from esmvalcore.cmor._fixes.fix import get_time_bounds
+from esmvalcore.cmor.fixes import get_time_bounds
 
 from ..common import ClFixHybridHeightCoord, OceanFixGrid
 from ..fix import Fix

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -1,6 +1,7 @@
 """Shared functions for fixes."""
 import logging
 import os
+from datetime import datetime
 from functools import lru_cache
 
 import dask.array as da
@@ -9,7 +10,10 @@ import numpy as np
 import pandas as pd
 from cf_units import Unit
 from iris import NameConstraint
+from iris.coords import Coord
 from scipy.interpolate import interp1d
+
+from esmvalcore.iris_helpers import date2num
 
 logger = logging.getLogger(__name__)
 
@@ -411,3 +415,92 @@ def fix_ocean_depth_coord(cube):
     depth_coord.units = 'm'
     depth_coord.long_name = 'ocean depth coordinate'
     depth_coord.attributes = {'positive': 'down'}
+
+
+def get_next_month(month: int, year: int) -> tuple[int, int]:
+    """Get next month and year.
+
+    Parameters
+    ----------
+    month:
+        Current month.
+    year:
+        Current year.
+
+    Returns
+    -------
+    tuple[int, int]
+        Next month and next year.
+
+    """
+    if month != 12:
+        return month + 1, year
+    return 1, year + 1
+
+
+def get_time_bounds(time: Coord, freq: str):
+    """Get bounds for time coordinate.
+
+    For monthly data, use the first day of the current month and the first day
+    of the next month. For yearly or decadal data, use 1 January of the current
+    year and 1 January of the next year or 10 years from the current year. For
+    other frequencies (daily, 6-hourly, 3-hourly, hourly), half of the
+    frequency is subtracted/added from the current point in time to get the
+    bounds.
+
+    Parameters
+    ----------
+    time:
+        Time coordinate.
+    freq:
+        Frequency.
+
+    Returns
+    -------
+    np.ndarray
+        Time bounds
+
+    Raises
+    ------
+    NotImplementedError
+        Non-supported frequency is given.
+
+    """
+    bounds = []
+    dates = time.units.num2date(time.points)
+    for step, date in enumerate(dates):
+        month = date.month
+        year = date.year
+        if freq in ['mon', 'mo']:
+            next_month, next_year = get_next_month(month, year)
+            min_bound = date2num(datetime(year, month, 1, 0, 0),
+                                 time.units, time.dtype)
+            max_bound = date2num(datetime(next_year, next_month, 1, 0, 0),
+                                 time.units, time.dtype)
+        elif freq == 'yr':
+            min_bound = date2num(datetime(year, 1, 1, 0, 0),
+                                 time.units, time.dtype)
+            max_bound = date2num(datetime(year + 1, 1, 1, 0, 0),
+                                 time.units, time.dtype)
+        elif freq == 'dec':
+            min_bound = date2num(datetime(year, 1, 1, 0, 0),
+                                 time.units, time.dtype)
+            max_bound = date2num(datetime(year + 10, 1, 1, 0, 0),
+                                 time.units, time.dtype)
+        else:
+            delta = {
+                'day': 12.0 / 24,
+                '6hr': 3.0 / 24,
+                '3hr': 1.5 / 24,
+                '1hr': 0.5 / 24,
+            }
+            if freq not in delta:
+                raise NotImplementedError(
+                    f"Cannot guess time bounds for frequency '{freq}'"
+                )
+            point = time.points[step]
+            min_bound = point - delta[freq]
+            max_bound = point + delta[freq]
+        bounds.append([min_bound, max_bound])
+
+    return np.array(bounds)

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -438,7 +438,7 @@ def get_next_month(month: int, year: int) -> tuple[int, int]:
     return 1, year + 1
 
 
-def get_time_bounds(time: Coord, freq: str):
+def get_time_bounds(time: Coord, freq: str) -> np.ndarray:
     """Get bounds for time coordinate.
 
     For monthly data, use the first day of the current month and the first day

--- a/esmvalcore/cmor/fixes.py
+++ b/esmvalcore/cmor/fixes.py
@@ -1,8 +1,15 @@
 """Functions for fixing specific issues with datasets."""
 
-from ._fixes.shared import add_altitude_from_plev, add_plev_from_altitude
+from ._fixes.shared import (
+    add_altitude_from_plev,
+    add_plev_from_altitude,
+    get_next_month,
+    get_time_bounds,
+)
 
 __all__ = [
     'add_altitude_from_plev',
     'add_plev_from_altitude',
+    'get_time_bounds',
+    'get_next_month',
 ]

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -23,7 +23,7 @@ from iris.coords import AuxCoord
 from iris.cube import Cube, CubeList
 from iris.time import PartialDateTime
 
-from esmvalcore.cmor._fixes.fix import get_next_month, get_time_bounds
+from esmvalcore.cmor.fixes import get_next_month, get_time_bounds
 from esmvalcore.iris_helpers import date2num
 
 from ._shared import get_iris_analysis_operation, operator_accept_weights

--- a/tests/integration/cmor/_fixes/test_shared.py
+++ b/tests/integration/cmor/_fixes/test_shared.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from cf_units import Unit
 from iris import NameConstraint
+from iris.coords import AuxCoord
 
 from esmvalcore.cmor._fixes.shared import (
     _map_on_filled,
@@ -25,6 +26,7 @@ from esmvalcore.cmor._fixes.shared import (
     get_altitude_to_pressure_func,
     get_bounds_cube,
     get_pressure_to_altitude_func,
+    get_time_bounds,
     round_coordinates,
 )
 
@@ -620,3 +622,39 @@ def test_fix_ocean_depth_coord():
     assert depth_coord.units == 'm'
     assert depth_coord.long_name == 'ocean depth coordinate'
     assert depth_coord.attributes == {'positive': 'down'}
+
+
+@pytest.fixture
+def time_coord():
+    """Time coordinate."""
+    time_coord = AuxCoord(
+        [15, 350],
+        standard_name='time',
+        units='days since 1850-01-01'
+    )
+    return time_coord
+
+
+@pytest.mark.parametrize(
+    'freq,expected_bounds',
+    [
+        ('mon', [[0, 31], [334, 365]]),
+        ('mo', [[0, 31], [334, 365]]),
+        ('yr', [[0, 365], [0, 365]]),
+        ('dec', [[0, 3652], [0, 3652]]),
+        ('day', [[14.5, 15.5], [349.5, 350.5]]),
+        ('6hr', [[14.875, 15.125], [349.875, 350.125]]),
+        ('3hr', [[14.9375, 15.0625], [349.9375, 350.0625]]),
+        ('1hr', [[14.97916666, 15.020833333], [349.97916666, 350.020833333]]),
+    ]
+)
+def test_get_time_bounds(time_coord, freq, expected_bounds):
+    """Test ``get_time_bounds`."""
+    bounds = get_time_bounds(time_coord, freq)
+    np.testing.assert_allclose(bounds, expected_bounds)
+
+
+def test_get_time_bounds_invalid_freq_fail(time_coord):
+    """Test ``get_time_bounds`."""
+    with pytest.raises(NotImplementedError):
+        get_time_bounds(time_coord, 'invalid_freq')

--- a/tests/unit/cmor/test_fixes.py
+++ b/tests/unit/cmor/test_fixes.py
@@ -8,6 +8,8 @@ import esmvalcore.cmor.fixes as fixes
 @pytest.mark.parametrize('func', [
     'add_altitude_from_plev',
     'add_plev_from_altitude',
+    'get_next_month',
+    'get_time_bounds',
 ])
 def test_imports(func):
     assert func in fixes.__all__

--- a/tests/unit/cmor/test_generic_fix.py
+++ b/tests/unit/cmor/test_generic_fix.py
@@ -2,24 +2,12 @@
 
 from unittest.mock import sentinel
 
-import numpy as np
 import pytest
 from iris.coords import AuxCoord
 from iris.cube import Cube, CubeList
 
-from esmvalcore.cmor._fixes.fix import GenericFix, get_time_bounds
+from esmvalcore.cmor._fixes.fix import GenericFix
 from esmvalcore.cmor.table import get_var_info
-
-
-@pytest.fixture
-def time_coord():
-    """Time coordinate."""
-    time_coord = AuxCoord(
-        [15, 350],
-        standard_name='time',
-        units='days since 1850-01-01'
-    )
-    return time_coord
 
 
 @pytest.fixture
@@ -28,31 +16,6 @@ def generic_fix():
     vardef = get_var_info('CMIP6', 'CFmon', 'ta')
     extra_facets = {'short_name': 'ta', 'project': 'CMIP6', 'dataset': 'MODEL'}
     return GenericFix(vardef, extra_facets=extra_facets)
-
-
-@pytest.mark.parametrize(
-    'freq,expected_bounds',
-    [
-        ('mon', [[0, 31], [334, 365]]),
-        ('mo', [[0, 31], [334, 365]]),
-        ('yr', [[0, 365], [0, 365]]),
-        ('dec', [[0, 3652], [0, 3652]]),
-        ('day', [[14.5, 15.5], [349.5, 350.5]]),
-        ('6hr', [[14.875, 15.125], [349.875, 350.125]]),
-        ('3hr', [[14.9375, 15.0625], [349.9375, 350.0625]]),
-        ('1hr', [[14.97916666, 15.020833333], [349.97916666, 350.020833333]]),
-    ]
-)
-def test_get_time_bounds(time_coord, freq, expected_bounds):
-    """Test ``get_time_bounds`."""
-    bounds = get_time_bounds(time_coord, freq)
-    np.testing.assert_allclose(bounds, expected_bounds)
-
-
-def test_get_time_bounds_invalid_freq_fail(time_coord):
-    """Test ``get_time_bounds`."""
-    with pytest.raises(NotImplementedError):
-        get_time_bounds(time_coord, 'invalid_freq')
 
 
 def test_generic_fix_empty_long_name(generic_fix, monkeypatch):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR adds `esmvalcore.cmor.fixes.get_time_bounds` and `esmvalcore.cmor.fixes.get_next_month`.

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
