### PR TITLE
Support loading ICON grid from ICON rootpath

### DIFF
--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -388,7 +388,9 @@ This grid file can either be specified as absolute or relative (to
 with the facet ``horizontal_grid`` in the recipe or the extra facets (see
 below), or retrieved automatically from the `grid_file_uri` attribute of the
 input files.
-In the latter case, the file is downloaded once and then cached.
+In the latter case, ESMValCore first searches the input directories specified
+for ICON for a grid file with that name, and if that was not successful, tries
+to download the file and cache it.
 The cached file is valid for 7 days.
 
 ESMValCore can automatically make native ICON data `UGRID
@@ -467,7 +469,7 @@ Key                 Description                      Default value if not specif
 =================== ================================ ===================================
 ``horizontal_grid`` Absolute or relative (to         If not given, use file attribute
                     ``auxiliary_data_dir`` defined   ``grid_file_uri`` to retrieve ICON
-                    in the                           grid file
+                    in the                           grid file (see details above)
                     :ref:`user configuration file`)
                     path to the ICON grid file
 ``latitude``        Standard name of the latitude    ``latitude``

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -239,7 +239,7 @@ class IconFix(NativeDatasetFix):
             'zghalf_file',
         ]
         for facet in facets_to_consider:
-            if facet not in self.extra_facets:
+            if self.extra_facets.get(facet) is None:
                 continue
             path_to_add = self._get_path_from_facet(facet)
             logger.debug("Adding cubes from %s", path_to_add)
@@ -352,7 +352,7 @@ class IconFix(NativeDatasetFix):
             file.
 
         """
-        if 'horizontal_grid' in self.extra_facets:
+        if self.extra_facets.get('horizontal_grid') is not None:
             grid = self._get_grid_from_facet()
         else:
             grid = self._get_grid_from_cube_attr(cube)
@@ -393,7 +393,7 @@ class IconFix(NativeDatasetFix):
         """
         # If specified by the user, use `horizontal_grid` facet to determine
         # grid name; otherwise, use the `grid_file_uri` attribute of the cube
-        if 'horizontal_grid' in self.extra_facets:
+        if self.extra_facets.get('horizontal_grid') is not None:
             grid_path = self._get_path_from_facet(
                 'horizontal_grid', 'Horizontal grid file'
             )
@@ -401,7 +401,7 @@ class IconFix(NativeDatasetFix):
         else:
             (_, grid_name) = self._get_grid_url(cube)
 
-        # Re-use mesh if possible
+        # Reuse mesh if possible
         if grid_name in self._meshes:
             logger.debug("Reusing ICON mesh for grid %s", grid_name)
         else:

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -306,7 +306,8 @@ class IconFix(NativeDatasetFix):
         for grid_path in possible_grid_paths:
             if grid_path.is_file():
                 logger.debug("Using ICON grid file '%s'", grid_path)
-                return self._load_cubes(grid_path)
+                cubes = self._load_cubes(grid_path)
+                return cubes
         return None
 
     def _get_downloaded_grid(self, grid_url: str, grid_name: str) -> CubeList:
@@ -363,7 +364,8 @@ class IconFix(NativeDatasetFix):
                 grid_path,
             )
 
-        return self._load_cubes(grid_path)
+        cubes = self._load_cubes(grid_path)
+        return cubes
 
     def get_horizontal_grid(self, cube):
         """Get copy of ICON horizontal grid.

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -318,7 +318,7 @@ class IconFix(NativeDatasetFix):
         Note
         ----
         In order to make this function thread-safe, the downloaded grid file is
-        first save to a temporary location and copied to the actual location
+        first saved to a temporary location, then copied to the actual location
         later.
 
         """

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -283,9 +283,7 @@ class IconFix(NativeDatasetFix):
         if grid is None:
             grid = self._get_downloaded_grid(grid_url, grid_name)
 
-        self._horizontal_grids[grid_name] = grid
-
-        return self._horizontal_grids[grid_name]
+        return grid
 
     def _get_grid_from_rootpath(self, grid_name: str) -> CubeList | None:
         """Try to get grid from the ICON rootpath."""
@@ -298,7 +296,8 @@ class IconFix(NativeDatasetFix):
         for grid_path in possible_grid_paths:
             if grid_path.is_file():
                 logger.debug("Using ICON grid file '%s'", grid_path)
-                return self._load_cubes(grid_path)
+                self._horizontal_grids[grid_name] = self._load_cubes(grid_path)
+                return self._horizontal_grids[grid_name]
         return None
 
     def _get_downloaded_grid(self, grid_url: str, grid_name: str) -> CubeList:
@@ -348,9 +347,9 @@ class IconFix(NativeDatasetFix):
                 grid_path,
             )
 
-            grid = self._load_cubes(grid_path)
+            self._horizontal_grids[grid_name] = self._load_cubes(grid_path)
 
-        return grid
+        return self._horizontal_grids[grid_name]
 
     def get_horizontal_grid(self, cube):
         """Get copy of ICON horizontal grid.

--- a/esmvalcore/cmor/_fixes/icon/icon.py
+++ b/esmvalcore/cmor/_fixes/icon/icon.py
@@ -1,6 +1,7 @@
 """On-the-fly CMORizer for ICON."""
 
 import logging
+import warnings
 from datetime import datetime, timedelta
 
 import dask.array as da
@@ -493,7 +494,15 @@ class AllVars(IconFix):
         # this results in times that are off by 1s (e.g., 13:59:59 instead of
         # 14:00:00).
         rounded_datetimes = (year_month_day + day_float).round('s')
-        new_datetimes = np.array(rounded_datetimes.dt.to_pydatetime())
+        with warnings.catch_warnings():
+            # We already fixed the deprecated code as recommended in the
+            # warning, but it still shows up -> ignore it
+            warnings.filterwarnings(
+                'ignore',
+                message="The behavior of DatetimeProperties.to_pydatetime .*",
+                category=FutureWarning,
+            )
+            new_datetimes = np.array(rounded_datetimes.dt.to_pydatetime())
         new_dt_points = date2num(np.array(new_datetimes), new_t_units)
 
         # Modify time coordinate in place

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -519,16 +519,6 @@ class PreprocessorFile(TrackedFile):
         if 'frequency' in ref_cube.attributes:
             self.attributes['frequency'] = ref_cube.attributes['frequency']
 
-        # Years
-        if ref_cube.coords('time'):
-            time = ref_cube.coord('time')
-            self.attributes['start_year'] = time.units.num2date(
-                time.points[0]
-            ).year
-            self.attributes['end_year'] = time.units.num2date(
-                time.points[-1]
-            ).year
-
     @property
     def is_closed(self):
         """Check if the file is closed."""

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -519,6 +519,16 @@ class PreprocessorFile(TrackedFile):
         if 'frequency' in ref_cube.attributes:
             self.attributes['frequency'] = ref_cube.attributes['frequency']
 
+        # Years
+        if ref_cube.coords('time'):
+            time = ref_cube.coord('time')
+            self.attributes['start_year'] = time.units.num2date(
+                time.points[0]
+            ).year
+            self.attributes['end_year'] = time.units.num2date(
+                time.points[-1]
+            ).year
+
     @property
     def is_closed(self):
         """Check if the file is closed."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Currently, the ICON grid file can either be specified via the facet `horizontal_grid` or automatically downloaded from a public website specified by the `GRID_FILE_URI` attribute of the data. Since the grid file is almost always present in the ICON output directory, this PR adds support for that. If possible, the ICON grid file is now retrieved from the ICON directory specified in the user configuration file.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Link to documentation: https://esmvaltool--2337.org.readthedocs.build/projects/ESMValCore/en/2337/quickstart/find_data.html#icon

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
