### PR TITLE
Preserve cube attribute global vs local when concatenating

### DIFF
--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -148,13 +148,12 @@ def merge_cube_attributes(
 
     # Step 2: if values are not equal, first convert them to strings (so that
     # set() can be used); then extract unique elements from this list, sort it,
-    # and use the delimiter to join all elements to a single string
-    final_attributes: Dict[str, NetCDFAttr] = {}
+    # and use the delimiter to join all elements to a single string.
+    # Uses the first cube to decide if an attribute is global or local.
+    final_attributes = cubes[0].attributes.copy()
     for (attr, vals) in attributes.items():
         set_of_str = sorted({str(v) for v in vals})
-        if len(set_of_str) == 1:
-            final_attributes[attr] = vals[0]
-        else:
+        if len(set_of_str) > 1:
             final_attributes[attr] = delimiter.join(set_of_str)
 
     # Step 3: modify the cubes in-place

--- a/tests/unit/test_iris_helpers.py
+++ b/tests/unit/test_iris_helpers.py
@@ -2,6 +2,7 @@
 import datetime
 from copy import deepcopy
 from itertools import permutations
+from pprint import pformat
 from unittest import mock
 
 import dask.array as da
@@ -141,8 +142,10 @@ def test_date2num_scalar(date, dtype, expected, units):
     assert num.dtype == dtype
 
 
-def assert_attribues_equal(attrs_1: dict, attrs_2: dict) -> None:
+def assert_attributes_equal(attrs_1: dict, attrs_2: dict) -> None:
     """Check attributes using :func:`numpy.testing.assert_array_equal`."""
+    print(pformat(dict(attrs_1)))
+    print(pformat(dict(attrs_2)))
     assert len(attrs_1) == len(attrs_2)
     for (attr, val) in attrs_1.items():
         assert attr in attrs_2
@@ -210,7 +213,7 @@ def test_merge_cube_attributes(cubes):
     merge_cube_attributes(cubes)
     assert len(cubes) == 3
     for cube in cubes:
-        assert_attribues_equal(cube.attributes, expected_attributes)
+        assert_attributes_equal(cube.attributes, expected_attributes)
 
 
 def test_merge_cube_attributes_0_cubes():
@@ -224,7 +227,20 @@ def test_merge_cube_attributes_1_cube():
     expected_attributes = deepcopy(cubes[0].attributes)
     merge_cube_attributes(cubes)
     assert len(cubes) == 1
-    assert_attribues_equal(cubes[0].attributes, expected_attributes)
+    assert_attributes_equal(cubes[0].attributes, expected_attributes)
+
+
+def test_merge_cube_attributes_global_local():
+    cube1 = CUBES[0].copy()
+    cube2 = CUBES[1].copy()
+    cube1.attributes.globals['attr1'] = 1
+    cube1.attributes.globals['attr2'] = 1
+    cube1.attributes.globals['attr3'] = 1
+    cube2.attributes.locals['attr1'] = 1
+    merge_cube_attributes([cube1, cube2])
+    for cube in [cube1, cube2]:
+        for attr in ['attr1', 'attr2', 'attr3']:
+            assert attr in cube.attributes.globals
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Preserve cube attribute global vs local as well as possible in `esmvalcore.preprocessor.concatenate`. See [`iris.cube.CubeAttrsDict`](https://scitools-iris.readthedocs.io/en/stable/generated/api/iris.cube.html#iris.cube.CubeAttrsDict) for more information.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
