### PR TITLE
Fix `positive` attributes in custom CMOR variables

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_clhmtisccp.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_clhmtisccp.dat
@@ -17,6 +17,5 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_clhtkisccp.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_clhtkisccp.dat
@@ -17,6 +17,5 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_cllmtisccp.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_cllmtisccp.dat
@@ -17,6 +17,5 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_clltkisccp.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_clltkisccp.dat
@@ -17,6 +17,5 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_clmmtisccp.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_clmmtisccp.dat
@@ -17,6 +17,5 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_clmtkisccp.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_clmtkisccp.dat
@@ -17,6 +17,5 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_lwcre.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_lwcre.dat
@@ -17,6 +17,6 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
+positive:          down
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_netcre.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_netcre.dat
@@ -17,6 +17,6 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
+positive:          down
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_rsnt.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_rsnt.dat
@@ -17,6 +17,6 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
+positive:          down
 !----------------------------------
 !

--- a/esmvalcore/cmor/tables/custom/CMOR_swcre.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_swcre.dat
@@ -17,6 +17,6 @@ comment:           at the top of the atmosphere (to be compared with satellite m
 !----------------------------------
 dimensions:        longitude latitude time
 type:              real
-positive:          up
+positive:          down
 !----------------------------------
 !

--- a/esmvalcore/preprocessor/_derive/lwcre.py
+++ b/esmvalcore/preprocessor/_derive/lwcre.py
@@ -31,5 +31,6 @@ class DerivedVariable(DerivedVariableBase):
 
         lwcre_cube = rlutcs_cube - rlut_cube
         lwcre_cube.units = rlut_cube.units
+        lwcre_cube.attributes['positive'] = 'down'
 
         return lwcre_cube

--- a/esmvalcore/preprocessor/_derive/netcre.py
+++ b/esmvalcore/preprocessor/_derive/netcre.py
@@ -43,5 +43,6 @@ class DerivedVariable(DerivedVariableBase):
 
         netcre_cube = lwcre_cube + swcre_cube
         netcre_cube.units = lwcre_cube.units
+        netcre_cube.attributes['positive'] = 'down'
 
         return netcre_cube

--- a/esmvalcore/preprocessor/_derive/rsnt.py
+++ b/esmvalcore/preprocessor/_derive/rsnt.py
@@ -30,5 +30,7 @@ class DerivedVariable(DerivedVariableBase):
             Constraint(name='toa_outgoing_shortwave_flux'))
 
         rsnt_cube = rsdt_cube - rsut_cube
+        rsnt_cube.units = rsdt_cube.units
+        rsnt_cube.attributes['positive'] = 'down'
 
         return rsnt_cube

--- a/esmvalcore/preprocessor/_derive/swcre.py
+++ b/esmvalcore/preprocessor/_derive/swcre.py
@@ -30,5 +30,7 @@ class DerivedVariable(DerivedVariableBase):
             Constraint(name='toa_outgoing_shortwave_flux_assuming_clear_sky'))
 
         swcre_cube = rsutcs_cube - rsut_cube
+        swcre_cube.units = rsut_cube.units
+        swcre_cube.attributes['positive'] = 'down'
 
         return swcre_cube

--- a/tests/unit/preprocessor/_derive/test_lwcre.py
+++ b/tests/unit/preprocessor/_derive/test_lwcre.py
@@ -1,0 +1,28 @@
+"""Test derivation of `lwcre`."""
+import numpy as np
+import pytest
+from iris.cube import Cube, CubeList
+
+import esmvalcore.preprocessor._derive.lwcre as lwcre
+
+
+@pytest.fixture
+def cubes():
+    rlut_cube = Cube(
+        3, standard_name='toa_outgoing_longwave_flux', units='W m-2'
+    )
+    rlutcs_cube = Cube(
+        1,
+        standard_name='toa_outgoing_longwave_flux_assuming_clear_sky',
+        units='W m-2',
+    )
+    return CubeList([rlut_cube, rlutcs_cube])
+
+
+def test_lwcre_calculation(cubes):
+    """Test calculation of `lwcre`."""
+    derived_var = lwcre.DerivedVariable()
+    out_cube = derived_var.calculate(cubes)
+    np.testing.assert_equal(out_cube.data, -2)
+    assert out_cube.units == 'W m-2'
+    assert out_cube.attributes['positive'] == 'down'

