### PR TITLE
retire Mambaforge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
   test_installation_from_source_test_mode:
     # Test installation from source
     docker:
-      - image: condaforge/miniforge
+      - image: condaforge/miniforge3
     resource_class: large
     steps:
       - test_installation_from_source
@@ -162,7 +162,7 @@ jobs:
   test_installation_from_source_develop_mode:
     # Test development installation
     docker:
-      - image: condaforge/miniforge
+      - image: condaforge/miniforge3
     resource_class: large
     steps:
       - test_installation_from_source:
@@ -172,7 +172,7 @@ jobs:
   test_with_upstream_developments:
     # Test with development versions of upstream packages
     docker:
-      - image: condaforge/miniforge
+      - image: condaforge/miniforge3
     resource_class: large
     steps:
       - test_installation_from_source:
@@ -192,7 +192,7 @@ jobs:
     # Test conda package installation
     working_directory: /esmvaltool
     docker:
-      - image: condaforge/miniforge
+      - image: condaforge/miniforge3
     resource_class: medium
     steps:
       - run:
@@ -214,7 +214,7 @@ jobs:
   build_documentation:
     # Test building documentation
     docker:
-      - image: condaforge/miniforge
+      - image: condaforge/miniforge3
     resource_class: medium
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
   test_installation_from_source_test_mode:
     # Test installation from source
     docker:
-      - image: condaforge/mambaforge
+      - image: condaforge/miniforge
     resource_class: large
     steps:
       - test_installation_from_source
@@ -162,7 +162,7 @@ jobs:
   test_installation_from_source_develop_mode:
     # Test development installation
     docker:
-      - image: condaforge/mambaforge
+      - image: condaforge/miniforge
     resource_class: large
     steps:
       - test_installation_from_source:
@@ -172,7 +172,7 @@ jobs:
   test_with_upstream_developments:
     # Test with development versions of upstream packages
     docker:
-      - image: condaforge/mambaforge
+      - image: condaforge/miniforge
     resource_class: large
     steps:
       - test_installation_from_source:
@@ -192,7 +192,7 @@ jobs:
     # Test conda package installation
     working_directory: /esmvaltool
     docker:
-      - image: condaforge/mambaforge
+      - image: condaforge/miniforge
     resource_class: medium
     steps:
       - run:
@@ -214,7 +214,7 @@ jobs:
   build_documentation:
     # Test building documentation
     docker:
-      - image: condaforge/mambaforge
+      - image: condaforge/miniforge
     resource_class: medium
     steps:
       - checkout

--- a/.github/workflows/create-condalock-file.yml
+++ b/.github/workflows/create-condalock-file.yml
@@ -29,7 +29,6 @@ jobs:
           activate-environment: esmvaltool-fromlock
           python-version: "3.12"
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - name: Update and show conda config
         run: |

--- a/.github/workflows/install-from-conda.yml
+++ b/.github/workflows/install-from-conda.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p conda_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
@@ -85,7 +84,6 @@ jobs:
           architecture: ${{ matrix.architecture }}
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p conda_install_osx_artifacts_python_${{ matrix.python-version }}
       - name: Record versions

--- a/.github/workflows/install-from-pypi.yml
+++ b/.github/workflows/install-from-pypi.yml
@@ -52,7 +52,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p pip_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
@@ -90,7 +89,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p pip_install_osx_artifacts_python_${{ matrix.python-version }}
       - name: Record versions

--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -50,7 +50,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p source_install_linux_artifacts_python_${{ matrix.python-version }}
       - name: Record versions
@@ -89,7 +88,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p source_install_osx_artifacts_python_${{ matrix.python-version }}
       - name: Record versions

--- a/.github/workflows/run-tests-monitor.yml
+++ b/.github/workflows/run-tests-monitor.yml
@@ -35,7 +35,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
@@ -70,7 +69,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,6 @@ on:
   push:
     branches:
       - main
-      - retire_Mambaforge
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - main
+      - retire_Mambaforge
   # run the test only if the PR is to main
   # turn it on if required
   #pull_request:
@@ -52,7 +53,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p test_linux_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_linux_artifacts_python_${{ matrix.python-version }}/conda_version.txt
@@ -90,7 +90,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           miniforge-version: "latest"
-          miniforge-variant: Mambaforge
           use-mamba: true
       - run: mkdir -p test_osx_artifacts_python_${{ matrix.python-version }}
       - run: conda --version 2>&1 | tee test_osx_artifacts_python_${{ matrix.python-version }}/conda_version.txt


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

- sister PR of https://github.com/ESMValGroup/ESMValTool/pull/3774
- Original issue from ESMValTool (with description of "brownouts" and Miniforge's attempts to get us all off Mambaforge asap) https://github.com/ESMValGroup/ESMValTool/issues/3772
- move to Miniforge3 image from [condaforge/miniforge3](https://hub.docker.com/r/condaforge/miniforge3)
- no references of Mambaforge in our docs...
- though, the `mambaforge` container needs be changed from Readthedocs' build configuration - problem is, RTD don't support Miniforge3 https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python - will see what I can do - for now I opened an issue at RTD https://github.com/readthedocs/readthedocs.org/issues/11690

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
