### PR TITLE
Always ignore user's configuration when running Dask tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,22 @@ import pytest
 
 import esmvalcore.config._dask
 from esmvalcore.config import CFG, Config
+from esmvalcore.config._config_object import _get_global_config
 
 
 @pytest.fixture
-def cfg_default(mocker):
+def cfg_default():
     """Create a configuration object with default values."""
-    cfg = deepcopy(CFG)
+    cfg = _get_global_config()
     cfg.load_from_dirs([])
     return cfg
+
+
+@pytest.fixture(autouse=True)
+def ignore_existing_user_config(monkeypatch, cfg_default):
+    """Ignore user's configuration when running tests."""
+    for key, value in cfg_default.items():
+        monkeypatch.setitem(CFG, key, deepcopy(value))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def cfg_default():
     return cfg
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def ignore_existing_user_config(monkeypatch, cfg_default):
     """Ignore user's configuration when running tests."""
     for key, value in cfg_default.items():

--- a/tests/unit/config/test_dask.py
+++ b/tests/unit/config/test_dask.py
@@ -18,7 +18,7 @@ def mock_dask_config_set(mocker):
     return mock_dask_set
 
 
-def test_get_no_distributed_client():
+def test_get_no_distributed_client(ignore_existing_user_config):
     with _dask.get_distributed_client() as client:
         assert client is None
 
@@ -40,7 +40,12 @@ def test_get_distributed_client_empty_dask_file(mocker, tmp_path):
 # TODO: Remove in v2.14.0
 @pytest.mark.parametrize("use_new_dask_config", ["", "1"])
 def test_force_new_dask_config(
-    monkeypatch, mocker, tmp_path, mock_dask_config_set, use_new_dask_config
+    monkeypatch,
+    mocker,
+    tmp_path,
+    mock_dask_config_set,
+    ignore_existing_user_config,
+    use_new_dask_config,
 ):
     # Old config -> threaded scheduler
     cfg_file = tmp_path / "dask.yml"
@@ -116,7 +121,7 @@ def test_get_old_dask_config(mocker, tmp_path):
 
 
 def test_get_distributed_client_external(
-    monkeypatch, mocker, mock_dask_config_set
+    monkeypatch, mocker, mock_dask_config_set, ignore_existing_user_config
 ):
     monkeypatch.setitem(
         CFG,
@@ -188,7 +193,11 @@ def test_get_distributed_client_external_old(
 
 @pytest.mark.parametrize("shutdown_timeout", [False, True])
 def test_get_distributed_client_slurm(
-    monkeypatch, mocker, mock_dask_config_set, shutdown_timeout
+    monkeypatch,
+    mocker,
+    mock_dask_config_set,
+    ignore_existing_user_config,
+    shutdown_timeout,
 ):
     slurm_cluster = {
         "type": "dask_jobqueue.SLURMCluster",
@@ -292,7 +301,11 @@ def test_get_distributed_client_slurm_old(
     )
 
 
-def test_custom_default_scheduler(monkeypatch, mock_dask_config_set):
+def test_custom_default_scheduler(
+    monkeypatch,
+    mock_dask_config_set,
+    ignore_existing_user_config,
+):
     default_scheduler = {"num_workers": 42, "scheduler": "processes"}
     monkeypatch.setitem(
         CFG,
@@ -306,7 +319,7 @@ def test_custom_default_scheduler(monkeypatch, mock_dask_config_set):
     with _dask.get_distributed_client() as client:
         assert client is None
 
-    mock_dask_config_set.assert_called_once_with(
+    mock_dask_config_set.assert_called_with(
         {"num_workers": 42, "scheduler": "processes"}
     )
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Add fixture to always ignore user's configuration when running tests.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/2623

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
