### PR TITLE
Use our own unit conversion function in our fixes

### DIFF
--- a/esmvalcore/cmor/_fixes/fix.py
+++ b/esmvalcore/cmor/_fixes/fix.py
@@ -28,6 +28,7 @@ from esmvalcore.cmor._utils import (
 from esmvalcore.cmor.fixes import get_time_bounds
 from esmvalcore.cmor.table import get_var_info
 from esmvalcore.iris_helpers import has_unstructured_grid
+from esmvalcore.preprocessor._units import safe_convert_units
 
 if TYPE_CHECKING:
     from esmvalcore.cmor.table import CoordinateInfo, VariableInfo
@@ -455,7 +456,7 @@ class GenericFix(Fix):
             if str(cube.units) != units:
                 old_units = cube.units
                 try:
-                    cube.convert_units(units)
+                    safe_convert_units(cube, units)
                 except (ValueError, UnitConversionError):
                     self._warning_msg(
                         cube,

--- a/esmvalcore/cmor/_fixes/fix.py
+++ b/esmvalcore/cmor/_fixes/fix.py
@@ -27,8 +27,7 @@ from esmvalcore.cmor._utils import (
 )
 from esmvalcore.cmor.fixes import get_time_bounds
 from esmvalcore.cmor.table import get_var_info
-from esmvalcore.iris_helpers import has_unstructured_grid
-from esmvalcore.preprocessor._units import safe_convert_units
+from esmvalcore.iris_helpers import has_unstructured_grid, safe_convert_units
 
 if TYPE_CHECKING:
     from esmvalcore.cmor.table import CoordinateInfo, VariableInfo

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -7,6 +7,7 @@ import iris
 import numpy as np
 
 from esmvalcore.iris_helpers import date2num
+from esmvalcore.preprocessor._units import safe_convert_units
 
 from ...table import CMOR_TABLES
 from ..fix import Fix
@@ -414,10 +415,6 @@ class AllVars(Fix):
             coord.points = 0.5 * (start + end)
             coord.bounds = np.column_stack([start, end])
 
-    def _fix_units(self, cube):
-        """Fix units."""
-        cube.convert_units(self.vardef.units)
-
     def fix_metadata(self, cubes):
         """Fix metadata."""
         fixed_cubes = iris.cube.CubeList()
@@ -428,7 +425,7 @@ class AllVars(Fix):
             cube.long_name = self.vardef.long_name
 
             cube = self._fix_coordinates(cube)
-            self._fix_units(cube)
+            cube = safe_convert_units(cube, self.vardef.units)
 
             cube.data = cube.core_data().astype("float32")
             year = datetime.datetime.now().year

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -6,8 +6,7 @@ import logging
 import iris
 import numpy as np
 
-from esmvalcore.iris_helpers import date2num
-from esmvalcore.preprocessor._units import safe_convert_units
+from esmvalcore.iris_helpers import date2num, safe_convert_units
 
 from ...table import CMOR_TABLES
 from ..fix import Fix

--- a/esmvalcore/cmor/_fixes/native_datasets.py
+++ b/esmvalcore/cmor/_fixes/native_datasets.py
@@ -5,6 +5,8 @@ from typing import Dict
 
 from iris import NameConstraint
 
+from esmvalcore.preprocessor._units import safe_convert_units
+
 from ..fix import Fix
 from .shared import (
     add_scalar_height_coord,
@@ -77,7 +79,7 @@ class NativeDatasetFix(Fix):
                     f"Failed to fix invalid units '{invalid_units}' for "
                     f"variable '{self.vardef.short_name}'"
                 ) from exc
-        cube.convert_units(self.vardef.units)
+        safe_convert_units(cube, self.vardef.units)
 
         # Fix attributes
         if self.vardef.positive != "":

--- a/esmvalcore/cmor/_fixes/native_datasets.py
+++ b/esmvalcore/cmor/_fixes/native_datasets.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from iris import NameConstraint
 
-from esmvalcore.preprocessor._units import safe_convert_units
+from esmvalcore.iris_helpers import safe_convert_units
 
 from ..fix import Fix
 from .shared import (

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -361,7 +361,7 @@ def has_unstructured_grid(cube: Cube) -> bool:
     return True
 
 
-# List containing special cases for convert_units. Each list item is another
+# List containing special cases for unit conversion. Each list item is another
 # list. Each of these sublists defines one special conversion. Each element in
 # the sublists is a tuple (standard_name, units). Note: All units for a single
 # special case need to be "physically identical", e.g., 1 kg m-2 s-1 "equals" 1

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -9,6 +9,7 @@ import iris
 import iris.cube
 import iris.util
 import numpy as np
+from cf_units import Unit
 from iris.coords import Coord
 from iris.cube import Cube
 from iris.exceptions import CoordinateMultiDimError, CoordinateNotFoundError
@@ -358,3 +359,121 @@ def has_unstructured_grid(cube: Cube) -> bool:
     if cube.coord_dims(lat) != cube.coord_dims(lon):
         return False
     return True
+
+
+# List containing special cases for convert_units. Each list item is another
+# list. Each of these sublists defines one special conversion. Each element in
+# the sublists is a tuple (standard_name, units). Note: All units for a single
+# special case need to be "physically identical", e.g., 1 kg m-2 s-1 "equals" 1
+# mm s-1 for precipitation
+_SPECIAL_UNIT_CONVERSIONS = [
+    [
+        ("precipitation_flux", "kg m-2 s-1"),
+        ("lwe_precipitation_rate", "mm s-1"),
+    ],
+    [
+        ("equivalent_thickness_at_stp_of_atmosphere_ozone_content", "m"),
+        ("equivalent_thickness_at_stp_of_atmosphere_ozone_content", "1e5 DU"),
+    ],
+]
+
+
+def _try_special_unit_conversions(cube: Cube, units: str | Unit) -> bool:
+    """Try special unit conversion (in-place).
+
+    Parameters
+    ----------
+    cube:
+        Input cube (modified in place).
+    units:
+        New units
+
+    Returns
+    -------
+    bool
+        ``True`` if special unit conversion was successful, ``False`` if not.
+
+    """
+    for special_case in _SPECIAL_UNIT_CONVERSIONS:
+        for std_name, special_units in special_case:
+            # Special unit conversion only works if all of the following
+            # criteria are met:
+            # - the cube's standard_name is one of the supported
+            #   standard_names
+            # - the cube's units are convertible to the ones defined for
+            #   that given standard_name
+            # - the desired target units are convertible to the units of
+            #   one of the other standard_names in that special case
+
+            # Step 1: find suitable source name and units
+            if cube.standard_name == std_name and cube.units.is_convertible(
+                special_units
+            ):
+                for target_std_name, target_units in special_case:
+                    if target_units == special_units:
+                        continue
+
+                    # Step 2: find suitable target name and units
+                    if Unit(units).is_convertible(target_units):
+                        cube.standard_name = target_std_name
+
+                        # In order to avoid two calls to cube.convert_units,
+                        # determine the conversion factor between the cube's
+                        # units and the source units first and simply add this
+                        # factor to the target units (remember that the source
+                        # units and the target units should be "physically
+                        # identical").
+                        factor = cube.units.convert(1.0, special_units)
+                        cube.units = f"{factor} {target_units}"
+                        cube.convert_units(units)
+                        return True
+
+    # If no special case has been detected, return False
+    return False
+
+
+def safe_convert_units(cube: Cube, units: str | Unit) -> Cube:
+    """Safe unit conversion (change of `standard_name` not allowed; in-place).
+
+    This is a safe version of :func:`esmvalcore.preprocessor.convert_units`
+    that will raise an error if the input cube's
+    :attr:`~iris.cube.Cube.standard_name` has been changed.
+
+    Arguments
+    ---------
+    cube:
+        Input cube (modified in place).
+    units:
+        New units.
+
+    Returns
+    -------
+    iris.cube.Cube
+        Converted cube. Just returned for convenience; input cube is modified
+        in place.
+
+    Raises
+    ------
+    iris.exceptions.UnitConversionError
+        Old units are unknown.
+    ValueError
+        Old units are not convertible to new units or unit conversion required
+        change of `standard_name`.
+
+    """
+    old_units = cube.units
+    old_standard_name = cube.standard_name
+
+    try:
+        cube.convert_units(units)
+    except ValueError:
+        if not _try_special_unit_conversions(cube, units):
+            raise
+
+    if cube.standard_name != old_standard_name:
+        raise ValueError(
+            f"Cannot safely convert units from '{old_units}' to '{units}'; "
+            f"standard_name changed from '{old_standard_name}' to "
+            f"'{cube.standard_name}'"
+        )
+    return cube

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -93,8 +93,8 @@ def date2num(date, unit, dtype=np.float64):
     This is a custom version of :meth:`cf_units.Unit.date2num` that
     guarantees the correct dtype for the return value.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     date : :class:`datetime.datetime` or :class:`cftime.datetime`
     unit : :class:`cf_units.Unit`
     dtype : a numpy dtype
@@ -439,8 +439,8 @@ def safe_convert_units(cube: Cube, units: str | Unit) -> Cube:
     that will raise an error if the input cube's
     :attr:`~iris.cube.Cube.standard_name` has been changed.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     cube:
         Input cube (modified in place).
     units:

--- a/esmvalcore/preprocessor/_units.py
+++ b/esmvalcore/preprocessor/_units.py
@@ -49,8 +49,8 @@ def convert_units(cube: Cube, units: str | Unit) -> Cube:
     Note that for precipitation variables, a water density of ``1000 kg m-3``
     is assumed.
 
-    Argumentss
-    ---------
+    Parameters
+    ----------
     cube:
         Input cube (modified in place).
     units:

--- a/tests/unit/preprocessor/_units/test_convert_units.py
+++ b/tests/unit/preprocessor/_units/test_convert_units.py
@@ -1,15 +1,14 @@
 """Unit test for the :func:`esmvalcore.preprocessor._units` function."""
 
+import unittest
+
 import cf_units
 import iris
 import iris.fileformats
 import numpy as np
 
 import tests
-from esmvalcore.preprocessor._units import (
-    accumulate_coordinate,
-    convert_units,
-)
+from esmvalcore.preprocessor._units import accumulate_coordinate, convert_units
 
 
 class TestConvertUnits(tests.Test):
@@ -256,3 +255,7 @@ class TestFluxToTotal(tests.Test):
         expected_units = cf_units.Unit("kg")
         self.assertEqual(result.units, expected_units)
         self.assert_array_equal(result.data, expected_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/preprocessor/_units/test_convert_units.py
+++ b/tests/unit/preprocessor/_units/test_convert_units.py
@@ -1,20 +1,14 @@
 """Unit test for the :func:`esmvalcore.preprocessor._units` function."""
 
-import unittest
-
 import cf_units
 import iris
 import iris.fileformats
 import numpy as np
-import pytest
-from iris.cube import Cube
-from iris.exceptions import UnitConversionError
 
 import tests
 from esmvalcore.preprocessor._units import (
     accumulate_coordinate,
     convert_units,
-    safe_convert_units,
 )
 
 
@@ -262,63 +256,3 @@ class TestFluxToTotal(tests.Test):
         expected_units = cf_units.Unit("kg")
         self.assertEqual(result.units, expected_units)
         self.assert_array_equal(result.data, expected_data)
-
-
-@pytest.mark.parametrize(
-    "old_units,new_units,old_standard_name,new_standard_name,err_msg",
-    [
-        ("m", "km", "altitude", "altitude", None),
-        ("Pa", "hPa", "air_pressure", "air_pressure", None),
-        (
-            "m",
-            "DU",
-            "equivalent_thickness_at_stp_of_atmosphere_ozone_content",
-            "equivalent_thickness_at_stp_of_atmosphere_ozone_content",
-            None,
-        ),
-        (
-            "m",
-            "s",
-            "altitude",
-            ValueError,
-            r"Unable to convert from 'Unit\('m'\)' to 'Unit\('s'\)'",
-        ),
-        (
-            "unknown",
-            "s",
-            "air_temperature",
-            UnitConversionError,
-            r"Cannot convert from unknown units",
-        ),
-        (
-            "kg m-2 s-1",
-            "mm day-1",
-            "precipitation_flux",
-            ValueError,
-            r"Cannot safely convert units from 'kg m-2 s-1' to 'mm day-1'; "
-            r"standard_name changed from 'precipitation_flux' to "
-            r"'lwe_precipitation_rate'",
-        ),
-    ],
-)
-def test_safe_convert_units(
-    old_units, new_units, old_standard_name, new_standard_name, err_msg
-):
-    """Test ``esmvalcore.preprocessor._units.safe_convert_units``."""
-    cube = Cube(0, standard_name=old_standard_name, units=old_units)
-
-    # Exceptions
-    if isinstance(new_standard_name, type):
-        with pytest.raises(new_standard_name, match=err_msg):
-            safe_convert_units(cube, new_units)
-        return
-
-    # Regular test cases
-    new_cube = safe_convert_units(cube, new_units)
-    assert new_cube is cube
-    assert new_cube.standard_name == new_standard_name
-    assert new_cube.units == new_units
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

While performing tests for https://github.com/ESMValGroup/ESMValTool/pull/3784, I noticed that our fixes do not use our [own unit conversion function](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.convert_units), which allows special unit conversions like m -> DU.

This PR adds this, but uses a "safe" version of the unit conversion which will not allow a change of the cube's `standard_name` (this would lead to errors in the subsequent CMOR checks).

*Note*: I had to restructure the functions a little bit to avoid circular imports.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Related to
- https://github.com/ESMValGroup/ESMValTool/pull/3784
- https://github.com/ESMValGroup/ESMValCore/pull/2509

Link to documentation:
- https://esmvaltool--2560.org.readthedocs.build/projects/ESMValCore/en/2560/api/esmvalcore.iris_helpers.html#esmvalcore.iris_helpers.safe_convert_units
- https://esmvaltool--2560.org.readthedocs.build/projects/ESMValCore/en/2560/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.convert_units

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
