### PR TITLE
Do not use `Path` objects as configuration dictionary keys to avoid errors in `dask.config.merge`

### DIFF
--- a/esmvalcore/config/_config_validators.py
+++ b/esmvalcore/config/_config_validators.py
@@ -228,7 +228,7 @@ def validate_rootpath(value):
         else:
             validate_dict(paths)
 
-            # dask.config.merge cannot handle Paths as dict keys -> we convert
+            # dask.config.merge cannot handle pathlib.Path objects as dict keys -> we convert
             # the validated Path back to a string and handle this downstream in
             # local.py (see
             # https://github.com/ESMValGroup/ESMValCore/issues/2577)

--- a/esmvalcore/config/_config_validators.py
+++ b/esmvalcore/config/_config_validators.py
@@ -230,7 +230,8 @@ def validate_rootpath(value):
 
             # dask.config.merge cannot handle Paths as dict keys -> we convert
             # the validated Path back to a string and handle this downstream in
-            # local.py
+            # local.py (see
+            # https://github.com/ESMValGroup/ESMValCore/issues/2577)
             new_mapping[key] = {
                 str(validate_path(path)): validate_string(drs)
                 for path, drs in paths.items()

--- a/esmvalcore/config/_config_validators.py
+++ b/esmvalcore/config/_config_validators.py
@@ -228,9 +228,9 @@ def validate_rootpath(value):
         else:
             validate_dict(paths)
 
-            # dask.config.merge cannot handle pathlib.Path objects as dict keys -> we convert
-            # the validated Path back to a string and handle this downstream in
-            # local.py (see
+            # dask.config.merge cannot handle pathlib.Path objects as dict keys
+            # -> we convert the validated Path back to a string and handle this
+            # downstream in local.py (see also
             # https://github.com/ESMValGroup/ESMValCore/issues/2577)
             new_mapping[key] = {
                 str(validate_path(path)): validate_string(drs)

--- a/esmvalcore/config/_config_validators.py
+++ b/esmvalcore/config/_config_validators.py
@@ -227,8 +227,12 @@ def validate_rootpath(value):
             new_mapping[key] = validate_pathlist(paths)
         else:
             validate_dict(paths)
+
+            # dask.config.merge cannot handle Paths as dict keys -> we convert
+            # the validated Path back to a string and handle this downstream in
+            # local.py
             new_mapping[key] = {
-                validate_path(path): validate_string(drs)
+                str(validate_path(path)): validate_string(drs)
                 for path, drs in paths.items()
             }
 

--- a/esmvalcore/local.py
+++ b/esmvalcore/local.py
@@ -479,6 +479,7 @@ def _get_data_sources(project: str) -> list[DataSource]:
                 paths = {p: structure for p in paths}
             sources: list[DataSource] = []
             for path, structure in paths.items():
+                path = Path(path)
                 dir_templates = _select_drs("input_dir", project, structure)
                 file_templates = _select_drs("input_file", project, structure)
                 sources.extend(

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -176,8 +176,8 @@ def generate_validator_testcases(valid):
                     },
                     {
                         "CMIP6": {
-                            Path("/a"): "DKRZ",
-                            Path("/b"): "ESGF",
+                            "/a": "DKRZ",
+                            "/b": "ESGF",
                         },
                     },
                 ),


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Closes https://github.com/ESMValGroup/ESMValCore/issues/2577

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
