### PR TITLE
Add custom CMOR table for total cloud water (tcw)

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_tcw.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_tcw.dat
@@ -15,7 +15,7 @@ long_name:         Mass Fraction of Cloud Total Water (liquid + ice)
 ! Additional variable information:
 !----------------------------------
 dimensions:        longitude latitude plevs time
-out_name:          tcp
+out_name:          tcw
 type:              real
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_tcw.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_tcw.dat
@@ -1,0 +1,21 @@
+SOURCE: custom
+!============
+variable_entry:    tcw
+!============
+modeling_realm:    atmos
+!----------------------------------
+! Variable attributes:
+!----------------------------------
+standard_name:
+units:             kg kg-1
+cell_methods:      time: mean
+cell_measures:     area: areacella
+long_name:         Mass Fraction of Cloud Total Water (liquid + ice)
+!----------------------------------
+! Additional variable information:
+!----------------------------------
+dimensions:        longitude latitude plevs time
+out_name:          tcp
+type:              real
+!----------------------------------
+!


### PR DESCRIPTION
## Description

This PR adds a custom CMOR table for the 3-dim variable total cloud water (tcw) that is needed by the new JRA-25 CMORizer (https://github.com/ESMValGroup/ESMValTool/pull/3470).

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful
