### PR TITLE
Unify dtype handling of preprocessors

### DIFF
--- a/esmvalcore/preprocessor/_derive/sm.py
+++ b/esmvalcore/preprocessor/_derive/sm.py
@@ -29,7 +29,7 @@ class DerivedVariable(DerivedVariableBase):
         """
         mrsos_cube = cubes.extract_cube(NameConstraint(var_name='mrsos'))
 
-        depth = mrsos_cube.coord('depth').core_bounds().astype(np.float32)
+        depth = mrsos_cube.coord('depth').core_bounds().astype(np.float64)
         layer_thickness = depth[..., 1] - depth[..., 0]
 
         sm_cube = mrsos_cube / layer_thickness / 998.2

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -31,6 +31,7 @@ from esmvalcore.cmor.table import CMOR_TABLES
 from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 from esmvalcore.iris_helpers import has_irregular_grid, has_unstructured_grid
 from esmvalcore.preprocessor._other import get_array_module
+from esmvalcore.preprocessor._shared import preserve_float_dtype
 from esmvalcore.preprocessor._supplementary_vars import (
     add_ancillary_variable,
     add_cell_measure,
@@ -639,6 +640,7 @@ def _load_generic_scheme(scheme: dict):
     return loaded_scheme
 
 
+@preserve_float_dtype
 def regrid(
     cube: Cube,
     target_grid: Cube | Dataset | Path | str | dict,
@@ -1118,6 +1120,7 @@ def _rechunk_aux_factory_dependencies(
     return cube
 
 
+@preserve_float_dtype
 def extract_levels(
     cube: iris.cube.Cube,
     levels: np.typing.ArrayLike | da.Array,
@@ -1308,6 +1311,7 @@ def get_reference_levels(dataset):
     return coord.points.tolist()
 
 
+@preserve_float_dtype
 def extract_coordinate_points(cube, definition, scheme):
     """Extract points from any coordinate with interpolation.
 

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -255,7 +255,7 @@ def adapt_float_dtype(data: DataType, dtype: DTypeLike) -> DataType:
 
 
 def preserve_float_dtype(func: Callable) -> Callable:
-    """Preserve object's float dtype (all other dtypes are left unchanged).
+    """Preserve object's float dtype (all other dtypes are allowed to change).
 
     This can be used as a decorator for preprocessor functions to ensure that
     floating dtypes are preserved. For example, input of type float32 will

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -32,6 +32,7 @@ from esmvalcore.cmor.fixes import get_next_month, get_time_bounds
 from esmvalcore.iris_helpers import date2num, rechunk_cube
 from esmvalcore.preprocessor._shared import (
     get_iris_aggregator,
+    preserve_float_dtype,
     update_weights_kwargs,
 )
 
@@ -446,6 +447,7 @@ def _aggregate_time_fx(result_cube, source_cube):
                                                    ancillary_dims)
 
 
