### PR TITLE
Update interval check in resample_hours

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -1233,7 +1233,7 @@ def resample_hours(cube: Cube, interval: int, offset: int = 0) -> Cube:
                          f'the interval ({interval})')
     time = cube.coord('time')
     cube_period = time.cell(1).point - time.cell(0).point
-    if cube_period.total_seconds() / 3600 >= interval:
+    if cube_period.total_seconds() / 3600 > interval:
         raise ValueError(f"Data period ({cube_period}) should be lower than "
                          f"the interval ({interval})")
     hours = [PartialDateTime(hour=h) for h in range(0 + offset, 24, interval)]

--- a/tests/unit/preprocessor/_time/test_time.py
+++ b/tests/unit/preprocessor/_time/test_time.py
@@ -2082,8 +2082,9 @@ class TestResampleHours(tests.Test):
         times = np.arange(0, 48, 12)
         cube = self._create_cube(data, times)
 
-        with self.assertRaises(ValueError):
-            resample_hours(cube, interval=12)
+        result = resample_hours(cube, interval=12)
+        expected = np.arange(0, 48, 12)
+        assert_array_equal(result.data, expected)
 
     def test_resample_nodata(self):
         """Test average of a 1D field."""


### PR DESCRIPTION
## Description

This PR updates the check of argument `interval` in the preprocessor function `resample_hours` (line 1236 in `_time.py`) from

`    if cube_period.total_seconds() / 3600 >= interval:`
to
`    if cube_period.total_seconds() / 3600 > interval:`

This change allows to process 3-hourly CMIP6 data and hourly ERA5 data with the same preprocessor settings. This is needed e.g. when calculating diurnal cycles from CMIP6 and ERA5 that need to have the same time coordinate (frequency and actual values) to be compared with the preprocessor function `distance_metric`.

The preprocessor `resample_hours` is currently not used by any recipe in the main branch, so risks of this change affecting existing diagnostics is expected to be very small.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful
