### PR TITLE
Remove deprecated CMOR fix/check code

### DIFF
--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from collections import namedtuple
 from collections.abc import Callable
 from enum import IntEnum
@@ -20,7 +19,6 @@ import numpy as np
 from iris.coords import Coord
 from iris.cube import Cube
 
-from esmvalcore.cmor._fixes.fix import GenericFix
 from esmvalcore.cmor._utils import (
     _get_alternative_generic_lev_coord,
     _get_generic_lev_coord_names,
@@ -28,7 +26,6 @@ from esmvalcore.cmor._utils import (
     _get_simplified_calendar,
 )
 from esmvalcore.cmor.table import CoordinateInfo, get_var_info
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 from esmvalcore.iris_helpers import has_unstructured_grid
 
 
@@ -70,18 +67,6 @@ class CMORCheck:
     fail_on_error: bool
         If true, CMORCheck stops on the first error. If false, it collects
         all possible errors before stopping.
-    automatic_fixes: bool
-        If True, CMORCheck will try to apply automatic fixes for any
-        detected error, if possible.
-
-        .. deprecated:: 2.10.0
-            This option has been deprecated in ESMValCore version 2.10.0 and is
-            scheduled for removal in version 2.12.0. Please use the functions
-            :func:`~esmvalcore.preprocessor.fix_metadata`,
-            :func:`~esmvalcore.preprocessor.fix_data`, or
-            :meth:`esmvalcore.dataset.Dataset.load` (which automatically
-            includes the first two functions) instead. Fixes and CMOR checks
-            have been clearly separated in ESMValCore version 2.10.0.
     check_level: CheckLevels
         Level of strictness of the checks.
 
@@ -104,7 +89,6 @@ class CMORCheck:
         frequency=None,
         fail_on_error=False,
         check_level=CheckLevels.DEFAULT,
-        automatic_fixes=False,
     ):
         self._cube = cube
         self._failerr = fail_on_error
@@ -118,26 +102,6 @@ class CMORCheck:
         if not frequency:
             frequency = self._cmor_var.frequency
         self.frequency = frequency
-        self.automatic_fixes = automatic_fixes
-
-        # Deprecate automatic_fixes (remove in v2.12)
-        if automatic_fixes:
-            msg = (
-                "The option `automatic_fixes` has been deprecated in "
-                "ESMValCore version 2.10.0 and is scheduled for removal in "
-                "version 2.12.0. Please use the functions "
-                "esmvalcore.preprocessor.fix_metadata(), "
-                "esmvalcore.preprocessor.fix_data(), or "
-                "esmvalcore.dataset.Dataset.load() (which automatically "
-                "includes the first two functions) instead. Fixes and CMOR "
-                "checks have been clearly separated in ESMValCore version "
-                "2.10.0."
-            )
-            warnings.warn(msg, ESMValCoreDeprecationWarning)
-
-        # TODO: remove in v2.12
-
-        self._generic_fix = GenericFix(var_info, frequency=frequency)
 
     @cached_property
     def _unstructured_grid(self) -> bool:
@@ -170,10 +134,6 @@ class CMORCheck:
         """
         if logger is not None:
             self._logger = logger
-
-        # TODO: remove in v2.12
-        if self.automatic_fixes:
-            [self._cube] = self._generic_fix.fix_metadata([self._cube])
 
         self._check_var_metadata()
         self._check_fill_value()
@@ -219,10 +179,6 @@ class CMORCheck:
         """
         if logger is not None:
             self._logger = logger
-
-        # TODO: remove in v2.12
-        if self.automatic_fixes:
-            self._cube = self._generic_fix.fix_data(self._cube)
 
         self._check_coords_data()
 
@@ -345,7 +301,6 @@ class CMORCheck:
 
     def _get_effective_units(self):
         """Get effective units."""
-        # TODO: remove entire function in v2.12
         if self._cmor_var.units.lower() == "psu":
             units = "1.0"
         else:
@@ -605,12 +560,6 @@ class CMORCheck:
                 coord = self._cube.coord(var_name=var_name, dim_coords=True)
             except iris.exceptions.CoordinateNotFoundError:
                 continue
