### PR TITLE
use `miniforge3` for our docker builds instead of `mambaforge`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # To build this container, go to ESMValCore root folder and execute:
 # docker build -t esmvalcore:latest . -f docker/Dockerfile
-FROM condaforge/mambaforge
+FROM condaforge/miniforge3
 
 WORKDIR /src/ESMValCore
 COPY environment.yml .

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,7 +1,7 @@
 # To build this container, go to ESMValCore root folder and execute:
 # This container is used to run the tests on CircleCI.
 # docker build -t esmvalcore:development . -f docker/Dockerfile.dev
-FROM condaforge/mambaforge
+FROM condaforge/miniforge3
 
 WORKDIR /src/ESMValCore
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y curl git ssh && apt clean


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html


-->

   Missed this in #2556 - this is the last but on Mambaforge apart from the RTD wait

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)


## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
