### PR TITLE
Added fix for wrong units of `clt` for CIESM and FIO-ESM-2-0

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/ciesm.py
+++ b/esmvalcore/cmor/_fixes/cmip6/ciesm.py
@@ -20,9 +20,32 @@ class Cl(ClFixHybridPressureCoord):
         -------
         iris.cube.Cube
         """
-        metadata = cube.metadata
-        cube *= 100
-        cube.metadata = metadata
+        if cube.core_data().max() <= 1.0:
+            cube.units = '1'
+            cube.convert_units('%')
+        return cube
+
+
+class Clt(Fix):
+    """Fixes for clt."""
+
+    def fix_data(self, cube):
+        """Fix data.
+
+        Fixes discrepancy between declared units and real units.
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube.
+
+        Returns
+        -------
+        iris.cube.Cube
+        """
+        if cube.core_data().max() <= 1.0:
+            cube.units = '1'
+            cube.convert_units('%')
         return cube
 
 

--- a/esmvalcore/cmor/_fixes/cmip6/fio_esm_2_0.py
+++ b/esmvalcore/cmor/_fixes/cmip6/fio_esm_2_0.py
@@ -70,3 +70,26 @@ class Amon(Fix):
                     longitude.bounds = None
                     longitude.guess_bounds()
         return cubes
+
+
+class Clt(Fix):
+    """Fixes for clt."""
+
+    def fix_data(self, cube):
+        """Fix data.
+
+        Fixes discrepancy between declared units and real units.
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube.
+
+        Returns
+        -------
+        iris.cube.Cube
+        """
+        if cube.core_data().max() <= 1.0:
+            cube.units = '1'
+            cube.convert_units('%')
+        return cube

--- a/tests/integration/cmor/_fixes/cmip6/test_ciesm.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_ciesm.py
@@ -1,5 +1,6 @@
 """Tests for the fixes of CIESM."""
 import iris.cube
+import numpy as np
 import pytest
 
 from esmvalcore.cmor._fixes.cmip6.ciesm import Cl
@@ -38,8 +39,17 @@ def test_cl_fix_data(cl_cube):
     assert out_cube.data == [100.0]
 
 
+def test_clt_fix():
+    """Test `Clt.fix_data`."""
+    cube = iris.cube.Cube(0.5)
+    fix = Fix.get_fixes('CMIP6', 'CIESM', 'Amon', 'clt')[0]
+    out_cube = fix.fix_data(cube)
+    np.testing.assert_allclose(out_cube.data, 50.0)
+    assert out_cube.units == '%'
+
+
 def test_pr_fix():
-    """Test `Pr.fix_metadata`."""
+    """Test `Pr.fix_data`."""
     cube = iris.cube.Cube(
         [2.82e-08],
         var_name='pr',

--- a/tests/integration/cmor/_fixes/cmip6/test_fio_esm_2_0.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fio_esm_2_0.py
@@ -11,6 +11,15 @@ from esmvalcore.cmor.fix import Fix
 from esmvalcore.cmor.table import get_var_info
 
 
+def test_clt_fix():
+    """Test `Clt.fix_data`."""
+    cube = iris.cube.Cube(0.5)
+    fix = Fix.get_fixes('CMIP6', 'FIO-ESM-2-0', 'Amon', 'clt')[0]
+    out_cube = fix.fix_data(cube)
+    np.testing.assert_allclose(out_cube.data, 50.0)
+    assert out_cube.units == '%'
+
+
 def test_get_tas_fix():
     """Test getting of fix."""
     fix = Fix.get_fixes('CMIP6', 'FIO-ESM-2-0', 'Amon', 'tas')


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Units of input data claim to be `%`, but they are `1`. This PR adds a fix for that.

Tested this myself thoroughly.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