-
-            # TODO: remove in v2.12
-            if self.automatic_fixes:
-                (self._cube, coord) = self._generic_fix._fix_coord_direction(
-                    self._cube, coordinate, coord
-                )
 
             self._check_coord_monotonicity_and_direction(
                 coordinate, coord, var_name
@@ -935,7 +884,6 @@ def _get_cmor_checker(
     frequency: None | str = None,
     fail_on_error: bool = False,
     check_level: CheckLevels = CheckLevels.DEFAULT,
-    automatic_fixes: bool = False,  # TODO: remove in v2.12
 ) -> Callable[[Cube], CMORCheck]:
     """Get a CMOR checker."""
     var_info = get_var_info(project, mip, short_name)
@@ -947,7 +895,6 @@ def _get_cmor_checker(
             frequency=frequency,
             fail_on_error=fail_on_error,
             check_level=check_level,
-            automatic_fixes=automatic_fixes,
         )
 
     return _checker

--- a/esmvalcore/cmor/fix.py
+++ b/esmvalcore/cmor/fix.py
@@ -8,7 +8,6 @@ variables to be sure that all known errors are fixed.
 from __future__ import annotations
 
 import logging
-import warnings
 from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
@@ -17,8 +16,6 @@ from typing import TYPE_CHECKING, Optional
 from iris.cube import Cube, CubeList
 
 from esmvalcore.cmor._fixes.fix import Fix
-from esmvalcore.cmor.check import CheckLevels, _get_cmor_checker
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 
 if TYPE_CHECKING:
     from ..config import Session
@@ -109,7 +106,6 @@ def fix_metadata(
     dataset: str,
     mip: str,
     frequency: Optional[str] = None,
-    check_level: CheckLevels = CheckLevels.DEFAULT,
     session: Optional[Session] = None,
     **extra_facets,
 ) -> CubeList:
@@ -132,17 +128,6 @@ def fix_metadata(
         Variable's MIP.
     frequency:
         Variable's data frequency, if available.
-    check_level:
-        Level of strictness of the checks.
-
-        .. deprecated:: 2.10.0
-            This option has been deprecated in ESMValCore version 2.10.0 and is
-            scheduled for removal in version 2.12.0. Please use the functions
-            :func:`~esmvalcore.preprocessor.cmor_check_metadata`,
-            :func:`~esmvalcore.preprocessor.cmor_check_data`, or
-            :meth:`~esmvalcore.cmor.check.cmor_check` instead. This function
-            will no longer perform CMOR checks. Fixes and CMOR checks have been
-            clearly separated in ESMValCore version 2.10.0.
     session:
         Current session which includes configuration and directory information.
     **extra_facets:
@@ -155,20 +140,6 @@ def fix_metadata(
         Fixed cubes.
 
     """
-    # Deprecate CMOR checks (remove in v2.12)
-    if check_level != CheckLevels.DEFAULT:
-        msg = (
-            "The option `check_level` has been deprecated in ESMValCore "
-            "version 2.10.0 and is scheduled for removal in version 2.12.0. "
-            "Please use the functions "
-            "esmvalcore.preprocessor.cmor_check_metadata, "
-            "esmvalcore.preprocessor.cmor_check_data, or "
-            "esmvalcore.cmor.check.cmor_check instead. This function will no "
-            "longer perform CMOR checks. Fixes and CMOR checks have been "
-            "clearly separated in ESMValCore version 2.10.0."
-        )
-        warnings.warn(msg, ESMValCoreDeprecationWarning)
-
     # Update extra_facets with variable information given as regular arguments
     # to this function
     extra_facets.update(
@@ -207,18 +178,6 @@ def fix_metadata(
         # returns a single cube
         cube = cube_list[0]
 
-        # Perform CMOR checks
-        # TODO: remove in v2.12
-        checker = _get_cmor_checker(
-            project,
-            mip,
-            short_name,
-            frequency,
-            fail_on_error=False,
-            check_level=check_level,
-        )
-        cube = checker(cube).check_metadata()
-
         cube.attributes.pop("source_file", None)
         fixed_cubes.append(cube)
 
@@ -232,7 +191,6 @@ def fix_data(
     dataset: str,
     mip: str,
     frequency: Optional[str] = None,
-    check_level: CheckLevels = CheckLevels.DEFAULT,
     session: Optional[Session] = None,
     **extra_facets,
 ) -> Cube:
@@ -257,17 +215,6 @@ def fix_data(
         Variable's MIP.
     frequency:
         Variable's data frequency, if available.
-    check_level:
-        Level of strictness of the checks.
-
-        .. deprecated:: 2.10.0
-            This option has been deprecated in ESMValCore version 2.10.0 and is
-            scheduled for removal in version 2.12.0. Please use the functions
-            :func:`~esmvalcore.preprocessor.cmor_check_metadata`,
-            :func:`~esmvalcore.preprocessor.cmor_check_data`, or
-            :meth:`~esmvalcore.cmor.check.cmor_check` instead. This function
-            will no longer perform CMOR checks. Fixes and CMOR checks have been
-            clearly separated in ESMValCore version 2.10.0.
     session:
         Current session which includes configuration and directory information.
     **extra_facets:
@@ -280,20 +227,6 @@ def fix_data(
         Fixed cube.
 
     """
-    # Deprecate CMOR checks (remove in v2.12)
-    if check_level != CheckLevels.DEFAULT:
-        msg = (
-            "The option `check_level` has been deprecated in ESMValCore "
-            "version 2.10.0 and is scheduled for removal in version 2.12.0. "
-            "Please use the functions "
-            "esmvalcore.preprocessor.cmor_check_metadata, "
-            "esmvalcore.preprocessor.cmor_check_data, or "
-            "esmvalcore.cmor.check.cmor_check instead. This function will no "
-            "longer perform CMOR checks. Fixes and CMOR checks have been "
-            "clearly separated in ESMValCore version 2.10.0."
-        )
-        warnings.warn(msg, ESMValCoreDeprecationWarning)
-
     # Update extra_facets with variable information given as regular arguments
     # to this function
     extra_facets.update(
@@ -316,17 +249,5 @@ def fix_data(
         frequency=frequency,
     ):
         cube = fix.fix_data(cube)
-
-    # Perform CMOR checks
-    # TODO: remove in v2.12
-    checker = _get_cmor_checker(
-        project,
-        mip,
-        short_name,
-        frequency,
-        fail_on_error=False,
-        check_level=check_level,
-    )
-    cube = checker(cube).check_data()
 
     return cube

--- a/esmvalcore/dataset.py
+++ b/esmvalcore/dataset.py
@@ -761,7 +761,6 @@ class Dataset:
             ),
         }
         settings["fix_metadata"] = {
-            "check_level": self.session["check_level"],
             "session": self.session,
             **self.facets,
         }
@@ -778,7 +777,6 @@ class Dataset:
                 "timerange": self.facets["timerange"],
             }
         settings["fix_data"] = {
-            "check_level": self.session["check_level"],
             "session": self.session,
             **self.facets,
         }

--- a/tests/integration/cmor/_fixes/obs4mips/test_airs_2_0.py
+++ b/tests/integration/cmor/_fixes/obs4mips/test_airs_2_0.py
@@ -20,14 +20,7 @@ def test_fix_metadata_hur():
         ]
     )
 
