### PR TITLE
Add preprocessor to extract surface values from 3D atmospheric variables

### DIFF
--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -90,6 +90,7 @@ from ._volume import (
     extract_transect,
     extract_volume,
     volume_statistics,
+    extract_surface_from_atm,
 )
 from ._weighting import weighting_landsea_fraction
 
@@ -122,6 +123,8 @@ __all__ = [
     "resample_time",
     # Level extraction
     "extract_levels",
+    # Extract surface
+    "extract_surface_from_atm",
     # Weighting
     "weighting_landsea_fraction",
     # Mask landsea (fx or Natural Earth)

--- a/esmvalcore/preprocessor/_supplementary_vars.py
+++ b/esmvalcore/preprocessor/_supplementary_vars.py
@@ -5,7 +5,6 @@ from typing import Iterable
 
 import iris.coords
 import iris.cube
-import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/esmvalcore/preprocessor/_supplementary_vars.py
+++ b/esmvalcore/preprocessor/_supplementary_vars.py
@@ -5,6 +5,7 @@ from typing import Iterable
 
 import iris.coords
 import iris.cube
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -105,13 +106,21 @@ def add_ancillary_variable(cube, ancillary_cube):
         var_name=ancillary_cube.var_name,
         attributes=ancillary_cube.attributes,
     )
-    start_dim = cube.ndim - len(ancillary_var.shape)
-    cube.add_ancillary_variable(ancillary_var, range(start_dim, cube.ndim))
-    logger.debug(
-        "Added %s as ancillary variable in cube of %s.",
-        ancillary_cube.var_name,
-        cube.var_name,
-    )
+    data_dims = [None] * ancillary_cube.ndim
+    for coord in ancillary_cube.coords():
+        for ancillary_dim, cube_dim in zip(
+            ancillary_cube.coord_dims(coord), cube.coord_dims(coord)):
+            data_dims[ancillary_dim] = cube_dim
+    if None in data_dims:
+        none_dims = ", ".join(
+            str(i) for i, d in enumerate(data_dims) if d is None)
+        msg = (
+            f"Failed to add {ancillary_cube} to {cube} as ancillary variable. "
+            f"No coordinate associated with ancillary cube dimensions {none_dims}"
+        )
+        raise ValueError(msg)
+
+    cube.add_ancillary_variable(ancillary_var, data_dims)
 
 
 def add_supplementary_variables(


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This pull request introduces a new preprocessor function to extract the surface values from 3D atmospheric variables and corresponding surface pressure `ps`. The preprocessor function is largely based on the implementation done for the derivation of surface CO2 `co2s` at https://github.com/ESMValGroup/ESMValCore/blob/main/esmvalcore/preprocessor/_derive/co2s.py. It thus avoids having to create either at standalone derive preprocessor or a new entry in the relevant CMOR tables. The attributes of the 3D atmospheric variables are transferred to the newly created cube and the variable name is changed to `f'{var_name}s'`.

Note: so far, the variable name is required as input of the preprocessor and needs to be used in a recipe as
```
preprocessors:
  extract_co2s:
    extract_surface_from_atm:
      var: 'co2'
```

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2611 

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
