### PR TITLE
Expand Amon fix of FIO-ESM-2-0 (CMIP6)

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/fio_esm_2_0.py
+++ b/esmvalcore/cmor/_fixes/cmip6/fio_esm_2_0.py
@@ -3,6 +3,7 @@
 import logging
 
 import numpy as np
+from iris.util import promote_aux_coord_to_dim_coord
 
 from ..common import OceanFixGrid
 from ..fix import Fix
@@ -64,12 +65,24 @@ class Amon(Fix):
                 if np.any(latitude.bounds[1:, 0] != latitude.bounds[:-1, 1]):
                     latitude.bounds = None
                     latitude.guess_bounds()
+                if np.any(latitude.bounds[:, 0] == latitude.bounds[:, 1]):
+                    latitude.bounds = None
+                    latitude.guess_bounds()
 
             longitude = cube.coord("longitude")
             if longitude.has_bounds():
                 if np.any(longitude.bounds[1:, 0] != longitude.bounds[:-1, 1]):
                     longitude.bounds = None
                     longitude.guess_bounds()
+                if np.any(longitude.bounds[:, 0] == longitude.bounds[:, 1]):
+                    longitude.bounds = None
+                    longitude.guess_bounds()
+
+            if not cube.coords("latitude", dim_coords=True):
+                promote_aux_coord_to_dim_coord(cube, latitude)
+            if not cube.coords("longitude", dim_coords=True):
+                promote_aux_coord_to_dim_coord(cube, longitude)
+
         return cubes
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

FIO-ESM-2-0 (CMIP6) Amon data can have invalid latitude and/or longitude bounds. The existing fix does not consider all problematic cases (e.g., when the invalid latitude point is at 90° with bounds 90° and 90°). This PR expands this fix for this corner case.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
