### PR TITLE
Draft: Modify `extract_season` to return only "full" seasons upon request

### DIFF
--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -355,11 +355,11 @@ def extract_season(cube: Cube, season: str, full: False) -> Cube:
     season = season.upper()
 
     allmonths = "JFMAMJJASOND" * 2
-    # if season not in allmonths:
-    #     raise ValueError(
-    #         f"Unable to extract Season {season} "
-    #         f"combination of months not possible."
-    #     )
+    if season not in allmonths:
+        raise ValueError(
+            f"Unable to extract Season {season} "
+            f"combination of months not possible."
+        )
     sstart = allmonths.index(season)
     res_season = allmonths[sstart + len(season) : sstart + 12]
     seasons = [season, res_season]

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -331,7 +331,7 @@ def clip_timerange(cube: Cube, timerange: str) -> Cube:
     return _extract_datetime(cube, t_1, t_2)
 
 
-def extract_season(cube: Cube, season: str, full: False) -> Cube:
+def extract_season(cube: Cube, season: str, full: bool = False) -> Cube:
     """Slice cube to get only the data belonging to a specific season.
 
     Parameters
@@ -341,6 +341,9 @@ def extract_season(cube: Cube, season: str, full: False) -> Cube:
     season:
         Season to extract. Available: DJF, MAM, JJA, SON
         and all sequentially correct combinations: e.g. JJAS
+    full:
+        Only return full seasons e.g. DJF and never JF
+        default: False
 
     Returns
     -------
@@ -365,16 +368,16 @@ def extract_season(cube: Cube, season: str, full: False) -> Cube:
     seasons = [season, res_season]
     coords_to_remove = []
 
-    send = sstart + len(season) # end of season
-    if (send>12) and full: # need to first extract time to trim incomplete seasons
+    if full: # need to first extract time to trim incomplete seasons
         time_coord = cube.coord('time')
         
-        time0 = time_coord.units.num2date( time_coord.points[0] )
-        start_time = dict( start_year=time0.year, start_month=sstart+1, start_day=1 )
+        start_year = time_coord.units.num2date( time_coord.points[0] ).year
+        start_time = dict( start_year=start_year, start_month=sstart+1, start_day=1 )
 
-        timeF = time_coord.units.num2date( time_coord.points[-1] )
-        end_month_plus_one = (send-12+1) +1
-        end_time_plus_one_day = dict( start_year=timeF.year, start_month=end_month_plus_one, start_day=1 )
+        end_year = time_coord.units.num2date( time_coord.points[-1] ).year
+        end_month = sstart + len(season) + 1 # end of season
+        if end_month>12: end_month -= 12
+        end_time_plus_one_day = dict( end_year=end_year, end_month=end_month +1, end_day=1 )
 
         cube = extract_time( cube, **start_time, **end_time_plus_one_day )
 

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -60,48 +60,6 @@ for _coord in (
     )
 
 
-##########################################################################
-# start of custom code ###################################################
-
-def get_date_from_time( time_coord, default=None, year=None, month=None, day=None ):
-    time_coord = cube.coord('time')
-    if not default: default = time_coord.points[0] # first point
-    default_time = time_coord.units.num2date( default )
-
-    if year is None:  year = default_time.year
-    if month is None: month = default_time.month
-    if day is None: day = default_time.day
-
-    return dict( start_year=year, start_month=month, start_day=day )
-
-def extract_fullseason(cube: Cube, season: str) -> Cube:
-    """
-    extract full seasons (DJF, never D,JF)
-    Useful mainly for seasons spanning multiple years
-    Calls extract_time to trim incomplete seasons, then extract_season
-    """
-    season = season.upper()
-
-    allmonths = 'JFMAMJJASOND' * 2
-    if season not in allmonths:
-        raise ValueError(f"Unable to extract Season {season} "
-                         f"combination of months not possible.")
-    sstart = allmonths.index(season)
-    send = sstart + len(season)
-
-    if send>12: # need to first extract time
-        time_coord = cube.coord('time')
-        start_month = sstart+1
-        start_time = get_date_from_time( time_coord, default=time_coord.points[0], month=start_month )
-        end_month = send-12+1
-        end_time = get_date_from_time( time_coord, default=time_coord.points[-1], month=end_month )
-        cube = extract_time( cube, **start_time, **end_time )
-
-    return extract_season( cube, season=season )
-
-# end of custom code ###################################################
-##########################################################################
-
 def extract_time(
     cube: Cube,
     start_year: int | None,
@@ -373,7 +331,7 @@ def clip_timerange(cube: Cube, timerange: str) -> Cube:
     return _extract_datetime(cube, t_1, t_2)
 
 
-def extract_season(cube: Cube, season: str) -> Cube:
+def extract_season(cube: Cube, season: str, full: False) -> Cube:
     """Slice cube to get only the data belonging to a specific season.
 
     Parameters
@@ -406,6 +364,19 @@ def extract_season(cube: Cube, season: str) -> Cube:
     res_season = allmonths[sstart + len(season) : sstart + 12]
     seasons = [season, res_season]
     coords_to_remove = []
+
+    send = sstart + len(season) # end of season
+    if (send>12) and full: # need to first extract time to trim incomplete seasons
+        time_coord = cube.coord('time')
+        
+        time0 = time_coord.units.num2date( time_coord.points[0] )
+        start_time = dict( start_year=time0.year, start_month=sstart+1, start_day=1 )
+
+        timeF = time_coord.units.num2date( time_coord.points[-1] )
+        end_month_plus_one = (send-12+1) +1
+        end_time_plus_one_day = dict( start_year=timeF.year, start_month=end_month_plus_one, start_day=1 )
+
+        cube = extract_time( cube, **start_time, **end_time_plus_one_day )
 
     if not cube.coords("clim_season"):
         iris.coord_categorisation.add_season(


### PR DESCRIPTION
## Description

Related issue: https://github.com/ESMValGroup/ESMValCore/issues/2591

Include a parameter `full` (I'm open to this being a different word) which triggers `extract_season` to only return "complete" seasons. For example, "DJF" and never just "JF". Invokes `extract_time` to clip the time vector prior to season extraction

Closes [#issue_number](https://github.com/ESMValGroup/ESMValCore/issues/2591)

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
