### PR TITLE
Pin pandas to avoid broken `round` function

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
       - main
-      - pin_pandas
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - main
+      - pin_pandas
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - netcdf4
   - numpy !=1.24.3
   - packaging
-  - pandas !=2.2.0
+  - pandas !=2.2.0  # github.com/ESMValGroup/ESMValCore/pull/2305
   - pillow
   - pip !=21.3
   - prov

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - netcdf4
   - numpy !=1.24.3
   - packaging
-  - pandas
+  - pandas !=2.2.0
   - pillow
   - pip !=21.3
   - prov

--- a/esmvalcore/cmor/_fixes/icon/icon.py
+++ b/esmvalcore/cmor/_fixes/icon/icon.py
@@ -492,9 +492,8 @@ class AllVars(IconFix):
         # it to correct units. Note: we also round to next second, otherwise
         # this results in times that are off by 1s (e.g., 13:59:59 instead of
         # 14:00:00).
-        new_datetimes = (year_month_day + day_float).round(
-            'S'
-        ).dt.to_pydatetime()
+        rounded_datetimes = (year_month_day + day_float).round('s')
+        new_datetimes = np.array(rounded_datetimes.dt.to_pydatetime())
         new_dt_points = date2num(np.array(new_datetimes), new_t_units)
 
         # Modify time coordinate in place

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ REQUIREMENTS = {
         'netCDF4',
         'numpy!=1.24.3',
         'packaging',
-        'pandas!=2.2.0',
+        'pandas!=2.2.0',  # github.com/ESMValGroup/ESMValCore/pull/2305
         'pillow',
         'prov',
         'psutil',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ REQUIREMENTS = {
         'netCDF4',
         'numpy!=1.24.3',
         'packaging',
-        'pandas',
+        'pandas!=2.2.0',
         'pillow',
         'prov',
         'psutil',


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR fixes [recent test failures](https://app.circleci.com/pipelines/github/ESMValGroup/ESMValCore/10270/workflows/774a0b7d-be4a-436a-89b2-2b1429d1b77b/jobs/44121) that are caused by a [bug in pandas](https://github.com/pandas-dev/pandas/issues/57002). This bug breaks the `round` function that we use to round to the nearest second:

https://github.com/ESMValGroup/ESMValCore/blob/d6008f3d010e3ad6d2708d47ed8d48aa396af739/esmvalcore/cmor/_fixes/icon/icon.py#L495-L497

In addition, this removes the use of two deprecated features:
1. Replace 'S' by 's' (see https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
2. Surround `DatetimeProperties.to_pydatetime` by `np.array` as recommended in the deprecation message. Unfortunately, this does not remove the warning, but hopefully this will avoid problems in the future.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
