### PR TITLE
Update `CFG` with configuration options given via command line

### DIFF
--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -440,7 +440,6 @@ class ESMValTool:
         recipe = self._get_recipe(recipe)
 
         CFG.update(kwargs)
-        print(CFG["resume_from"])
         CFG["resume_from"] = parse_resume(CFG["resume_from"], recipe)
         session = CFG.start_session(recipe.stem)
 

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -439,9 +439,10 @@ class ESMValTool:
 
         recipe = self._get_recipe(recipe)
 
+        CFG.update(kwargs)
+        print(CFG["resume_from"])
+        CFG["resume_from"] = parse_resume(CFG["resume_from"], recipe)
         session = CFG.start_session(recipe.stem)
-        session.update(kwargs)
-        session["resume_from"] = parse_resume(session["resume_from"], recipe)
 
         self._run(recipe, session, cli_config_dir)
 

--- a/tests/unit/main/test_esmvaltool.py
+++ b/tests/unit/main/test_esmvaltool.py
@@ -21,12 +21,17 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture
 def cfg(mocker, tmp_path):
     """Mock `esmvalcore.config.CFG`."""
-    session = mocker.MagicMock()
-
     cfg_dict = {"resume_from": []}
-    session.__getitem__.side_effect = cfg_dict.__getitem__
-    session.__setitem__.side_effect = cfg_dict.__setitem__
-    session.update.side_effect = cfg_dict.update
+
+    cfg = mocker.MagicMock()
+    cfg.__getitem__.side_effect = cfg_dict.__getitem__
+    cfg.__setitem__.side_effect = cfg_dict.__setitem__
+    cfg.update.side_effect = cfg_dict.update
+
+    session = mocker.MagicMock()
+    session.__getitem__.side_effect = cfg.__getitem__
+    session.__setitem__.side_effect = cfg.__setitem__
+    session.update.side_effect = cfg.update
 
     output_dir = tmp_path / "esmvaltool_output"
     session.session_dir = output_dir / "recipe_test"
@@ -34,7 +39,6 @@ def cfg(mocker, tmp_path):
     session.preproc_dir = session.session_dir / "preproc_dir"
     session._fixed_file_dir = session.preproc_dir / "fixed_files"
 
-    cfg = mocker.Mock()
     cfg.start_session.return_value = session
 
     return cfg


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

While testing https://github.com/ESMValGroup/ESMValCore/pull/2522, I noticed that `CFG` is not updated with config options given via command line. This PR fixes that.

It would probably be good to unify our usage of `Session` and `CFG` in the code base, but that's something for another PR.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/2594

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
