### PR TITLE
Monotonicity fixes for Fgoals

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/fgoals_g3.py
+++ b/esmvalcore/cmor/_fixes/cmip6/fgoals_g3.py
@@ -85,7 +85,7 @@ class Mrsos(Fix):
             iris.util.promote_aux_coord_to_dim_coord(cube, "longitude")
 
         return super().fix_metadata(cubes)
-    
+
 
 class Tas(Fix):
     """Fixes for tas."""

--- a/esmvalcore/cmor/_fixes/cmip6/fgoals_g3.py
+++ b/esmvalcore/cmor/_fixes/cmip6/fgoals_g3.py
@@ -2,6 +2,7 @@
 
 import dask.array as da
 import iris
+import numpy as np
 
 from ..common import OceanFixGrid
 from ..fix import Fix
@@ -84,3 +85,78 @@ class Mrsos(Fix):
             iris.util.promote_aux_coord_to_dim_coord(cube, "longitude")
 
         return super().fix_metadata(cubes)
+    
+
+class Tas(Fix):
+    """Fixes for tas."""
+
+    def fix_metadata(self, cubes):
+        """Fix time coordinates.
+
+        Parameters
+        ----------
+        cubes : iris.cube.CubeList
+                Cubes to fix
+
+        Returns
+        -------
+        iris.cube.CubeList
+        """
+        new_list = iris.cube.CubeList()
+        for cube in cubes:
+            try:
+                old_time = cube.coord("time")
+            except iris.exceptions.CoordinateNotFoundError:
+                new_list.append(cube)
+            else:
+                if old_time.is_monotonic():
+                    new_list.append(cube)
+                else:
+                    time_units = old_time.units
+                    time_data = old_time.points
+
+                    # erase erroneously copy-pasted points
+                    time_diff = np.diff(time_data)
+                    idx_neg = np.where(time_diff <= 0.0)[0]
+                    while len(idx_neg) > 0:
+                        time_data = np.delete(time_data, idx_neg[0] + 1)
+                        time_diff = np.diff(time_data)
+                        idx_neg = np.where(time_diff <= 0.0)[0]
+
+                    # create the new time coord
+                    new_time = iris.coords.DimCoord(
+                        time_data,
+                        standard_name="time",
+                        var_name="time",
+                        units=time_units,
+                    )
+
+                    # create a new cube with the right shape
+                    dims = (
+                        time_data.shape[0],
+                        cube.coord("latitude").shape[0],
+                        cube.coord("longitude").shape[0],
+                    )
+                    data = cube.data
+                    new_data = np.ma.append(
+                        data[: dims[0] - 1, :, :], data[-1, :, :]
+                    )
+                    new_data = new_data.reshape(dims)
+
+                    tmp_cube = iris.cube.Cube(
+                        new_data,
+                        standard_name=cube.standard_name,
+                        long_name=cube.long_name,
+                        var_name=cube.var_name,
+                        units=cube.units,
+                        attributes=cube.attributes,
+                        cell_methods=cube.cell_methods,
+                        dim_coords_and_dims=[
+                            (new_time, 0),
+                            (cube.coord("latitude"), 1),
+                            (cube.coord("longitude"), 2),
+                        ],
+                    )
+
+                    new_list.append(tmp_cube)
+        return new_list

--- a/tests/integration/cmor/_fixes/cmip6/test_cesm2.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cesm2.py
@@ -507,7 +507,7 @@ def test_pr_fix_metadata(pr_cubes):
 
     out_cubes = fix.fix_metadata(pr_cubes)
     for cube in out_cubes:
-        if cube.var_name == "tas":
+        if cube.var_name == "pr":
             assert cube.coord("time").is_monotonic()
 
 

--- a/tests/integration/cmor/_fixes/cmip6/test_fgoals_g3.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fgoals_g3.py
@@ -4,10 +4,10 @@ from unittest import mock
 
 import iris
 import numpy as np
-import pytest
 import pandas as pd
+import pytest
 
