### PR TITLE
Fix tests if deprecated `~/.esmvaltool/config-user.yml` file is available

### DIFF
--- a/esmvalcore/config/_config_object.py
+++ b/esmvalcore/config/_config_object.py
@@ -385,7 +385,6 @@ class Config(ValidatedConfig):
         # TODO: remove in v2.14.0
         self.clear()
         _deprecated_config_user_path = Config._get_config_user_path()
-        print(_deprecated_config_user_path)
         if _deprecated_config_user_path.is_file():
             deprecation_msg = (
                 f"Usage of the single configuration file "
@@ -402,7 +401,6 @@ class Config(ValidatedConfig):
             return
 
         # New since v2.12.0
-        print(USER_CONFIG_DIR)
         try:
             self.load_from_dirs([USER_CONFIG_DIR])
         except InvalidConfigParameter as exc:

--- a/esmvalcore/config/_config_object.py
+++ b/esmvalcore/config/_config_object.py
@@ -385,6 +385,7 @@ class Config(ValidatedConfig):
         # TODO: remove in v2.14.0
         self.clear()
         _deprecated_config_user_path = Config._get_config_user_path()
+        print(_deprecated_config_user_path)
         if _deprecated_config_user_path.is_file():
             deprecation_msg = (
                 f"Usage of the single configuration file "
@@ -401,6 +402,7 @@ class Config(ValidatedConfig):
             return
 
         # New since v2.12.0
+        print(USER_CONFIG_DIR)
         try:
             self.load_from_dirs([USER_CONFIG_DIR])
         except InvalidConfigParameter as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from esmvalcore.config import CFG
+from esmvalcore.config import CFG, Config
 
 
 @pytest.fixture
@@ -22,3 +22,13 @@ def session(tmp_path: Path, cfg_default, monkeypatch):
     monkeypatch.setitem(CFG, "rootpath", {"default": {tmp_path: "default"}})
     monkeypatch.setitem(CFG, "output_dir", tmp_path / "esmvaltool_output")
     return CFG.start_session("recipe_test")
+
+
+# TODO: remove in v2.14.0
+@pytest.fixture(autouse=True)
+def ignore_old_config_user(tmp_path, monkeypatch):
+    """Ignore potentially existing old config-user.yml file in all tests."""
+    nonexistent_config_dir = tmp_path / "nonexistent_config_dir"
+    monkeypatch.setattr(
+        Config, "_DEFAULT_USER_CONFIG_DIR", nonexistent_config_dir
+    )

--- a/tests/unit/config/test_config_object.py
+++ b/tests/unit/config/test_config_object.py
@@ -73,12 +73,14 @@ def test_load_from_file(monkeypatch):
 
 
 # TODO: remove in v2.14.0
-def test_load_from_file_filenotfound(monkeypatch):
+def test_load_from_file_filenotfound(monkeypatch, tmp_path):
     """Test `Config.load_from_file`."""
     config = Config()
     assert not config
 
-    expected_path = Path.home() / ".esmvaltool" / "not_existent_file.yml"
+    expected_path = (
+        tmp_path / "nonexistent_config_dir" / "not_existent_file.yml"
+    )
     msg = f"Config file '{expected_path}' does not exist"
     with pytest.raises(FileNotFoundError, match=msg):
         config.load_from_file("not_existent_file.yml")
@@ -110,6 +112,9 @@ def test_config_key_error():
 
 def test_reload(cfg_default, monkeypatch, tmp_path):
     """Test `Config.reload`."""
+    # TODO: remove in v2.14.0
+    monkeypatch.delenv("_ESMVALTOOL_USER_CONFIG_FILE_", raising=False)
+
     monkeypatch.setattr(
         esmvalcore.config._config_object,
         "USER_CONFIG_DIR",
@@ -124,6 +129,9 @@ def test_reload(cfg_default, monkeypatch, tmp_path):
 
 def test_reload_fail(monkeypatch, tmp_path):
     """Test `Config.reload`."""
+    # TODO: remove in v2.14.0
+    monkeypatch.delenv("_ESMVALTOOL_USER_CONFIG_FILE_", raising=False)
+
     config_file = tmp_path / "invalid_config_file.yml"
     config_file.write_text("invalid_option: 1")
     monkeypatch.setattr(
@@ -160,26 +168,32 @@ def test_session_config_dir():
 
 
 TEST_GET_CFG_PATH = [
-    (None, None, None, "~/.esmvaltool/config-user.yml", False),
+    (
+        None,
+        None,
+        None,
+        "{tmp_path}/nonexistent_config_dir/config-user.yml",
+        False,
+    ),
     (
         None,
         None,
         ("any_other_module", "--config_file=cli.yml"),
-        "~/.esmvaltool/config-user.yml",
+        "{tmp_path}/nonexistent_config_dir/config-user.yml",
         False,
     ),
     (
         None,
         None,
         ("esmvaltool", "run", "--max_parallel_tasks=4"),
-        "~/.esmvaltool/config-user.yml",
+        "{tmp_path}/nonexistent_config_dir/config-user.yml",
         True,
     ),
     (
         None,
         None,
         ("esmvaltool", "--config_file"),
-        "~/.esmvaltool/config-user.yml",
+        "{tmp_path}/nonexistent_config_dir/config-user.yml",
         True,
     ),
     (
@@ -214,7 +228,7 @@ TEST_GET_CFG_PATH = [
         None,
         None,
         ("esmvaltool", "run", "--config-file=relative_cli.yml"),
-        "~/.esmvaltool/relative_cli.yml",
+        "{tmp_path}/nonexistent_config_dir/relative_cli.yml",
         True,
     ),
     (
@@ -264,7 +278,7 @@ TEST_GET_CFG_PATH = [
         "filename.yml",
         None,
         None,
-        "~/.esmvaltool/filename.yml",
+        "{tmp_path}/nonexistent_config_dir/filename.yml",
         False,
     ),
     (
@@ -285,6 +299,7 @@ def test_get_config_user_path(
     filename, env, cli_args, output, env_var_set, monkeypatch, tmp_path
 ):
     """Test `Config._get_config_user_path`."""
+    output = output.format(tmp_path=tmp_path)
     monkeypatch.delenv("_ESMVALTOOL_USER_CONFIG_FILE_", raising=False)
 
     # Create empty test file
@@ -313,9 +328,11 @@ def test_get_config_user_path(
 
 
 # TODO: remove in v2.14.0
-def test_load_user_config_filenotfound():
+def test_load_user_config_filenotfound(tmp_path):
     """Test `Config._load_user_config`."""
-    expected_path = Path.home() / ".esmvaltool" / "not_existent_file.yml"
+    expected_path = (
+        tmp_path / "nonexistent_config_dir" / "not_existent_file.yml"
+    )
     msg = f"Config file '{expected_path}' does not exist"
     with pytest.raises(FileNotFoundError, match=msg):
         Config._load_user_config("not_existent_file.yml")

--- a/tests/unit/main/test_esmvaltool.py
+++ b/tests/unit/main/test_esmvaltool.py
@@ -205,8 +205,11 @@ def test_do_not_clean_preproc_dir(session):
     assert session._fixed_file_dir.exists()
 
 
+@mock.patch("esmvalcore._main.ESMValTool._get_config_info")
 @mock.patch("esmvalcore._main.entry_points")
-def test_header(mock_entry_points, monkeypatch, tmp_path, caplog):
+def test_header(
+    mock_entry_points, mock_get_config_info, monkeypatch, tmp_path, caplog
+):
     tmp_path.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(
         esmvalcore.config._config_object, "USER_CONFIG_DIR", tmp_path
@@ -220,6 +223,9 @@ def test_header(mock_entry_points, monkeypatch, tmp_path, caplog):
     entry_point.name = "Entry name"
     mock_entry_points.return_value = [entry_point]
     cli_config_dir = tmp_path / "this" / "does" / "not" / "exist"
+
+    # TODO: remove in v2.14.0
+    mock_get_config_info.return_value = "config_dir (SOURCE)"
 
     with caplog.at_level(logging.INFO):
         ESMValTool()._log_header(
@@ -235,11 +241,7 @@ def test_header(mock_entry_points, monkeypatch, tmp_path, caplog):
     assert caplog.messages[4] == "MyEntry: v42.42.42"
     assert caplog.messages[5] == "----------------"
     assert caplog.messages[6] == (
-        f"Reading configuration files from:\n"
-        f"{Path(esmvalcore.__file__).parent}/config/configurations/defaults "
-        f"(defaults)\n"
-        f"{tmp_path} (SOURCE)\n"
-        f"{cli_config_dir} [NOT AN EXISTING DIRECTORY] (command line argument)"
+        "Reading configuration files from:\nconfig_dir (SOURCE)"
     )
     assert caplog.messages[7] == (
         "Writing program log files to:\n"


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Fix tests if a deprecated `~/.esmvaltool/config-user.yml` file exists on the system.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/2541

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