--- a/tests/unit/preprocessor/_derive/test_netcre.py
+++ b/tests/unit/preprocessor/_derive/test_netcre.py
@@ -1,0 +1,36 @@
+"""Test derivation of `netcre`."""
+import numpy as np
+import pytest
+from iris.cube import Cube, CubeList
+
+import esmvalcore.preprocessor._derive.netcre as netcre
+
+
+@pytest.fixture
+def cubes():
+    rlut_cube = Cube(
+        3, standard_name='toa_outgoing_longwave_flux', units='W m-2'
+    )
+    rlutcs_cube = Cube(
+        1,
+        standard_name='toa_outgoing_longwave_flux_assuming_clear_sky',
+        units='W m-2',
+    )
+    rsut_cube = Cube(
+        3, standard_name='toa_outgoing_shortwave_flux', units='W m-2'
+    )
+    rsutcs_cube = Cube(
+        1,
+        standard_name='toa_outgoing_shortwave_flux_assuming_clear_sky',
+        units='W m-2',
+    )
+    return CubeList([rlut_cube, rlutcs_cube, rsut_cube, rsutcs_cube])
+
+
+def test_netcre_calculation(cubes):
+    """Test calculation of `netcre`."""
+    derived_var = netcre.DerivedVariable()
+    out_cube = derived_var.calculate(cubes)
+    np.testing.assert_equal(out_cube.data, -4)
+    assert out_cube.units == 'W m-2'
+    assert out_cube.attributes['positive'] == 'down'

--- a/tests/unit/preprocessor/_derive/test_rsnt.py
+++ b/tests/unit/preprocessor/_derive/test_rsnt.py
@@ -1,0 +1,26 @@
+"""Test derivation of `rsnt`."""
+import numpy as np
+import pytest
+from iris.cube import Cube, CubeList
+
+import esmvalcore.preprocessor._derive.rsnt as rsnt
+
+
+@pytest.fixture
+def cubes():
+    rsdt_cube = Cube(
+        3, standard_name='toa_incoming_shortwave_flux', units='W m-2'
+    )
+    rsut_cube = Cube(
+        1, standard_name='toa_outgoing_shortwave_flux', units='W m-2'
+    )
+    return CubeList([rsdt_cube, rsut_cube])
+
+
+def test_rsnt_calculation(cubes):
+    """Test calculation of `rsnt`."""
+    derived_var = rsnt.DerivedVariable()
+    out_cube = derived_var.calculate(cubes)
+    np.testing.assert_equal(out_cube.data, 2)
+    assert out_cube.units == 'W m-2'
+    assert out_cube.attributes['positive'] == 'down'

--- a/tests/unit/preprocessor/_derive/test_swcre.py
+++ b/tests/unit/preprocessor/_derive/test_swcre.py
@@ -1,0 +1,28 @@
+"""Test derivation of `swcre`."""
+import numpy as np
+import pytest
+from iris.cube import Cube, CubeList
+
+import esmvalcore.preprocessor._derive.swcre as swcre
+
+
+@pytest.fixture
+def cubes():
+    rsut_cube = Cube(
+        3, standard_name='toa_outgoing_shortwave_flux', units='W m-2'
+    )
+    rsutcs_cube = Cube(
+        1,
+        standard_name='toa_outgoing_shortwave_flux_assuming_clear_sky',
+        units='W m-2',
+    )
+    return CubeList([rsut_cube, rsutcs_cube])
+
+
+def test_swcre_calculation(cubes):
+    """Test calculation of `swcre`."""
+    derived_var = swcre.DerivedVariable()
+    out_cube = derived_var.calculate(cubes)
+    np.testing.assert_equal(out_cube.data, -2)
+    assert out_cube.units == 'W m-2'
+    assert out_cube.attributes['positive'] == 'down'


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR fixes `positive` attributes in custom CMOR variables:
- For ISCCP cloud are fractions, remove it (it does not make sense to have it here)
- For the cloud radiative effects (CREs), change it from `up` to `down`
- For TOA Net downward Shortwave Radiation, change it from `up` to `down`

This PR also adds missing tests for these derived variables to improve our overall test coverage.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
