### PR TITLE
Make Dask configurable in configuration

### DIFF
--- a/esmvalcore/config/_config_validators.py
+++ b/esmvalcore/config/_config_validators.py
@@ -326,6 +326,7 @@ _validators = {
     "check_level": validate_check_level,
     "compress_netcdf": validate_bool,
     "config_developer_file": validate_config_developer,
+    "dask": validate_dict,
     "diagnostics": validate_diagnostics,
     "download_dir": validate_path,
     "drs": validate_drs,

--- a/esmvalcore/config/configurations/defaults/dask.yml
+++ b/esmvalcore/config/configurations/defaults/dask.yml
@@ -1,0 +1,25 @@
+dask:
+  client: {}
+  clusters:
+    default:
+      type: default
+    compute:
+      type: dask_jobqueue.SLURMCluster
+      queue: compute
+      account: bk1088
+      cores: 64
+      memory: 4GiB
+      processes: 32
+      interface: ib0
+      local_directory: "/scratch/b/b381141/dask-tmp"
+      n_workers: 32
+    debug:
+      type: default
+      scheduler: synchronous
+    local:
+      type: distributed.LocalCluster
+      n_workers: 2
+      threads_per_worker: 2
+      memory_limit: 4GiB
+  config: {}
+  run: default  # Start the `default` cluster defined above

--- a/esmvalcore/config/configurations/defaults/more_top_level_options.yml
+++ b/esmvalcore/config/configurations/defaults/more_top_level_options.yml
@@ -1,4 +1,3 @@
-# Other options not included in config-user.yml
 check_level: default
 diagnostics: null
 extra_facets_dir: []

--- a/esmvalcore/experimental/recipe.py
+++ b/esmvalcore/experimental/recipe.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional
 import yaml
 
 from esmvalcore._recipe.recipe import Recipe as RecipeEngine
-from esmvalcore.config import CFG, Session, _dask
+from esmvalcore.config import CFG, Session
 
 from ._logging import log_to_dir
 from .recipe_info import RecipeInfo
@@ -133,7 +133,6 @@ class Recipe:
             session["diagnostics"] = task
 
         with log_to_dir(session.run_dir):
-            _dask.check_distributed_config()
             self._engine = self._load(session=session)
             self._engine.run()
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR makes Dask configurable in our configuration, e.g.,

```yml
dask:
  client: {}
  clusters:
    default:
      type: default
    local:
      type: distributed.LocalCluster
      n_workers: 2
      threads_per_worker: 2
      memory_limit: 4GiB
  config: {}
  run: default  # Start the `default` cluster defined above
```

This also deprecates the usage of the file `~/.esmvaltool/dask.yml`.


<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/2040
Closes https://github.com/ESMValGroup/ESMValCore/issues/2369

Link to documentation: TBA

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