-from esmvalcore.cmor._fixes.cmip6.fgoals_g3 import Mrsos, Siconc, Tos, Tas
+from esmvalcore.cmor._fixes.cmip6.fgoals_g3 import Mrsos, Siconc, Tas, Tos
 from esmvalcore.cmor._fixes.common import OceanFixGrid
 from esmvalcore.cmor._fixes.fix import GenericFix
 from esmvalcore.cmor.fix import Fix

--- a/tests/integration/cmor/_fixes/cmip6/test_fgoals_g3.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_fgoals_g3.py
@@ -4,8 +4,10 @@ from unittest import mock
 
 import iris
 import numpy as np
+import pytest
+import pandas as pd
 
-from esmvalcore.cmor._fixes.cmip6.fgoals_g3 import Mrsos, Siconc, Tos
+from esmvalcore.cmor._fixes.cmip6.fgoals_g3 import Mrsos, Siconc, Tos, Tas
 from esmvalcore.cmor._fixes.common import OceanFixGrid
 from esmvalcore.cmor._fixes.fix import GenericFix
 from esmvalcore.cmor.fix import Fix
@@ -163,3 +165,71 @@ def test_mrsos_fix_metadata_2(mock_base_fix_metadata):
         [[0.5, 1.5], [1.5, 2.5], [2.5, 3.5]],
     )
     mock_base_fix_metadata.assert_called_once_with(fix, cubes)
+
+
+@pytest.fixture
+def tas_cubes():
+    correct_time_coord = iris.coords.DimCoord(
+        points=[1.0, 2.0, 3.0, 4.0, 5.0],
+        var_name="time",
+        standard_name="time",
+        units="days since 1850-01-01",
+    )
+
+    lat_coord = iris.coords.DimCoord(
+        [0.0], var_name="lat", standard_name="latitude"
+    )
+
+    lon_coord = iris.coords.DimCoord(
+        [0.0], var_name="lon", standard_name="longitude"
+    )
+
+    correct_coord_specs = [
+        (correct_time_coord, 0),
+        (lat_coord, 1),
+        (lon_coord, 2),
+    ]
+
+    correct_tas_cube = iris.cube.Cube(
+        np.ones((5, 1, 1)),
+        var_name="tas",
+        units="K",
+        dim_coords_and_dims=correct_coord_specs,
+    )
+
+    scalar_cube = iris.cube.Cube(0.0, var_name="ps")
+
+    return iris.cube.CubeList([correct_tas_cube, scalar_cube])
+
+
+def test_get_tas_fix():
+    """Test tas fix."""
+    fix = Fix.get_fixes("CMIP6", "FGOALS-g3", "day", "tas")
+    assert fix == [Tas(None), GenericFix(None)]
+
+
+def test_tas_fix_metadata(tas_cubes):
+    """Test metadata fix."""
+    vardef = get_var_info("CMIP6", "day", "tas")
+    fix = Tas(vardef)
+
+    out_cubes = fix.fix_metadata(tas_cubes)
+    assert out_cubes[0].var_name == "tas"
+    coord = out_cubes[0].coord("time")
+    assert pd.Series(coord.points).is_monotonic_increasing
+
+    # de-monotonize time points
+    for cube in tas_cubes:
+        if cube.var_name == "tas":
+            time = cube.coord("time")
+            points = np.array(time.points)
+            points[-1] = points[0]
+            dims = cube.coord_dims(time)
+            cube.remove_coord(time)
+            time = iris.coords.AuxCoord.from_coord(time)
+            cube.add_aux_coord(time.copy(points), dims)
+
+    out_cubes = fix.fix_metadata(tas_cubes)
+    for cube in out_cubes:
+        if cube.var_name == "tas":
+            assert cube.coord("time").is_monotonic()


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description
This is a follow up for #2602. This is pretty much the same fix and tests I had created for CESM2 from NCAR in #2574 and also I found a slight typo from my last pull request. This should fix the monotonicity issue but I could not figure out where the frequency issue is coming from. 

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful
***