-    fixed_cubes = fix_metadata(
-        cubes,
-        "hur",
-        "obs4MIPs",
-        "AIRS-2-0",
-        "Amon",
-        check_level=5,
-    )
+    fixed_cubes = fix_metadata(cubes, "hur", "obs4MIPs", "AIRS-2-0", "Amon")
 
     assert len(fixed_cubes) == 1
     fixed_cube = fixed_cubes[0]

--- a/tests/integration/cmor/test_fix.py
+++ b/tests/integration/cmor/test_fix.py
@@ -8,33 +8,13 @@ from iris.aux_factory import HybridHeightFactory, HybridPressureFactory
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube, CubeList
 
-from esmvalcore.cmor.check import CheckLevels, CMORCheckError
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning
+from esmvalcore.cmor.check import CMORCheckError
 from esmvalcore.preprocessor import (
     cmor_check_data,
     cmor_check_metadata,
     fix_data,
     fix_metadata,
 )
-
-
-# TODO: remove in v2.12
-@pytest.fixture(autouse=True)
-def disable_fix_cmor_checker(mocker):
-    """Disable the CMOR checker in fixes (will be default in v2.12)."""
-
-    class MockChecker:
-        def __init__(self, cube):
-            self._cube = cube
-
-        def check_metadata(self):
-            return self._cube
-
-        def check_data(self):
-            return self._cube
-
-    mock = mocker.patch("esmvalcore.cmor.fix._get_cmor_checker")
-    mock.return_value = MockChecker
 
 
 class TestGenericFix:
@@ -887,27 +867,3 @@ class TestGenericFix:
 
         assert self.mock_debug.call_count == 0
         assert self.mock_warning.call_count == 0
