### PR TITLE
Add `esmvaltool compare` command to run `esmvaltool/utils/testing/regression/compare.py`

### DIFF
--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -38,6 +38,7 @@ else:
     from importlib.metadata import entry_points  # type: ignore
 
 import fire
+from esmvaltool.utils.testing.regression import compare
 
 # set up logging
 logger = logging.getLogger(__name__)
@@ -413,6 +414,36 @@ class ESMValTool():
         self._run(recipe, session)
         # Print warnings about deprecated configuration options again:
         CFG.reload()
+
+
+    def compare(self,
+                reference,
+                current,
+                verbose=False):
+        """Compare results from two runs of esmvaltool.
+
+        `esmvaltool compare` compares the results from two runs of esmvaltool. 
+        Returns 0 if results were successfully compared and identical, 1
+        otherwise.
+
+        Parameters
+        ----------
+        reference : str
+            Directory containing results obtained with reference version.
+        current : str
+            Directory containing results obtained with current version.
+        verbose : bool, optional
+            Display more information on differences.
+
+        """
+
+        reference = Path(reference)
+        current = Path(current)
+
+        same = compare.compare(reference, current, verbose)
+
+        sys.exit(not(same))
+
 
     @staticmethod
     def _create_session_dir(session):


### PR DESCRIPTION
## Description

TBA - just a draft for now, pending thinking about whether a command group is needed.

Closes #2381

Link to documentation: TBA

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful
