### PR TITLE
Load data only once for ESMPy regridders

### DIFF
--- a/esmvalcore/preprocessor/_regrid_esmpy.py
+++ b/esmvalcore/preprocessor/_regrid_esmpy.py
@@ -67,6 +67,9 @@ class ESMPyRegridder:
         mask_threshold: float = 0.99,
     ):
         """Initialize class instance."""
+        # These regridders are not lazy, so load source and target data once.
+        src_cube.data  # pylint: disable=pointless-statement
+        tgt_cube.data  # pylint: disable=pointless-statement
         self.src_cube = src_cube
         self.tgt_cube = tgt_cube
         self.method = method
@@ -86,6 +89,8 @@ class ESMPyRegridder:
             Regridded cube.
 
         """
+        # These regridders are not lazy, so load source data once.
+        cube.data  # pylint: disable=pointless-statement
         src_rep, dst_rep = get_grid_representants(cube, self.tgt_cube)
         regridder = build_regridder(
             src_rep, dst_rep, self.method, mask_threshold=self.mask_threshold

--- a/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
+++ b/tests/unit/preprocessor/_regrid_esmpy/test_regrid_esmpy.py
@@ -713,6 +713,31 @@ class TestHelpers(tests.Test):
                                                 mock.sentinel.regridder,
                                                 self.cube_3d, self.cube)
 
+    @mock.patch('esmvalcore.preprocessor._regrid_esmpy.map_slices')
+    @mock.patch('esmvalcore.preprocessor._regrid_esmpy.build_regridder')
+    @mock.patch('esmvalcore.preprocessor._regrid_esmpy.get_grid_representants',
+                mock.Mock(side_effect=identity))
+    def test_data_realized_once(self, mock_build_regridder, mock_map_slices):
+        """Test that the regridder realizes the data only once."""
+        src_cube = mock.MagicMock()
+        src_data = mock.PropertyMock()
+        type(src_cube).data = src_data
+        tgt_cube1 = mock.MagicMock()
+        tgt_data1 = mock.PropertyMock()
+        type(tgt_cube1).data = tgt_data1
+        # Check that constructing the regridder realizes the source and
+        # target data.
+        regridder = ESMPyAreaWeighted().regridder(src_cube, tgt_cube1)
+        src_data.assert_called_with()
+        tgt_data1.assert_called_with()
+        tgt_cube2 = mock.MagicMock()
+        tgt_data2 = mock.PropertyMock()
+        # Check that calling the regridder with another cube also realizes
+        # target data.
+        type(tgt_cube2).data = tgt_data2
+        regridder(tgt_cube2)
+        tgt_data2.assert_called_with()
+
 
 @pytest.mark.parametrize(
     'scheme,output',


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Realize the data only once for the ESMPy regridders.

Closes https://github.com/ESMValGroup/ESMValTool/issues/3590

Test recipe:
```yaml
documentation:
  description: Example recipe that shows slow regridding.
  title: Example recipe that shows slow regridding.
  authors:
    - andela_bouwe
  maintainer:
    - andela_bouwe
  references:
    - acknow_project
  projects:
    - esmval

preprocessors:
  time_ocean_zonal_mean:
    custom_order: true
    climate_statistics:
      operator: mean
      period: full
    extract_levels:
      levels: [ 0,  10, 20, 50, 100, 200, 300, 500, 750, 1000, 1250, 1500, 1750, 2000, 2250, 2500, 2750, 3000, 3250, 3500, 3750, 4000, 4250, 4500, 4750, 5000, 5250, 5500, 5750]
      scheme: linear_extrapolate
      coordinate: depth
    regrid:
      target_grid: 1x1
      scheme: nearest
    zonal_statistics:
      operator: mean

datasets:
  - dataset: CanESM5-1
    exp: piControl
    ensemble: r1i1p2f1
    grid: gn
    institute: CCCma

diagnostics:
  diagnostic1:
    variables:
      thetao:
        mip: Omon
        project: CMIP6
        timerange: 6191/6220
        preprocessor: time_ocean_zonal_mean
    scripts: null
```

With these changes, the recipe takes less than a minute to run on my laptop. I did not wait for the process to complete (killed it after about 10 minutes), but reportedly it takes about an hour without these changes.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