-
-    def test_deprecate_check_level_fix_metadata(self):
-        """Test deprecation of check level in ``fix_metadata``."""
-        with pytest.warns(ESMValCoreDeprecationWarning):
-            fix_metadata(
-                self.cubes_4d,
-                "ta",
-                "CMIP6",
-                "MODEL",
-                "Amon",
-                check_level=CheckLevels.RELAXED,
-            )
-
-    def test_deprecate_check_level_fix_data(self):
-        """Test deprecation of check level in ``fix_data``."""
-        with pytest.warns(ESMValCoreDeprecationWarning):
-            fix_metadata(
-                self.cubes_4d,
-                "ta",
-                "CMIP6",
-                "MODEL",
-                "Amon",
-                check_level=CheckLevels.RELAXED,
-            )

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -20,7 +20,6 @@ from esmvalcore.cmor.check import (
     CMORCheckError,
     _get_cmor_checker,
 )
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning
 
 logger = logging.getLogger(__name__)
 
@@ -296,14 +295,6 @@ class TestCMORCheck(unittest.TestCase):
         """Test valid generic level coordinate."""
         self._setup_generic_level_var()
         checker = CMORCheck(self.cube, self.var_info)
-        checker.check_metadata()
-        checker.check_data()
-
-    # TODO: remove in v2.12
-    def test_valid_generic_level_automatic_fixes(self):
-        """Test valid generic level coordinate with automatic fixes."""
-        self._setup_generic_level_var()
-        checker = CMORCheck(self.cube, self.var_info, automatic_fixes=True)
         checker.check_metadata()
         checker.check_data()
 
@@ -679,20 +670,6 @@ class TestCMORCheck(unittest.TestCase):
         """Fail in metadata if decreasing coordinate is increasing."""
         self.var_info.coordinates["lat"].stored_direction = "decreasing"
         self._check_fails_in_metadata()
-
-    # TODO: remove in v2.12
-    def test_non_decreasing_automatic_fix_metadata(self):
-        """Automatic fix for decreasing coordinate."""
-        self.var_info.coordinates["lat"].stored_direction = "decreasing"
-        checker = CMORCheck(self.cube, self.var_info, automatic_fixes=True)
-        checker.check_metadata()
-
-    # TODO: remove in v2.12
-    def test_non_decreasing_automatic_fix_data(self):
-        """Automatic fix for decreasing coordinate."""
-        self.var_info.coordinates["lat"].stored_direction = "decreasing"
-        checker = CMORCheck(self.cube, self.var_info, automatic_fixes=True)
-        checker.check_data()
 
     def test_lat_non_monotonic(self):
         """Test fail for non monotonic latitude."""
@@ -1256,12 +1233,6 @@ def test_get_cmor_checker_invalid_project_fail():
     """Test ``_get_cmor_checker`` with invalid project."""
     with pytest.raises(KeyError):
         _get_cmor_checker("INVALID_PROJECT", "mip", "short_name", "frequency")
-
-
-def test_deprecate_automatic_fixes():
-    """Test deprecation of automatic_fixes."""
-    with pytest.warns(ESMValCoreDeprecationWarning):
-        CMORCheck("cube", "var_info", "frequency", automatic_fixes=True)
 
 
 if __name__ == "__main__":

--- a/tests/unit/cmor/test_fix.py
+++ b/tests/unit/cmor/test_fix.py
@@ -117,12 +117,9 @@ class TestFixMetadata:
     def setUp(self):
         """Prepare for testing."""
         self.cube = self._create_mock_cube()
-        self.intermediate_cube = self._create_mock_cube()
         self.fixed_cube = self._create_mock_cube()
         self.mock_fix = Mock()
