### PR TITLE
Show files of supplementary variables explicitly in log

### DIFF
--- a/esmvalcore/_recipe/recipe.py
+++ b/esmvalcore/_recipe/recipe.py
@@ -264,7 +264,7 @@ def _log_all_files(datasets: Iterable[Dataset]) -> None:
         supplemantary_files_str = ""
         if dataset.supplementaries:
             for sup_ds in dataset.supplementaries:
-                supplemantary_files_str += (
+                supplementary_files_str += (
                     f"\nwith files for supplementary variable "
                     f"{sup_ds['short_name']}:\n{_get_files_str(sup_ds)}"
                 )
@@ -280,13 +280,10 @@ def _log_all_files(datasets: Iterable[Dataset]) -> None:
 
 def _get_files_str(dataset: Dataset) -> str:
     """Get nice string representation of all files of a dataset."""
-    files_str = (
-        '\n'.join(
-            f'  {f}' if f.exists()  # type: ignore
-            else f'  {f} (will be downloaded)' for f in list(dataset.files)
-        )
+    return '\n'.join(
+        f'  {f}' if f.exists()  # type: ignore
+        else f'  {f} (will be downloaded)' for f in dataset.files
     )
-    return files_str
 
 
 def _check_input_files(input_datasets: Iterable[Dataset]) -> set[str]:

--- a/esmvalcore/_recipe/recipe.py
+++ b/esmvalcore/_recipe/recipe.py
@@ -250,23 +250,43 @@ def _add_to_download_list(dataset):
 
 
 def _schedule_for_download(datasets):
-    """Schedule files for download and show the list of files in the log."""
+    """Schedule files for download."""
     for dataset in datasets:
         _add_to_download_list(dataset)
         for supplementary_ds in dataset.supplementaries:
             _add_to_download_list(supplementary_ds)
 
-        files = list(dataset.files)
-        for supplementary_ds in dataset.supplementaries:
-            files.extend(supplementary_ds.files)
+
+def _log_all_files(datasets: Iterable[Dataset]) -> None:
+    """Show list of files in log (including supplementaries)."""
+    for dataset in datasets:
+        # Only log supplementary variables if present
+        supplemantary_files_str = ""
+        if dataset.supplementaries:
+            for sup_ds in dataset.supplementaries:
+                supplemantary_files_str += (
+                    f"\nwith files for supplementary variable "
+                    f"{sup_ds['short_name']}:\n{_get_files_str(sup_ds)}"
+                )
 
         logger.debug(
-            "Using input files for variable %s of dataset %s:\n%s",
+            "Using input files for variable %s of dataset %s:\n%s%s",
             dataset.facets['short_name'],
-            dataset.facets['alias'].replace('_', ' '),
-            '\n'.join(f'{f} (will be downloaded)' if not f.exists() else str(f)
-                      for f in files),
+            dataset.facets['alias'].replace('_', ' '),  # type: ignore
+            _get_files_str(dataset),
+            supplemantary_files_str
         )
+
+
+def _get_files_str(dataset: Dataset) -> str:
+    """Get nice string representation of all files of a dataset."""
+    files_str = (
+        '\n'.join(
+            f'  {f}' if f.exists()  # type: ignore
+            else f'  {f} (will be downloaded)' for f in list(dataset.files)
+        )
+    )
+    return files_str
 
 
 def _check_input_files(input_datasets: Iterable[Dataset]) -> set[str]:
@@ -517,6 +537,7 @@ def _get_preprocessor_products(
         _set_version(dataset, input_datasets)
         USED_DATASETS.append(dataset)
         _schedule_for_download(input_datasets)
+        _log_all_files(input_datasets)
         logger.info("Found input files for %s", dataset.summary(shorten=True))
 
         filename = _get_output_file(

--- a/esmvalcore/_recipe/recipe.py
+++ b/esmvalcore/_recipe/recipe.py
@@ -257,11 +257,11 @@ def _schedule_for_download(datasets):
             _add_to_download_list(supplementary_ds)
 
 
-def _log_all_files(datasets: Iterable[Dataset]) -> None:
+def _log_input_files(datasets: Iterable[Dataset]) -> None:
     """Show list of files in log (including supplementaries)."""
     for dataset in datasets:
         # Only log supplementary variables if present
-        supplemantary_files_str = ""
+        supplementary_files_str = ""
         if dataset.supplementaries:
             for sup_ds in dataset.supplementaries:
                 supplementary_files_str += (
@@ -274,7 +274,7 @@ def _log_all_files(datasets: Iterable[Dataset]) -> None:
             dataset.facets['short_name'],
             dataset.facets['alias'].replace('_', ' '),  # type: ignore
             _get_files_str(dataset),
-            supplemantary_files_str
+            supplementary_files_str
         )
 
 
@@ -534,7 +534,7 @@ def _get_preprocessor_products(
         _set_version(dataset, input_datasets)
         USED_DATASETS.append(dataset)
         _schedule_for_download(input_datasets)
-        _log_all_files(input_datasets)
+        _log_input_files(input_datasets)
         logger.info("Found input files for %s", dataset.summary(shorten=True))
 
         filename = _get_output_file(


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR makes sure that supplementary variables are shown explicitly in the debug log.

Before:

```bash
2024-01-17 10:30:37,879 UTC [504383] DEBUG   esmvalcore._recipe.recipe:263 Using input files for variable tas of dataset CMIP6 BCC-ESM1:
/work/bd0854/DATA/ESMValTool2/download/CMIP6/CMIP/BCC/BCC-ESM1/historical/r1i1p1f1/Amon/tas/gn/v20181214/tas_Amon_BCC-ESM1_historical_r1i1p1f1_gn_185001-201412.nc
/work/bd0854/DATA/ESMValTool2/CMIP6_DKRZ/CMIP/BCC/BCC-ESM1/1pctCO2/r1i1p1f1/fx/areacella/gn/v20190613/areacella_fx_BCC-ESM1_1pctCO2_r1i1p1f1_gn.nc
/work/bd0854/DATA/ESMValTool2/CMIP6_DKRZ/CMIP/BCC/BCC-ESM1/1pctCO2/r1i1p1f1/fx/sftlf/gn/v20190613/sftlf_fx_BCC-ESM1_1pctCO2_r1i1p1f1_gn.nc
```

After:

```bash
2024-01-17 10:19:03,774 UTC [447883] DEBUG   esmvalcore._recipe.recipe:272 Using input files for variable tas of dataset CMIP6 BCC-ESM1:
  /work/bd0854/DATA/ESMValTool2/download/CMIP6/CMIP/BCC/BCC-ESM1/historical/r1i1p1f1/Amon/tas/gn/v20181214/tas_Amon_BCC-ESM1_historical_r1i1p1f1_gn_185001-201412.nc
with files for supplementary variable areacella:
  /work/bd0854/DATA/ESMValTool2/CMIP6_DKRZ/CMIP/BCC/BCC-ESM1/1pctCO2/r1i1p1f1/fx/areacella/gn/v20190613/areacella_fx_BCC-ESM1_1pctCO2_r1i1p1f1_gn.nc
with files for supplementary variable sftlf:
  /work/bd0854/DATA/ESMValTool2/CMIP6_DKRZ/CMIP/BCC/BCC-ESM1/1pctCO2/r1i1p1f1/fx/sftlf/gn/v20190613/sftlf_fx_BCC-ESM1_1pctCO2_r1i1p1f1_gn.nc
```

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2302

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
