### PR TITLE
Remove warning about logging in to ESGF

### DIFF
--- a/doc/quickstart/configure.rst
+++ b/doc/quickstart/configure.rst
@@ -382,8 +382,8 @@ corresponding command line arguments ``--search_esgf=when_missing`` or
    tool by pressing the ``Ctrl`` and ``C`` keys on your keyboard simultaneously
    several times, edit the recipe so it contains fewer datasets and try again.
 
-For downloading some files (e.g. those produced by the CORDEX project),
-you need to log in to be able to download the data.
+For downloading some files, you may need to log in to be able to download the
+data.
 
 See the
 `ESGF user guide <https://esgf.github.io/esgf-user-support/user_guide.html>`_

--- a/esmvalcore/config/_esgf_pyclient.py
+++ b/esmvalcore/config/_esgf_pyclient.py
@@ -12,7 +12,6 @@ import importlib
 import logging
 import os
 import stat
-import textwrap
 from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
@@ -29,59 +28,6 @@ except ModuleNotFoundError:
 logger = logging.getLogger(__name__)
 
 CONFIG_FILE = Path.home() / '.esmvaltool' / 'esgf-pyclient.yml'
-
-INSTRUCTIONS = textwrap.dedent("""
-ESGF credentials missing, only data that is accessible without
-logging in will be available.
-
-See https://esgf.github.io/esgf-user-support/user_guide.html
-for instructions on how to create an account if you do not have
-one yet.
-
-Next, configure your system so esmvaltool can use your
-credentials. This can be done using the keyring package, or
-you can just enter them in {cfg_file}.
-
-keyring
-=======
-First install the keyring package (requires a supported
-backend, see https://pypi.org/project/keyring/):
-$ pip install keyring
-
-Next, set your username and password by running the commands:
-$ keyring set ESGF hostname
-$ keyring set ESGF username
-$ keyring set ESGF password
-
-To check that you entered your credentials correctly, run:
-$ keyring get ESGF hostname
-$ keyring get ESGF username
-$ keyring get ESGF password
-
-configuration file
-==================
-You can store the hostname, username, and password or your OpenID
-account in a plain text in the file {cfg_file} like this:
-
-logon:
-  hostname: "your-hostname"
-  username: "your-username"
-  password: "your-password"
-
-or your can configure an interactive log in:
-
-logon:
-  interactive: true
-
-Note that storing your password in plain text in the configuration
-file is less secure. On shared systems, make sure the permissions
-of the file are set so only you can read it, i.e.
-
-$ ls -l {cfg_file}
-
-shows permissions -rw-------.
-
-""".format(cfg_file=CONFIG_FILE))
 
 
 def get_keyring_credentials():
@@ -171,14 +117,6 @@ def load_esgf_pyclient_config():
             cfg['search_connection']['cache'])).expanduser().absolute()
         cfg['search_connection']['cache'] = cache_file
         Path(cache_file).parent.mkdir(parents=True, exist_ok=True)
-
-    missing_credentials = []
-    for key in ['hostname', 'username', 'password']:
-        if key not in cfg['logon']:
-            missing_credentials.append(key)
-
-    if missing_credentials and not cfg['logon'].get('interactive'):
-        logger.warning(INSTRUCTIONS)
 
     return cfg
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Remove the printed warning that users need to log on to ESGF, as this is no longer needed.

Closes  #1590


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