-        self.mock_fix.fix_metadata.return_value = [self.intermediate_cube]
-        self.checker = Mock()
-        self.check_metadata = self.checker.return_value.check_metadata
+        self.mock_fix.fix_metadata.return_value = [self.fixed_cube]
         self.expected_get_fixes_call = {
             "project": "project",
             "dataset": "model",
@@ -148,81 +145,58 @@ class TestFixMetadata:
 
     def test_fix(self):
         """Check that the returned fix is applied."""
-        self.check_metadata.side_effect = lambda: self.fixed_cube
         with patch(
             "esmvalcore.cmor._fixes.fix.Fix.get_fixes",
             return_value=[self.mock_fix],
         ) as mock_get_fixes:
-            with patch(
-                "esmvalcore.cmor.fix._get_cmor_checker",
-                return_value=self.checker,
-            ):
-                cube_returned = fix_metadata(
-                    cubes=[self.cube],
-                    short_name="short_name",
-                    project="project",
-                    dataset="model",
-                    mip="mip",
-                    frequency="frequency",
-                    session=sentinel.session,
-                )[0]
-                self.checker.assert_called_once_with(self.intermediate_cube)
-                self.check_metadata.assert_called_once_with()
-                assert cube_returned is not self.cube
-                assert cube_returned is not self.intermediate_cube
-                assert cube_returned is self.fixed_cube
-                mock_get_fixes.assert_called_once_with(
-                    **self.expected_get_fixes_call
-                )
+            cube_returned = fix_metadata(
+                cubes=[self.cube],
+                short_name="short_name",
+                project="project",
+                dataset="model",
+                mip="mip",
+                frequency="frequency",
+                session=sentinel.session,
+            )[0]
+            assert cube_returned is not self.cube
+            assert cube_returned is self.fixed_cube
+            mock_get_fixes.assert_called_once_with(
+                **self.expected_get_fixes_call
+            )
 
     def test_nofix(self):
         """Check that the same cube is returned if no fix is available."""
-        self.check_metadata.side_effect = lambda: self.cube
         with patch(
             "esmvalcore.cmor._fixes.fix.Fix.get_fixes", return_value=[]
         ) as mock_get_fixes:
-            with patch(
-                "esmvalcore.cmor.fix._get_cmor_checker",
-                return_value=self.checker,
-            ):
-                cube_returned = fix_metadata(
-                    cubes=[self.cube],
-                    short_name="short_name",
-                    project="project",
-                    dataset="model",
-                    mip="mip",
-                    frequency="frequency",
-                    session=sentinel.session,
-                )[0]
-                self.checker.assert_called_once_with(self.cube)
-                self.check_metadata.assert_called_once_with()
-                assert cube_returned is self.cube
-                assert cube_returned is not self.intermediate_cube
-                assert cube_returned is not self.fixed_cube
-                mock_get_fixes.assert_called_once_with(
-                    **self.expected_get_fixes_call
-                )
+            cube_returned = fix_metadata(
+                cubes=[self.cube],
+                short_name="short_name",
+                project="project",
+                dataset="model",
+                mip="mip",
+                frequency="frequency",
+                session=sentinel.session,
+            )[0]
+            assert cube_returned is self.cube
+            assert cube_returned is not self.fixed_cube
+            mock_get_fixes.assert_called_once_with(
+                **self.expected_get_fixes_call
+            )
 
     def test_select_var(self):
         """Check that the same cube is returned if no fix is available."""
-        self.check_metadata.side_effect = lambda: self.cube
         with patch(
             "esmvalcore.cmor._fixes.fix.Fix.get_fixes", return_value=[]
         ):
-            with patch(
-                "esmvalcore.cmor.fix._get_cmor_checker",
-                return_value=self.checker,
-            ):
-                cube_returned = fix_metadata(
-                    cubes=[self.cube, self._create_mock_cube("extra")],
-                    short_name="short_name",
-                    project="CMIP6",
-                    dataset="model",
-                    mip="mip",
-                )[0]
-                self.checker.assert_called_once_with(self.cube)
-                self.check_metadata.assert_called_once_with()
-                assert cube_returned is self.cube
+            cube_returned = fix_metadata(
+                cubes=[self.cube, self._create_mock_cube("extra")],
+                short_name="short_name",
+                project="CMIP6",
+                dataset="model",
+                mip="mip",
+            )[0]
+            assert cube_returned is self.cube
 
     def test_select_var_failed_if_bad_var_name(self):
         """Check that an error is raised if short_names do not match."""
@@ -247,12 +221,9 @@ class TestFixData:
     def setUp(self):
         """Prepare for testing."""
         self.cube = Mock()
-        self.intermediate_cube = Mock()
         self.fixed_cube = Mock()
         self.mock_fix = Mock()
-        self.mock_fix.fix_data.return_value = self.intermediate_cube
-        self.checker = Mock()
-        self.check_data = self.checker.return_value.check_data
+        self.mock_fix.fix_data.return_value = self.fixed_cube
         self.expected_get_fixes_call = {
             "project": "project",
             "dataset": "model",
@@ -271,57 +242,41 @@ class TestFixData:
 
     def test_fix(self):
         """Check that the returned fix is applied."""
-        self.check_data.side_effect = lambda: self.fixed_cube
         with patch(
             "esmvalcore.cmor._fixes.fix.Fix.get_fixes",
             return_value=[self.mock_fix],
         ) as mock_get_fixes:
-            with patch(
-                "esmvalcore.cmor.fix._get_cmor_checker",
-                return_value=self.checker,
-            ):
-                cube_returned = fix_data(
-                    self.cube,
-                    short_name="short_name",
-                    project="project",
-                    dataset="model",
-                    mip="mip",
-                    frequency="frequency",
-                    session=sentinel.session,
-                )
-                self.checker.assert_called_once_with(self.intermediate_cube)
-                self.check_data.assert_called_once_with()
-                assert cube_returned is not self.cube
-                assert cube_returned is not self.intermediate_cube
-                assert cube_returned is self.fixed_cube
-                mock_get_fixes.assert_called_once_with(
-                    **self.expected_get_fixes_call
-                )
+            cube_returned = fix_data(
+                self.cube,
+                short_name="short_name",
+                project="project",
+                dataset="model",
+                mip="mip",
+                frequency="frequency",
+                session=sentinel.session,
+            )
+            assert cube_returned is not self.cube
+            assert cube_returned is self.fixed_cube
+            mock_get_fixes.assert_called_once_with(
+                **self.expected_get_fixes_call
+            )
 
     def test_nofix(self):
         """Check that the same cube is returned if no fix is available."""
-        self.check_data.side_effect = lambda: self.cube
         with patch(
             "esmvalcore.cmor._fixes.fix.Fix.get_fixes", return_value=[]
         ) as mock_get_fixes:
-            with patch(
-                "esmvalcore.cmor.fix._get_cmor_checker",
-                return_value=self.checker,
-            ):
-                cube_returned = fix_data(
-                    self.cube,
-                    short_name="short_name",
-                    project="project",
-                    dataset="model",
-                    mip="mip",
-                    frequency="frequency",
-                    session=sentinel.session,
-                )
-                self.checker.assert_called_once_with(self.cube)
-                self.check_data.assert_called_once_with()
-                assert cube_returned is self.cube
-                assert cube_returned is not self.intermediate_cube
-                assert cube_returned is not self.fixed_cube
-                mock_get_fixes.assert_called_once_with(
-                    **self.expected_get_fixes_call
-                )
+            cube_returned = fix_data(
+                self.cube,
+                short_name="short_name",
+                project="project",
+                dataset="model",
+                mip="mip",
+                frequency="frequency",
+                session=sentinel.session,
+            )
+            assert cube_returned is self.cube
+            assert cube_returned is not self.fixed_cube
+            mock_get_fixes.assert_called_once_with(
+                **self.expected_get_fixes_call
+            )

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1735,7 +1735,6 @@ def test_load(mocker, session):
             "timerange": "2000/2005",
         },
         "fix_metadata": {
-            "check_level": CheckLevels.DEFAULT,
             "session": session,
             "dataset": "CanESM2",
             "ensemble": "r1i1p1",
@@ -1757,7 +1756,6 @@ def test_load(mocker, session):
             "timerange": "2000/2005",
         },
         "fix_data": {
-            "check_level": CheckLevels.DEFAULT,
             "session": session,
             "dataset": "CanESM2",
             "ensemble": "r1i1p1",


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR removes deprecated features related to CMOR fixes and checks that have been deprecated in v2.10.0 and are scheduled for removal in v2.12.0. See https://github.com/ESMValGroup/ESMValCore/pull/2157 for details.

### Backwards-incompatible changes

- Option `automatic_fixes` of [`CMORCheck`](https://esmvaltool--2157.org.readthedocs.build/projects/ESMValCore/en/2157/api/esmvalcore.cmor.html#esmvalcore.cmor.check.CMORCheck): use the functions [`fix_metadata`](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.fix_metadata), [`fix_data`](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.fix_data), or [`Dataset.load`](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.dataset.html#esmvalcore.dataset.Dataset.load) (which automatically includes the first two functions) instead. CMOR Checks will not include fixes anymore in the future.
- Option `check_level` in [`fix_metadata`](https://esmvaltool--2157.org.readthedocs.build/projects/ESMValCore/en/2157/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.fix_metadata) and [`fix_data`](https://esmvaltool--2157.org.readthedocs.build/projects/ESMValCore/en/2157/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.fix_data): use the functions [`cmor_check_metadata`](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.cmor_check_metadata), [`cmor_check_data`](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.cmor_check_data), or [`cmor_check`](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.cmor.html#esmvalcore.cmor.check.cmor_check) instead. Fixes will not check the data anymore in the future.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] ~Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
