### PR TITLE
Use `iris.FUTURE.save_split_attrs = True` to remove iris warning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - geopy
   - humanfriendly
   - importlib_metadata  # required for Python < 3.10
-  - iris >=3.6.1
+  - iris >=3.8.0
   - iris-esmf-regrid >=0.7.0
   - isodate
   - jinja2

--- a/esmvalcore/_provenance.py
+++ b/esmvalcore/_provenance.py
@@ -53,7 +53,7 @@ def attribute_to_authors(entity, authors):
 
 
 def attribute_to_projects(entity, projects):
-    """Attribute entity to projecs."""
+    """Attribute entity to projects."""
     namespace = 'project'
     create_namespace(entity.bundle, namespace)
 
@@ -193,7 +193,7 @@ class TrackedFile:
         self._initialize_ancestors(activity)
 
     def _initialize_namespaces(self):
-        """Inialize the namespaces."""
+        """Initialize the namespaces."""
         for namespace in ('file', 'attribute', 'preprocessor', 'task'):
             create_namespace(self.provenance, namespace)
 

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -35,6 +35,8 @@ VARIABLE_KEYS = {
     'alternative_dataset',
 }
 
+iris.FUTURE.save_split_attrs = True
+
 
 def _get_attr_from_field_coord(ncfield, coord_name, attr):
     if coord_name is not None:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ REQUIREMENTS = {
         'scipy>=1.6',
         # See the following issue for info on the iris pin below:
         # https://github.com/ESMValGroup/ESMValTool/issues/3239#issuecomment-1613298587
-        'scitools-iris>=3.6.1',
+        'scitools-iris>=3.8.0',
         'shapely>=2.0.0',
         'stratify>=0.3',
         'yamale',

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,7 +34,8 @@ def create_test_file(filename, tracking_id=None):
     attributes = {}
     if tracking_id is not None:
         attributes['tracking_id'] = tracking_id
-    cube = iris.cube.Cube([], attributes=attributes)
+    cube = iris.cube.Cube([])
+    cube.attributes.globals = attributes
 
     iris.save(cube, filename)
 

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -97,7 +97,8 @@ def create_test_file(filename, tracking_id=None):
     attributes = {}
     if tracking_id is not None:
         attributes['tracking_id'] = tracking_id
-    cube = iris.cube.Cube([], attributes=attributes)
+    cube = iris.cube.Cube([])
+    cube.attributes.globals = attributes
 
     iris.save(cube, filename)
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2376

Note: this is **not** fully backwards-compatible, as this changes the way iris writes attributes (some attributes are moved from global to local). I don't think this is a problem, but might be good to keep in mind.


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] ~~Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~~ see above
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
