### PR TITLE
Allow deprecated regridding scheme `unstructured_nearest` in recipe checks

### DIFF
--- a/esmvalcore/_recipe/check.py
+++ b/esmvalcore/_recipe/check.py
@@ -511,10 +511,11 @@ def regridding_schemes(settings: dict):
     if isinstance(scheme, str):
         scheme = settings['regrid']['scheme']
 
-        # Also allow deprecated 'linear_extrapolate' scheme (the corresponding
-        # deprecation warning will be raised in the regrid() preprocessor)
+        # Also allow deprecateded 'linear_extrapolate' and
+        # 'unstructured_nearest' schemes (the corresponding deprecation
+        # warnings will be raised in the regrid() preprocessor)
         # TODO: Remove in v2.13.0
-        if scheme == 'linear_extrapolate':
+        if scheme in ('linear_extrapolate', 'unstructured_nearest'):
             return
 
         allowed_regridding_schemes = list(

--- a/esmvalcore/_recipe/check.py
+++ b/esmvalcore/_recipe/check.py
@@ -511,7 +511,7 @@ def regridding_schemes(settings: dict):
     if isinstance(scheme, str):
         scheme = settings['regrid']['scheme']
 
-        # Also allow deprecated'linear_extrapolate' and 'unstructured_nearest'
+        # Also allow deprecated 'linear_extrapolate' and 'unstructured_nearest'
         # schemes (the corresponding deprecation warnings will be raised in the
         # regrid() preprocessor) TODO: Remove in v2.13.0
         if scheme in ('linear_extrapolate', 'unstructured_nearest'):

--- a/esmvalcore/_recipe/check.py
+++ b/esmvalcore/_recipe/check.py
@@ -511,10 +511,9 @@ def regridding_schemes(settings: dict):
     if isinstance(scheme, str):
         scheme = settings['regrid']['scheme']
 
-        # Also allow deprecateded 'linear_extrapolate' and
-        # 'unstructured_nearest' schemes (the corresponding deprecation
-        # warnings will be raised in the regrid() preprocessor)
-        # TODO: Remove in v2.13.0
+        # Also allow deprecated'linear_extrapolate' and 'unstructured_nearest'
+        # schemes (the corresponding deprecation warnings will be raised in the
+        # regrid() preprocessor) TODO: Remove in v2.13.0
         if scheme in ('linear_extrapolate', 'unstructured_nearest'):
             return
 

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -3094,7 +3094,9 @@ def test_invalid_generic_regridding_scheme(
     assert msg in str(rec_err_exp.value.failed_tasks[0].message)
 
 
-def test_deprecated_linear_extrapolate_scheme(tmp_path, patched_datafinder, session):
+def test_deprecated_linear_extrapolate_scheme(
+    tmp_path, patched_datafinder, session
+):
     content = dedent("""
         preprocessors:
           test:

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -3094,12 +3094,36 @@ def test_invalid_generic_regridding_scheme(
     assert msg in str(rec_err_exp.value.failed_tasks[0].message)
 
 
-def test_deprecated_regridding_scheme(tmp_path, patched_datafinder, session):
+def test_deprecated_linear_extrapolate_scheme(tmp_path, patched_datafinder, session):
     content = dedent("""
         preprocessors:
           test:
             regrid:
               scheme: linear_extrapolate
+              target_grid: 2x2
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                mip: Amon
+                preprocessor: test
+                timerange: '2000/2010'
+                additional_datasets:
+                  - {project: CMIP5, dataset: CanESM2, exp: amip,
+                     ensemble: r1i1p1}
+            scripts: null
+        """)
+    get_recipe(tmp_path, content, session)
+
+
+def test_deprecated_unstructured_nearest_scheme(
+    tmp_path, patched_datafinder, session
+):
+    content = dedent("""
+        preprocessors:
+          test:
+            regrid:
+              scheme: unstructured_nearest
               target_grid: 2x2
         diagnostics:
           diagnostic_name:


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Very similar to https://github.com/ESMValGroup/ESMValCore/pull/2324, I forgot another scheme in https://github.com/ESMValGroup/ESMValCore/pull/2231 😬 

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
