### PR TITLE
Remove compilers dependency from conda environment and force install x64 git in OSX Github Action workflows

### DIFF
--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -94,6 +94,8 @@ jobs:
         run: |
           mamba --version 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
           python -V 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
+      - name: Force install x64 git
+        run: mamba install -c conda-forge git
       - name: Install
         run: pip install -e .[develop] 2>&1 | tee source_install_osx_artifacts_python_${{ matrix.python-version }}/install.txt
       - name: Verify installation

--- a/.github/workflows/run-tests-monitor.yml
+++ b/.github/workflows/run-tests-monitor.yml
@@ -73,6 +73,7 @@ jobs:
       - run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - run: python -V 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
+      - run: mamba install -c conda-forge git
       - run: pip install pytest-monitor
       - run: pip install -e .[develop] 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/install.txt
       - run: conda list

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
       - main
-      - remove_compilers_dependency
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - main
+      - remove_compilers_dependency
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,6 +91,7 @@ jobs:
       - run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt
       - run: python -V 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/python_version.txt
+      - run: mamba install -c conda-forge git
       - run: pip install -e .[develop] 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/install.txt
       - run: conda list
       - run: flake8

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - cartopy
   - cf-units
   - cftime
-  - compilers
   - dask
   - dask-jobqueue
   - distributed


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2419 

`compilers` was added by @bouweandela four years ago in #603 - see https://github.com/ESMValGroup/ESMValCore/pull/603#issuecomment-631651179 - I don't think we still need it but may be worth checking the docker build goes well without it anyway

OSX tests: failing with "setuptools_scm._run_cmd.CommandNotFoundError: git" - this has been seen in https://github.com/ESMValGroup/ESMValTool/pull/3581 and it's not hitting just this node, but rather, it's an endemic issue related to macOS 14 on arm64:
```
  Image: macos-14-arm64
  Version: 20240422.3
  Included Software: https://github.com/actions/runner-images/blob/macos-14-arm64/20240422.3/images/macos/macos-14-arm64-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240422.3
```
For some reason, the system git goes fishing when the x64 environment is activated and used - @schlunma and I had a decent debate about it in the linked Tool PR - no time to really-really understand the issue, just plop a git installer in the workflow!

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
