### PR TITLE
New custom variable for tos uncertainty

### DIFF
--- a/esmvalcore/cmor/tables/custom/CMOR_tosStderr.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_tosStderr.dat
@@ -1,0 +1,26 @@
+SOURCE: CMIP5
+!============
+variable_entry:    tosStderr
+!============
+modeling_realm:    ocean
+!----------------------------------
+! Variable attributes:
+!----------------------------------
+standard_name:
+units:             K
+cell_methods:      time: mean
+cell_measures:     area: areacello
+long_name:         Sea Surface Temperature Error
+comment:           
+!----------------------------------
+! Additional variable information:
+!----------------------------------
+dimensions:        longitude latitude time
+out_name:          tosStderr
+type:              real
+valid_min:         0
+valid_max:         10
+ok_min_mean_abs:   0
+ok_max_mean_abs:   10
+!----------------------------------
+!

--- a/esmvalcore/cmor/tables/custom/CMOR_tosStderr.dat
+++ b/esmvalcore/cmor/tables/custom/CMOR_tosStderr.dat
@@ -19,8 +19,8 @@ dimensions:        longitude latitude time
 out_name:          tosStderr
 type:              real
 valid_min:         0
-valid_max:         10
+valid_max:
 ok_min_mean_abs:   0
-ok_max_mean_abs:   10
+ok_max_mean_abs:
 !----------------------------------
 !

--- a/tests/integration/cmor/test_table.py
+++ b/tests/integration/cmor/test_table.py
@@ -477,13 +477,22 @@ class TestCustomInfo(unittest.TestCase):
         self.assertEqual(var.units, 'K')
 
     def test_get_variable_ch4s(self):
-        """Get tas variable."""
+        """Get ch4s variable."""
         CustomInfo()
         var = self.variables_info.get_variable('Amon', 'ch4s')
         self.assertEqual(var.short_name, 'ch4s')
         self.assertEqual(var.long_name,
                          'Atmosphere CH4 surface')
         self.assertEqual(var.units, '1e-09')
+
+    def test_get_variable_tosStderr(self):
+        """Get tosStderr variable."""
+        CustomInfo()
+        var = self.variables_info.get_variable('Omon', 'tosStderr')
+        self.assertEqual(var.short_name, 'tosStderr')
+        self.assertEqual(var.long_name,
+                         'Sea Surface Temperature Error')
+        self.assertEqual(var.units, 'K')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This pull request adds a custom cmor table entry for sea surface temperature uncertainty (tosStderr), and a test for this new entry.

Closes #2469



***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
