### PR TITLE
Allow deprecated regridding scheme `linear_extrapolate` in recipe checks

### DIFF
--- a/esmvalcore/_recipe/check.py
+++ b/esmvalcore/_recipe/check.py
@@ -506,6 +506,13 @@ def regridding_schemes(settings: dict):
     # Check built-in regridding schemes (given as str)
     if isinstance(scheme, str):
         scheme = settings['regrid']['scheme']
+
+        # Also allow deprecated 'linear_extrapolate' scheme (the corresponding
+        # deprecation warning will be raised in the regrid() preprocessor)
+        # TODO: Remove in v2.13.0
+        if scheme == 'linear_extrapolate':
+            return
+
         allowed_regridding_schemes = list(
             set(
                 list(HORIZONTAL_SCHEMES_IRREGULAR) +

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -2884,6 +2884,7 @@ def test_invalid_builtin_regridding_scheme(
           test:
             regrid:
               scheme: INVALID
+              target_grid: 2x2
         diagnostics:
           diagnostic_name:
             variables:
@@ -2914,6 +2915,7 @@ def test_generic_regridding_scheme_no_ref(
             regrid:
               scheme:
                 no_reference: given
+              target_grid: 2x2
         diagnostics:
           diagnostic_name:
             variables:
@@ -2945,6 +2947,7 @@ def test_invalid_generic_regridding_scheme(
             regrid:
               scheme:
                 reference: invalid.module:and.function
+              target_grid: 2x2
         diagnostics:
           diagnostic_name:
             variables:
@@ -2966,3 +2969,25 @@ def test_invalid_generic_regridding_scheme(
         get_recipe(tmp_path, content, session)
     assert str(rec_err_exp.value) == INITIALIZATION_ERROR_MSG
     assert msg in str(rec_err_exp.value.failed_tasks[0].message)
+
+
+def test_deprecated_regridding_scheme(tmp_path, patched_datafinder, session):
+    content = dedent("""
+        preprocessors:
+          test:
+            regrid:
+              scheme: linear_extrapolate
+              target_grid: 2x2
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                mip: Amon
+                preprocessor: test
+                timerange: '2000/2010'
+                additional_datasets:
+                  - {project: CMIP5, dataset: CanESM2, exp: amip,
+                     ensemble: r1i1p1}
+            scripts: null
+        """)
+    get_recipe(tmp_path, content, session)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

In the preprocessor function `regrid`, the usage of the deprecated regridding scheme `linear_extrapolate` is allowed. However, the corresponding [recipe check](https://github.com/ESMValGroup/ESMValCore/blob/70b19569599c7c1511563b610c3e453340c6be58/esmvalcore/_recipe/check.py#L497) does not. This PR fixes that.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2323

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
