### PR TITLE
Added fixes for some 3D atmospheric variables of E3SM-1-1 (CMIP6)

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/e3sm_1_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/e3sm_1_1.py
@@ -1,0 +1,43 @@
+"""Fixes for E3SM-1-1 model."""
+
+from iris.cube import Cube
+
+from esmvalcore.cmor.fix import Fix
+from esmvalcore.preprocessor._shared import get_array_module
+
+
+def _mask_greater(cube: Cube, value: float) -> Cube:
+    """Mask all data of cube which is greater than ``value``."""
+    npx = get_array_module(cube.core_data())
+    cube.data = npx.ma.masked_greater(cube.core_data(), value)
+    return cube
+
+
+class Hus(Fix):
+    """Fixes for ``hus``."""
+
+    def fix_data(self, cube: Cube) -> Cube:
+        """Fix data.
+
+        Fix values that are not properly masked.
+
+        Parameters
+        ----------
+        cube: iris.cube.Cube
+            Input cube.
+
+        Returns
+        -------
+        iris.cube.Cube
+
+        """
+        return _mask_greater(cube, 1000.0)
+
+
+Ta = Hus
+
+
+Ua = Hus
+
+
+Va = Hus

--- a/tests/integration/cmor/_fixes/cmip6/test_e3sm_1_1.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_e3sm_1_1.py
@@ -1,0 +1,65 @@
+"""Tests for the fixes of E3SM-1-1."""
+
+import numpy as np
+import pytest
+from iris.cube import Cube
+
+from esmvalcore.cmor._fixes.cmip6.e3sm_1_1 import Hus, Ta, Ua, Va
+from esmvalcore.cmor._fixes.fix import GenericFix
+from esmvalcore.cmor.fix import Fix
+from tests import assert_array_equal
+
+
+def test_get_hus_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes("CMIP6", "E3SM-1-1", "Amon", "hus")
+    assert fix == [Hus(None), GenericFix(None)]
+
+
+def test_get_ta_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes("CMIP6", "E3SM-1-1", "Amon", "ta")
+    assert fix == [Ta(None), GenericFix(None)]
+
+
+def test_get_ua_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes("CMIP6", "E3SM-1-1", "Amon", "ua")
+    assert fix == [Ua(None), GenericFix(None)]
+
+
+def test_get_va_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes("CMIP6", "E3SM-1-1", "Amon", "va")
+    assert fix == [Va(None), GenericFix(None)]
+
+
+@pytest.mark.parametrize("lazy", [True, False])
+def test_hus_fix(lazy):
+    """Test fix for ``hus``."""
+    cube = Cube([1.0, 1e35])
+    if lazy:
+        cube.data = cube.lazy_data()
+
+    fix = Hus(None)
+
+    fixed_cube = fix.fix_data(cube)
+
+    assert fixed_cube is cube
+    assert fixed_cube.has_lazy_data() is lazy
+    assert_array_equal(fixed_cube.data, np.ma.masked_invalid([1.0, np.nan]))
+
+
+def test_ta_fix():
+    """Test fix for ``ta``."""
+    assert Ta == Hus
+
+
+def test_ua_fix():
+    """Test fix for ``ua``."""
+    assert Ua == Hus
+
+
+def test_va_fix():
+    """Test fix for ``va``."""
+    assert Va == Hus


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR adds fixes for the variables hus, ta, ua, and va for E3SM-1-1 (CMIP6). These contain values that are not properly masked (e.g., in the order of ~1e36). For these variables, it's safe to mask every value > 1000.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #issue_number

Link to documentation:

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
