### PR TITLE
Allow using multi model statistics preprocessor on datasets without `timerange`

### DIFF
--- a/esmvalcore/_recipe/recipe.py
+++ b/esmvalcore/_recipe/recipe.py
@@ -367,12 +367,14 @@ def _get_common_attributes(products, settings):
         if all(p.attributes.get(key, object()) == value for p in products):
             attributes[key] = value
 
-    # Ensure that attribute timerange is always available. This depends on the
-    # "span" setting: if "span=overlap", the intersection of all periods is
-    # used; if "span=full", the union is used. The default value for "span" is
-    # "overlap".
+    # Ensure that attribute timerange is always available if at least one of
+    # the input datasets defines it. This depends on the "span" setting: if
+    # "span=overlap", the intersection of all periods is used; if "span=full",
+    # the union is used. The default value for "span" is "overlap".
     span = settings.get("span", "overlap")
     for product in products:
+        if "timerange" not in product.attributes:
+            continue
         timerange = product.attributes["timerange"]
         start, end = _parse_period(timerange)
         if "timerange" not in attributes:
@@ -397,10 +399,12 @@ def _get_common_attributes(products, settings):
 
             attributes["timerange"] = _dates_to_timerange(start_date, end_date)
 
-    # Ensure that attributes start_year and end_year are always available
-    start_year, end_year = _parse_period(attributes["timerange"])
-    attributes["start_year"] = int(str(start_year[0:4]))
-    attributes["end_year"] = int(str(end_year[0:4]))
+    # Ensure that attributes start_year and end_year are always available if at
+    # least one of the input datasets defines it
+    if "timerange" in attributes:
+        start_year, end_year = _parse_period(attributes["timerange"])
+        attributes["start_year"] = int(str(start_year[0:4]))
+        attributes["end_year"] = int(str(end_year[0:4]))
 
     return attributes
 

--- a/esmvalcore/local.py
+++ b/esmvalcore/local.py
@@ -539,14 +539,18 @@ def _get_multiproduct_filename(attributes: dict, preproc_dir: Path) -> Path:
     # Remove duplicate segments:
     filename_segments = list(dict.fromkeys(filename_segments))
 
-    # Add period and extension
-    filename_segments.append(f"{attributes['timerange'].replace('/', '-')}.nc")
+    # Add time period if possible
+    if "timerange" in attributes:
+        filename_segments.append(
+            f"{attributes['timerange'].replace('/', '-')}"
+        )
 
+    filename = f"{'_'.join(filename_segments)}.nc"
     outfile = Path(
         preproc_dir,
         attributes["diagnostic"],
         attributes["variable_group"],
-        "_".join(filename_segments),
+        filename,
     )
 
     return outfile

--- a/tests/unit/recipe/test_recipe.py
+++ b/tests/unit/recipe/test_recipe.py
@@ -241,6 +241,19 @@ def test_multi_model_filename_full():
     assert attributes["end_year"] == 1992
 
 
+@pytest.mark.parametrize("span", ["full", "overlap"])
+def test_multi_model_filename_no_timerange(span):
+    """Test timerange in multi-model filename is correct."""
+    cube = iris.cube.Cube(np.array([1]))
+    products = [
+        PreprocessorFile(cube, "A", {}),
+        PreprocessorFile(cube, "B", {}),
+    ]
+    settings = {"span": span}
+    attributes = _recipe._get_common_attributes(products, settings)
+    assert "timerange" not in attributes
+
+
 def test_update_multiproduct_multi_model_statistics():
     """Test ``_update_multiproduct``."""
     settings = {
@@ -350,6 +363,72 @@ def test_update_multiproduct_multi_model_statistics():
     assert "std_dev" in stats
     assert "MultiModelMean" in str(stats["mean"].filename)
     assert "MultiModelStd_Dev" in str(stats["std_dev"].filename)
+
+
+def test_update_multiproduct_no_timerange():
+    """Test ``_update_multiproduct``."""
+    settings = {
+        "multi_model_statistics": {"statistics": ["mean"]},
+        "save": {"compute": False},
+    }
+    common_attributes = {
+        "project": "CMIP6",
+        "diagnostic": "d",
+        "variable_group": "var",
+    }
+    cube = iris.cube.Cube(np.array([1]))
+    products = [
+        PreprocessorFile(
+            cube,
+            "A",
+            attributes={
+                "dataset": "a",
+                **common_attributes,
+            },
+            settings=settings,
+        ),
+        PreprocessorFile(
+            cube,
+            "B",
+            attributes={
+                "dataset": "b",
+                **common_attributes,
+            },
+            settings=settings,
+        ),
+    ]
+    order = ("load", "multi_model_statistics", "save")
+    preproc_dir = "/preproc"
+    step = "multi_model_statistics"
+    output, settings = _recipe._update_multiproduct(
+        products, order, preproc_dir, step
+    )
+
+    assert len(output) == 1
+    product = list(output)[0]
+
+    assert product.filename == Path("/preproc/d/var/CMIP6_MultiModelMean.nc")
+
+    for attr in common_attributes:
+        assert attr in product.attributes
+        assert product.attributes[attr] == common_attributes[attr]
+        assert "alias" in product.attributes
+        assert "dataset" in product.attributes
+        assert "multi_model_statistics" in product.attributes
+        assert "timerange" not in product.attributes
+        assert "start_year" not in product.attributes
+        assert "end_year" not in product.attributes
+        assert product.attributes["alias"] == "MultiModelMean"
+        assert product.attributes["dataset"] == "MultiModelMean"
+        assert product.attributes["multi_model_statistics"] == "MultiModelMean"
+
+    assert len(settings) == 1
+    output_products = settings["output_products"]
+    assert len(output_products) == 1
+    stats = output_products[""]
+    assert len(stats) == 1
+    assert "mean" in stats
+    assert "MultiModelMean" in str(stats["mean"].filename)
 
 
 def test_update_multiproduct_multi_model_statistics_percentile():


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Since https://github.com/ESMValGroup/ESMValCore/pull/1808, it is possible to use the multi-model statistics preprocessor on data with arbitrary dimensions (i.e., also on data without a time dimension). Thus, it should be possible to use that on data without a `timerange`, too.

This PR implements that.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
