### PR TITLE
Raise error if weights are used with unweighted aggregator

### DIFF
--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -352,7 +352,12 @@ def area_statistics(
     # Get aggregator and correct kwargs (incl. weights)
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
     agg_kwargs = update_weights_kwargs(
-        agg, agg_kwargs, "cell_area", cube, try_adding_calculated_cell_area
+        operator,
+        agg,
+        agg_kwargs,
+        "cell_area",
+        cube,
+        try_adding_calculated_cell_area,
     )
 
     with warnings.catch_warnings():

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -160,7 +160,7 @@ def update_weights_kwargs(
     """
     kwargs = dict(kwargs)
     if not aggregator_accept_weights(aggregator) and "weights" in kwargs:
-        raise ValueError(f"Aggregator {operator} does not support weights")
+        raise ValueError(f"Aggregator '{operator}' does not support weights")
     if aggregator_accept_weights(aggregator) and kwargs.get("weights", True):
         kwargs["weights"] = weights
         if cube is not None and callback is not None:

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -88,7 +88,7 @@ def get_iris_aggregator(
     x_coord = DimCoord([1.0], bounds=[0.0, 2.0], var_name="x")
     cube = Cube([0.0], dim_coords_and_dims=[(x_coord, 0)])
     test_kwargs = update_weights_kwargs(
-        aggregator, aggregator_kwargs, np.array([1.0])
+        operator, aggregator, aggregator_kwargs, np.array([1.0])
     )
     try:
         cube.collapsed("x", aggregator, **test_kwargs)
@@ -122,6 +122,7 @@ def aggregator_accept_weights(aggregator: iris.analysis.Aggregator) -> bool:
 
 
 def update_weights_kwargs(
+    operator: str,
     aggregator: iris.analysis.Aggregator,
     kwargs: dict,
     weights: Any,
@@ -133,6 +134,8 @@ def update_weights_kwargs(
 
     Parameters
     ----------
+    operator:
+        Named operator.
     aggregator:
         Iris aggregator.
     kwargs:
@@ -156,6 +159,8 @@ def update_weights_kwargs(
 
     """
     kwargs = dict(kwargs)
+    if not aggregator_accept_weights(aggregator) and "weights" in kwargs:
+        raise ValueError(f"Aggregator {operator} does not support weights")
     if aggregator_accept_weights(aggregator) and kwargs.get("weights", True):
         kwargs["weights"] = weights
         if cube is not None and callback is not None:

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -824,7 +824,12 @@ def climate_statistics(
     if period in ("full",):
         (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
         agg_kwargs = update_weights_kwargs(
-            agg, agg_kwargs, "_time_weights_", cube, _add_time_weights_coord
+            operator,
+            agg,
+            agg_kwargs,
+            "_time_weights_",
+            cube,
+            _add_time_weights_coord,
         )
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -290,6 +290,7 @@ def volume_statistics(
 
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
     agg_kwargs = update_weights_kwargs(
+        operator,
         agg,
         agg_kwargs,
         "ocean_volume",
@@ -373,6 +374,7 @@ def axis_statistics(
     # bounds of the original coordinate (this handles units properly, e.g., for
     # sums)
     agg_kwargs = update_weights_kwargs(
+        operator,
         agg,
         agg_kwargs,
         "_axis_statistics_weights_",

--- a/tests/unit/preprocessor/test_shared.py
+++ b/tests/unit/preprocessor/test_shared.py
@@ -60,13 +60,12 @@ def test_get_iris_aggregator_mean(operator, kwargs):
     assert agg_kwargs == kwargs
 
 
-@pytest.mark.parametrize("kwargs", [{}, {"weights": True}])
 @pytest.mark.parametrize("operator", ["median", "mEdIaN", "MEDIAN"])
-def test_get_iris_aggregator_median(operator, kwargs):
+def test_get_iris_aggregator_median(operator):
     """Test ``get_iris_aggregator``."""
-    (agg, agg_kwargs) = get_iris_aggregator(operator, **kwargs)
+    (agg, agg_kwargs) = get_iris_aggregator(operator)
     assert agg == iris.analysis.MEDIAN
-    assert agg_kwargs == kwargs
+    assert agg_kwargs == {}
 
 
 @pytest.mark.parametrize("operator", ["min", "MiN", "MIN"])
@@ -164,6 +163,14 @@ def test_get_iris_aggregator_missing_kwarg():
     """Test ``get_iris_aggregator``."""
     with pytest.raises(ValueError):
         get_iris_aggregator("percentile")
+
+
+def test_get_iris_aggregator_no_weights_allowed():
+    """Test ``get_iris_aggregator``."""
+    operator = "median"
+    kwargs = {"weights": True}
+    with pytest.raises(ValueError):
+        get_iris_aggregator(operator, **kwargs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Currently, if a `weights` argument is specified for a statistical preprocessor that does not allow weights, this is silently ignored, e.g.

```yaml
area_statistics:
  operator: gmean
  weights: true
```

With this PR, a proper error is raised:

```
ERROR   Invalid options for area_statistics: Aggregator 'gmean' does not support weights
```

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
