### PR TITLE
Fix flaky regrid test by clearing LRU cache after each test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
       - main
-      - fix_regrid_test_lru
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - main
+      - fix_regrid_test_lru
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/tests/unit/preprocessor/_regrid/test__stock_cube.py
+++ b/tests/unit/preprocessor/_regrid/test__stock_cube.py
@@ -85,6 +85,10 @@ class Test(tests.Test):
             'iris.coords.DimCoord', return_value=self.mock_coord)
         self.mocks = [self.mock_Cube, self.mock_coord, self.mock_DimCoord]
 
+    def tearDown(self) -> None:
+        _global_stock_cube.cache_clear()
+        return super().tearDown()
+
     def test_invalid_cell_spec__alpha(self):
         emsg = 'Invalid MxN cell specification'
         with self.assertRaisesRegex(ValueError, emsg):

--- a/tests/unit/preprocessor/_regrid/test_extract_regional_grid.py
+++ b/tests/unit/preprocessor/_regrid/test_extract_regional_grid.py
@@ -11,6 +11,18 @@ from esmvalcore.preprocessor._regrid import (
     regrid,
 )
 
+
+@pytest.fixture(autouse=True)
+def clear_lru_cache():
+    """Make sure to clear LRU cache for ``_global_stock_cube``.
+
+    See https://github.com/ESMValGroup/ESMValCore/issues/2320.
+
+    """
+    yield  # execute tests
+    _global_stock_cube.cache_clear()
+
+
 SPEC_KEYS = ('start_longitude', 'end_longitude', 'step_longitude',
              'start_latitude', 'end_latitude', 'step_latitude')
 PASSING_SPECS = tuple(
@@ -44,7 +56,6 @@ FAILING_SPECS = tuple(
     ))
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize('spec', PASSING_SPECS)
 def test_extract_regional_grid_passing(spec):
     """Test regridding with regional target spec."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2320 

This PR clears the LRU grid of `_global_stock_cube` after each test to avoid a race condition that may lead to failing tests.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
