### PR TITLE
Add xESMF regridder

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -433,7 +433,7 @@ numfig = True
 
 # Configuration for intersphinx
 intersphinx_mapping = {
-    'cf_units': ('https://cf-units.readthedocs.io/en/latest/', None),
+    'cf_units': ('https://cf-units.readthedocs.io/en/stable/', None),
     'cftime': ('https://unidata.github.io/cftime/', None),
     'esmvalcore':
     (f'https://docs.esmvaltool.org/projects/ESMValCore/en/{rtd_version}/',
@@ -441,13 +441,13 @@ intersphinx_mapping = {
     'esmvaltool': (f'https://docs.esmvaltool.org/en/{rtd_version}/', None),
     'dask': ('https://docs.dask.org/en/stable/', None),
     'distributed': ('https://distributed.dask.org/en/stable/', None),
-    'iris': ('https://scitools-iris.readthedocs.io/en/latest/', None),
-    'iris-esmf-regrid': ('https://iris-esmf-regrid.readthedocs.io/en/latest',
+    'iris': ('https://scitools-iris.readthedocs.io/en/stable/', None),
+    'iris-esmf-regrid': ('https://iris-esmf-regrid.readthedocs.io/en/stable',
                          None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
-    'ncdata': ('https://ncdata.readthedocs.io/en/latest/', None),
+    'ncdata': ('https://ncdata.readthedocs.io/en/stable/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'pyesgf': ('https://esgf-pyclient.readthedocs.io/en/latest/', None),
+    'pyesgf': ('https://esgf-pyclient.readthedocs.io/en/stable/', None),
     'python': ('https://docs.python.org/3/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'xesmf': ('https://xesmf.readthedocs.io/en/stable/', None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -450,6 +450,7 @@ intersphinx_mapping = {
     'pyesgf': ('https://esgf-pyclient.readthedocs.io/en/stable/', None),
     'python': ('https://docs.python.org/3/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'xarray': ('https://docs.xarray.dev/en/stable/', None),
     'xesmf': ('https://xesmf.readthedocs.io/en/stable/', None),
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -445,10 +445,12 @@ intersphinx_mapping = {
     'iris-esmf-regrid': ('https://iris-esmf-regrid.readthedocs.io/en/latest',
                          None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
+    'ncdata': ('https://ncdata.readthedocs.io/en/latest/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pyesgf': ('https://esgf-pyclient.readthedocs.io/en/latest/', None),
     'python': ('https://docs.python.org/3/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'xesmf': ('https://xesmf.readthedocs.io/en/stable/', None),
 }
 
 # -- Extlinks extension -------------------------------------------------------

--- a/esmvalcore/preprocessor/_regrid_xesmf.py
+++ b/esmvalcore/preprocessor/_regrid_xesmf.py
@@ -1,0 +1,168 @@
+"""xESMF regridding.
+
+To use this, install xesmf and ncdata, e.g. ``mamba install xesmf ncdata``.
+"""
+
+import inspect
+
+import dask.array as da
+import iris.cube
+import numpy as np
+
+
+class xESMFRegridder:
+    """xESMF regridding function.
+
+    This is a wrapper around :class:`xesmf.Regrid` so it can be used in
+    :meth:`iris.cube.Cube.regrid`.
+
+    Supports lazy regridding.
+
+    Parameters
+    ----------
+    src_cube:
+        Cube describing the source grid.
+    tgt_cube:
+        Cube describing the target grid.
+    **kwargs:
+        Any keyword argument to :class:`xesmf.Regrid` or
+        :meth:`xesmf.Regrid.__call__` can be provided.
+
+    Attributes
+    ----------
+    kwargs:
+        Keyword arguments to :class:`xesmf.Regrid`.
+    default_call_kwargs:
+        Default keyword arguments to :meth:`xesmf.Regrid.__call__`.
+    """
+
+    def __init__(
+        self,
+        src_cube: iris.cube.Cube,
+        tgt_cube: iris.cube.Cube,
+        **kwargs,
+    ) -> None:
+        import ncdata.iris_xarray
+        import xesmf
+
+        call_arg_names = list(
+            inspect.signature(xesmf.Regridder.__call__).parameters
+        )[2:]
+        self.kwargs = {
+            k: v
+            for k, v in kwargs.items() if k not in call_arg_names
+        }
+        self.default_call_kwargs = {
+            k: v
+            for k, v in kwargs.items() if k in call_arg_names
+        }
+
+        src_ds = ncdata.iris_xarray.cubes_to_xarray([src_cube])
+        tgt_ds = ncdata.iris_xarray.cubes_to_xarray([tgt_cube])
+        for var in src_ds.values():
+            var.data = da.ma.filled(var.data, np.nan)
+        for var in tgt_ds.values():
+            var.data = da.ma.filled(var.data, np.nan)
+
+        self._regridder = xesmf.Regridder(src_ds, tgt_ds, **self.kwargs)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the class."""
+        kwargs = self.kwargs | self.default_call_kwargs
+        return f"{self.__class__.__name__}(**{kwargs})"
+
+    def __call__(self, src_cube: iris.cube.Cube, **kwargs) -> iris.cube.Cube:
+        """Run the regridder.
+
+        Parameters
+        ----------
+        src_cube:
+            The cube to regrid.
+        **kwargs:
+            Keyword arguments to :meth:`xesmf.Regrid.__call__`.
+
+        Returns
+        -------
+        iris.cube.Cube
+            The regridded cube.
+        """
+        import ncdata.iris_xarray
+
+        src_ds = ncdata.iris_xarray.cubes_to_xarray([src_cube])
+        for var in src_ds.values():
+            var.data = da.ma.filled(var.data, np.nan)
+
+        call_args = dict(self.default_call_kwargs)
+        call_args.update(kwargs)
+        tgt_ds = self._regridder(src_ds, **call_args)
+        for var in tgt_ds.values():
+            var.data = da.ma.masked_where(da.isnan(var.data), var.data)
+
+        cube = ncdata.iris_xarray.cubes_from_xarray(
+            tgt_ds,
+            iris_load_kwargs={'constraints': src_cube.standard_name},
+        )[0]
+        return cube
+
+
+class xESMF:
+    """xESMF regridding scheme.
+
+    This is a wrapper around :class:`xesmf.Regrid` so it can be used in
+    :meth:`iris.cube.Cube.regrid`. Ut uses the :mod:`ncdata` package to
+    convert the :class:`iris.cube.Cube` to an :class:`xarray.Dataset` before
+    regridding and back after regridding.
+
+    Supports lazy regridding.
+
+    Masks are converted to :obj:`np.nan` before regridding and converted
+    back to masks after regridding.
+
+    Parameters
+    ----------
+    **kwargs:
+        Any keyword argument to :class:`xesmf.Regrid` or
+        :meth:`xesmf.Regrid.__call__` can be provided. By default,
+        the arguments ``ignore_degenerate=True``, ``keep_attrs=True``,
+        ``skipna=True``, an ``unmapped_to_nan=True`` will be used.
+
+    Attributes
+    ----------
+    kwargs:
+        Keyword arguments that will be provided to the regridder.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        args = {
+            'ignore_degenerate': True,
+            'skipna': True,
+            'keep_attrs': True,
+            'unmapped_to_nan': True,
+        }
+        args.update(kwargs)
+        self.kwargs = args
+
+    def __repr__(self) -> str:
+        """Return string representation of class."""
+        return f'{self.__class__.__name__}(**{self.kwargs})'
+
+    def regridder(
+        self,
+        src_cube: iris.cube.Cube,
+        tgt_cube: iris.cube.Cube,
+    ) -> xESMFRegridder:
+        """Create xESMF regridding function.
+
+        Parameters
+        ----------
+        src_cube:
+            Cube defining the source grid.
+        tgt_cube:
+            Cube defining the target grid.
+
+        Returns
+        -------
+        xESMFRegridder
+            xESMF regridding function.
+        """
+        return xESMFRegridder(src_cube, tgt_cube, **self.kwargs)

--- a/esmvalcore/preprocessor/_regrid_xesmf.py
+++ b/esmvalcore/preprocessor/_regrid_xesmf.py
@@ -10,7 +10,7 @@ import iris.cube
 import numpy as np
 
 
-class xESMFRegridder:
+class xESMFRegridder:  # noqa
     """xESMF regridding function.
 
     This is a wrapper around :class:`xesmf.Regrid` so it can be used in
@@ -105,7 +105,7 @@ class xESMFRegridder:
         return cube
 
 
-class xESMF:
+class xESMF:  # noqa
     """xESMF regridding scheme.
 
     This is a wrapper around :class:`xesmf.Regrid` so it can be used in

--- a/esmvalcore/preprocessor/_regrid_xesmf.py
+++ b/esmvalcore/preprocessor/_regrid_xesmf.py
@@ -13,8 +13,8 @@ import numpy as np
 class xESMFRegridder:  # noqa
     """xESMF regridding function.
 
-    This is a wrapper around :class:`xesmf.Regridder` so it can be used in
-    :meth:`iris.cube.Cube.regrid`.
+    This is a wrapper around :class:`xesmf.frontend.Regridder` so it can be
+    used in :meth:`iris.cube.Cube.regrid`.
 
     Supports lazy regridding.
 
@@ -25,15 +25,15 @@ class xESMFRegridder:  # noqa
     tgt_cube:
         Cube describing the target grid.
     **kwargs:
-        Any keyword argument to :class:`xesmf.Regridder` or
-        :meth:`xesmf.Regridder.__call__` can be provided.
+        Any keyword argument to :class:`xesmf.frontend.Regridder` or
+        :meth:`xesmf.frontend.Regridder.__call__` can be provided.
 
     Attributes
     ----------
     kwargs:
-        Keyword arguments to :class:`xesmf.Regridder`.
+        Keyword arguments to :class:`xesmf.frontend.Regridder`.
     default_call_kwargs:
-        Default keyword arguments to :meth:`xesmf.Regridder.__call__`.
+        Default keyword arguments to :meth:`xesmf.frontend.Regridder.__call__`.
     """
 
     def __init__(
@@ -78,7 +78,7 @@ class xESMFRegridder:  # noqa
         src_cube:
             The cube to regrid.
         **kwargs:
-            Keyword arguments to :meth:`xesmf.Regridder.__call__`.
+            Keyword arguments to :meth:`xesmf.frontend.Regridder.__call__`.
 
         Returns
         -------
@@ -107,8 +107,8 @@ class xESMFRegridder:  # noqa
 class xESMF:  # noqa
     """xESMF regridding scheme.
 
-    This is a wrapper around :class:`xesmf.Regridder` so it can be used in
-    :meth:`iris.cube.Cube.regrid`. Ut uses the :mod:`ncdata` package to
+    This is a wrapper around :class:`xesmf.frontend.Regridder` so it can be
+    used in :meth:`iris.cube.Cube.regrid`. It uses the :mod:`ncdata` package to
     convert the :class:`iris.cube.Cube` to an :class:`xarray.Dataset` before
     regridding and back after regridding.
 
@@ -120,10 +120,10 @@ class xESMF:  # noqa
     Parameters
     ----------
     **kwargs:
-        Any keyword argument to :class:`xesmf.Regridder` or
-        :meth:`xesmf.Regridder.__call__` can be provided. By default,
+        Any keyword argument to :class:`xesmf.frontend.Regridder` or
+        :meth:`xesmf.frontend.Regridder.__call__` can be provided. By default,
         the arguments ``ignore_degenerate=True``, ``keep_attrs=True``,
-        ``skipna=True``, an ``unmapped_to_nan=True`` will be used.
+        ``skipna=True``, and ``unmapped_to_nan=True`` will be used.
 
     Attributes
     ----------

--- a/esmvalcore/preprocessor/_regrid_xesmf.py
+++ b/esmvalcore/preprocessor/_regrid_xesmf.py
@@ -13,7 +13,7 @@ import numpy as np
 class xESMFRegridder:  # noqa
     """xESMF regridding function.
 
-    This is a wrapper around :class:`xesmf.Regrid` so it can be used in
+    This is a wrapper around :class:`xesmf.Regridder` so it can be used in
     :meth:`iris.cube.Cube.regrid`.
 
     Supports lazy regridding.
@@ -25,15 +25,15 @@ class xESMFRegridder:  # noqa
     tgt_cube:
         Cube describing the target grid.
     **kwargs:
-        Any keyword argument to :class:`xesmf.Regrid` or
-        :meth:`xesmf.Regrid.__call__` can be provided.
+        Any keyword argument to :class:`xesmf.Regridder` or
+        :meth:`xesmf.Regridder.__call__` can be provided.
 
     Attributes
     ----------
     kwargs:
-        Keyword arguments to :class:`xesmf.Regrid`.
+        Keyword arguments to :class:`xesmf.Regridder`.
     default_call_kwargs:
-        Default keyword arguments to :meth:`xesmf.Regrid.__call__`.
+        Default keyword arguments to :meth:`xesmf.Regridder.__call__`.
     """
 
     def __init__(
@@ -46,8 +46,7 @@ class xESMFRegridder:  # noqa
         import xesmf
 
         call_arg_names = list(
-            inspect.signature(xesmf.Regridder.__call__).parameters
-        )[2:]
+            inspect.signature(xesmf.Regridder.__call__).parameters)[2:]
         self.kwargs = {
             k: v
             for k, v in kwargs.items() if k not in call_arg_names
@@ -79,7 +78,7 @@ class xESMFRegridder:  # noqa
         src_cube:
             The cube to regrid.
         **kwargs:
-            Keyword arguments to :meth:`xesmf.Regrid.__call__`.
+            Keyword arguments to :meth:`xesmf.Regridder.__call__`.
 
         Returns
         -------
@@ -108,21 +107,21 @@ class xESMFRegridder:  # noqa
 class xESMF:  # noqa
     """xESMF regridding scheme.
 
-    This is a wrapper around :class:`xesmf.Regrid` so it can be used in
+    This is a wrapper around :class:`xesmf.Regridder` so it can be used in
     :meth:`iris.cube.Cube.regrid`. Ut uses the :mod:`ncdata` package to
     convert the :class:`iris.cube.Cube` to an :class:`xarray.Dataset` before
     regridding and back after regridding.
 
     Supports lazy regridding.
 
-    Masks are converted to :obj:`np.nan` before regridding and converted
+    Masks are converted to :obj:`numpy.nan` before regridding and converted
     back to masks after regridding.
 
     Parameters
     ----------
     **kwargs:
-        Any keyword argument to :class:`xesmf.Regrid` or
-        :meth:`xesmf.Regrid.__call__` can be provided. By default,
+        Any keyword argument to :class:`xesmf.Regridder` or
+        :meth:`xesmf.Regridder.__call__` can be provided. By default,
         the arguments ``ignore_degenerate=True``, ``keep_attrs=True``,
         ``skipna=True``, an ``unmapped_to_nan=True`` will be used.
 

--- a/esmvalcore/preprocessor/regrid_schemes.py
+++ b/esmvalcore/preprocessor/regrid_schemes.py
@@ -17,9 +17,9 @@ from esmvalcore.preprocessor._regrid_unstructured import (
     UnstructuredLinearRegridder,
     UnstructuredNearest,
 )
+from esmvalcore.preprocessor._regrid_xesmf import xESMF, xESMFRegridder
 
 logger = logging.getLogger(__name__)
-
 
 __all__ = [
     'ESMPyAreaWeighted',
@@ -31,6 +31,8 @@ __all__ = [
     'UnstructuredLinear',
     'UnstructuredLinearRegridder',
     'UnstructuredNearest',
+    'xESMF',
+    'xESMFRegridder',
 ]
 
 
@@ -51,7 +53,6 @@ class GenericRegridder:
         Cube, \*\*kwargs) -> Cube.
     **kwargs:
         Keyword arguments for the generic regridding function.
-
     """
 
     def __init__(
@@ -79,7 +80,6 @@ class GenericRegridder:
         -------
         Cube
             Regridded cube.
-
         """
         return self.func(cube, self.tgt_cube, **self.kwargs)
 
@@ -98,7 +98,6 @@ class GenericFuncScheme:
         Cube, \*\*kwargs) -> Cube.
     **kwargs:
         Keyword arguments for the generic regridding function.
-
     """
 
     def __init__(self, func: Callable, **kwargs):
@@ -125,6 +124,5 @@ class GenericFuncScheme:
         -------
         GenericRegridder
             Regridder instance.
-
         """
         return GenericRegridder(src_cube, tgt_cube, self.func, **self.kwargs)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Add [xESMF](https://xesmf.readthedocs.io/en/stable/) regriding scheme for the regrid preprocessor.

Example usage in preprocessor in recipe:
```yaml
regrid:
  target_grid: 1x1
  scheme:
    reference: esmvalcore.preprocessor.regrid_schemes:xESMF
    method: bilinear
    periodic: true
```

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Link to documentation: https://esmvaltool--2433.org.readthedocs.build/projects/ESMValCore/en/2433/api/esmvalcore.regridding_schemes.html#esmvalcore.preprocessor.regrid_schemes.xESMF

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