+@preserve_float_dtype
 def hourly_statistics(
     cube: Cube,
     hours: int,
@@ -501,6 +503,7 @@ def hourly_statistics(
     return result
 
 
+@preserve_float_dtype
 def daily_statistics(
     cube: Cube,
     operator: str = 'mean',
@@ -541,6 +544,7 @@ def daily_statistics(
     return result
 
 
+@preserve_float_dtype
 def monthly_statistics(
     cube: Cube,
     operator: str = 'mean',
@@ -579,6 +583,7 @@ def monthly_statistics(
     return result
 
 
+@preserve_float_dtype
 def seasonal_statistics(
     cube: Cube,
     operator: str = 'mean',
@@ -673,6 +678,7 @@ def seasonal_statistics(
     return result
 
 
+@preserve_float_dtype
 def annual_statistics(
     cube: Cube,
     operator: str = 'mean',
@@ -714,6 +720,7 @@ def annual_statistics(
     return result
 
 
+@preserve_float_dtype
 def decadal_statistics(
     cube: Cube,
     operator: str = 'mean',
@@ -762,6 +769,7 @@ def decadal_statistics(
     return result
 
 
+@preserve_float_dtype
 def climate_statistics(
     cube: Cube,
     operator: str = 'mean',
@@ -804,7 +812,6 @@ def climate_statistics(
     iris.cube.Cube
         Climate statistics cube.
     """
-    original_dtype = cube.dtype
     period = period.lower()
 
     # Use Cube.collapsed when full period is requested
@@ -846,14 +853,6 @@ def climate_statistics(
                 clim_cube.slices_over(clim_coord.name())).merge_cube()
         cube.remove_coord(clim_coord)
 
-    # Make sure that original dtype is preserved
-    new_dtype = clim_cube.dtype
-    if original_dtype != new_dtype:
-        logger.debug(
-            "climate_statistics changed dtype from "
-            "%s to %s, changing back", original_dtype, new_dtype)
-        clim_cube.data = clim_cube.core_data().astype(original_dtype)
-
     return clim_cube
 
 
@@ -867,6 +866,7 @@ def _add_time_weights_coord(cube):
     cube.add_aux_coord(time_weights_coord, cube.coord_dims('time'))
 
 
+@preserve_float_dtype
 def anomalies(
     cube: Cube,
     period: str,
@@ -1104,6 +1104,7 @@ def low_pass_weights(window, cutoff):
     return weights[1:-1]
 
 
+@preserve_float_dtype
 def timeseries_filter(
     cube: Cube,
     window: int,
@@ -1658,6 +1659,7 @@ def _check_cube_coords(cube):
         )
 
 
+@preserve_float_dtype
 def local_solar_time(cube: Cube) -> Cube:
     """Convert UTC time coordinate to local solar time (LST).
 

--- a/esmvalcore/preprocessor/_trend.py
+++ b/esmvalcore/preprocessor/_trend.py
@@ -6,6 +6,8 @@ import iris
 import numpy as np
 from cf_units import Unit
 
+from esmvalcore.preprocessor._shared import preserve_float_dtype
+
 logger = logging.getLogger(__name__)
 
 
@@ -71,6 +73,7 @@ def _set_trend_units(cube, coord):
         cube.units /= coord_units
 
 
+@preserve_float_dtype
 def linear_trend(cube, coordinate='time'):
     """Calculate linear trend of data along a given coordinate.
 
@@ -122,6 +125,7 @@ def linear_trend(cube, coordinate='time'):
     return cube
 
 
+@preserve_float_dtype
 def linear_trend_stderr(cube, coordinate='time'):
     """Calculate standard error of linear trend along a given coordinate.
 

--- a/esmvalcore/typing.py
+++ b/esmvalcore/typing.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 from numbers import Number
 from typing import Dict, Iterable, Sequence, Union
 
+import dask.array as da
+import numpy as np
+from iris.cube import Cube
+
 FacetValue = Union[str, Sequence[str], Number]
 """Type describing a single facet."""
 
@@ -17,3 +21,6 @@ NetCDFAttr = Union[str, Number, Iterable]
 <https://unidata.github.io/netcdf4-python/#attributes-in-a-netcdf-file>`_ can
 be strings, numbers or sequences.
 """
+
+DataType = Union[np.ndarray, da.Array, Cube]
+"""Type describing data."""

--- a/tests/unit/preprocessor/_area/test_area.py
+++ b/tests/unit/preprocessor/_area/test_area.py
@@ -639,7 +639,7 @@ def test_area_statistics_sum_unstructured_grid_fail():
 def make_testcube():
     """Create a test cube on a Cartesian grid."""
     coord_sys = iris.coord_systems.GeogCS(EARTH_RADIUS)
-    data = np.ones((5, 5))
+    data = np.ones((5, 5), dtype=np.float32)
     lons = iris.coords.DimCoord(
         [i + .5 for i in range(5)],
         standard_name='longitude',

--- a/tests/unit/preprocessor/_regrid/test_regrid.py
+++ b/tests/unit/preprocessor/_regrid/test_regrid.py
@@ -47,8 +47,7 @@ class Test(tests.Test):
         self.remove_coord = mock.Mock()
         self.regridded_cube = mock.Mock()
         self.regridded_cube.data = mock.sentinel.data
-        self.regridded_cube_data = mock.Mock()
-        self.regridded_cube.core_data.return_value = self.regridded_cube_data
+        self.regridded_cube.astype.return_value = self.regridded_cube
         self.regrid = mock.Mock(return_value=self.regridded_cube)
         self.src_cube = mock.Mock(
             spec=iris.cube.Cube,


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Many preprocessors have use some kind of custom code to make sure that dtypes are preserved. This PR adds a decorator `@preserve_float_dtype` unifies this task. Only `float` dtypes will be preserved, other dtypes are allowed to change. This ensures that `int` objects may be transformed to `float` objects when taking the mean for example (similar to what numpy does).

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2370


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
