### PR TITLE
Unified ignoring of `iris.warnings.IrisVagueMetadataWarning` in preprocessors

### DIFF
--- a/esmvalcore/cmor/_fixes/emac/emac.py
+++ b/esmvalcore/cmor/_fixes/emac/emac.py
@@ -233,7 +233,7 @@ class Prodlnox(EmacFix):
         )
         dt_cube = self.get_cube(cubes, var_name="dt")
 
-        with warnings.catch_warnings(), ignore_iris_vague_metadata_warnings:
+        with warnings.catch_warnings(), ignore_iris_vague_metadata_warnings():
             warnings.filterwarnings(
                 "ignore",
                 message="Collapsing spatial coordinate 'latitude' without "

--- a/esmvalcore/cmor/_fixes/emac/emac.py
+++ b/esmvalcore/cmor/_fixes/emac/emac.py
@@ -24,7 +24,7 @@ from iris.cube import CubeList
 from netCDF4 import Dataset
 from scipy import constants
 
-from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 
 from ..shared import add_aux_coords_from_cubes
 from ._base_fixes import EmacFix, NegateData

--- a/esmvalcore/cmor/_fixes/emac/emac.py
+++ b/esmvalcore/cmor/_fixes/emac/emac.py
@@ -223,7 +223,6 @@ class Clwvi(EmacFix):
 class Prodlnox(EmacFix):
     """Fixes for ``prodlnox``."""
 
-    @ignore_iris_vague_metadata_warnings
     def fix_metadata(self, cubes):
         """Fix metadata."""
         noxcg_cube = self.get_cube(
@@ -234,7 +233,7 @@ class Prodlnox(EmacFix):
         )
         dt_cube = self.get_cube(cubes, var_name="dt")
 
-        with warnings.catch_warnings():
+        with warnings.catch_warnings(), ignore_iris_vague_metadata_warnings:
             warnings.filterwarnings(
                 "ignore",
                 message="Collapsing spatial coordinate 'latitude' without "
@@ -268,13 +267,13 @@ Hfss = NegateData
 class Od550aer(EmacFix):
     """Fixes for ``od550aer``."""
 
-    @ignore_iris_vague_metadata_warnings
     def fix_metadata(self, cubes):
         """Fix metadata."""
         cubes = super().fix_metadata(cubes)
         cube = self.get_cube(cubes)
         z_coord = cube.coord(axis="Z")
-        cube = cube.collapsed(z_coord, iris.analysis.SUM)
+        with ignore_iris_vague_metadata_warnings():
+            cube = cube.collapsed(z_coord, iris.analysis.SUM)
         return CubeList([cube])
 
 

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -24,8 +24,9 @@ from esmvalcore.typing import NetCDFAttr
 def ignore_iris_vague_metadata_warnings(func: Callable) -> Callable:
     """Ignore specific warnings.
 
-    This can be used as a decorator.
-see https://scitools-iris.readthedocs.io/en/stable/generated/api/iris.warnings.html#iris.warnings.IrisVagueMetadataWarning
+    This can be used as a decorator. See also
+    https://scitools-iris.readthedocs.io/en/stable/generated/api/iris.warnings.html#iris.warnings.IrisVagueMetadataWarning.
+
     """
 
     @wraps(func)

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Literal, Sequence
+import warnings
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, Dict, Iterable, List, Literal, Sequence
 
 import dask.array as da
 import iris
@@ -13,8 +16,30 @@ from cf_units import Unit
 from iris.coords import Coord
 from iris.cube import Cube
 from iris.exceptions import CoordinateMultiDimError, CoordinateNotFoundError
+from iris.warnings import IrisVagueMetadataWarning
 
 from esmvalcore.typing import NetCDFAttr
+
+
+def ignore_iris_vague_metadata_warnings(func: Callable) -> Callable:
+    """Ignore specific warnings.
+
+    This can be used as a decorator.
+
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=IrisVagueMetadataWarning,
+                module="iris",
+            )
+            result = func(*args, **kwargs)
+        return result
+
+    return wrapper
 
 
 def add_leading_dim_to_cube(cube, dim_coord):

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable
-from functools import wraps
-from typing import Any, Dict, Iterable, List, Literal, Sequence
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Dict, Iterable, List, Literal, Sequence
 
 import dask.array as da
 import iris
@@ -21,26 +21,21 @@ from iris.warnings import IrisVagueMetadataWarning
 from esmvalcore.typing import NetCDFAttr
 
 
-def ignore_iris_vague_metadata_warnings(func: Callable) -> Callable:
+@contextmanager
+def ignore_iris_vague_metadata_warnings() -> Generator[None]:
     """Ignore specific warnings.
 
-    This can be used as a decorator. See also
+    This can be used as a context manager. See also
     https://scitools-iris.readthedocs.io/en/stable/generated/api/iris.warnings.html#iris.warnings.IrisVagueMetadataWarning.
 
     """
-
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                category=IrisVagueMetadataWarning,
-                module="iris",
-            )
-            result = func(*args, **kwargs)
-        return result
-
-    return wrapper
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=IrisVagueMetadataWarning,
+            module="iris",
+        )
+        yield
 
 
 def add_leading_dim_to_cube(cube, dim_coord):

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -25,7 +25,7 @@ def ignore_iris_vague_metadata_warnings(func: Callable) -> Callable:
     """Ignore specific warnings.
 
     This can be used as a decorator.
-
+see https://scitools-iris.readthedocs.io/en/stable/generated/api/iris.warnings.html#iris.warnings.IrisVagueMetadataWarning
     """
 
     @wraps(func)

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -197,7 +197,6 @@ def _extract_irregular_region(
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def zonal_statistics(
     cube: Cube,
     operator: str,
@@ -241,14 +240,14 @@ def zonal_statistics(
             "Zonal statistics on irregular grids not yet implemented"
         )
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
-    result = cube.collapsed("longitude", agg, **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.collapsed("longitude", agg, **agg_kwargs)
     if normalize is not None:
         result = get_normalized_cube(cube, result, normalize)
     return result
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def meridional_statistics(
     cube: Cube,
     operator: str,
@@ -291,7 +290,8 @@ def meridional_statistics(
             "Meridional statistics on irregular grids not yet implemented"
         )
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
-    result = cube.collapsed("latitude", agg, **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.collapsed("latitude", agg, **agg_kwargs)
     if normalize is not None:
         result = get_normalized_cube(cube, result, normalize)
     return result
@@ -302,7 +302,6 @@ def meridional_statistics(
     required="prefer_at_least_one",
 )
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def area_statistics(
     cube: Cube,
     operator: str,
@@ -358,7 +357,8 @@ def area_statistics(
         agg, agg_kwargs, "cell_area", cube, try_adding_calculated_cell_area
     )
 
-    result = cube.collapsed(["latitude", "longitude"], agg, **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.collapsed(["latitude", "longitude"], agg, **agg_kwargs)
     if normalize is not None:
         result = get_normalized_cube(cube, result, normalize)
 

--- a/esmvalcore/preprocessor/_area.py
+++ b/esmvalcore/preprocessor/_area.py
@@ -20,12 +20,12 @@ from iris.coords import AuxCoord
 from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateNotFoundError
 
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 from esmvalcore.preprocessor._shared import (
     apply_mask,
     get_dims_along_axes,
     get_iris_aggregator,
     get_normalized_cube,
-    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
     try_adding_calculated_cell_area,
     update_weights_kwargs,

--- a/esmvalcore/preprocessor/_compare_with_refs.py
+++ b/esmvalcore/preprocessor/_compare_with_refs.py
@@ -390,7 +390,6 @@ def distance_metric(
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def _calculate_metric(
     cube: Cube,
     reference: Cube,
@@ -435,7 +434,8 @@ def _calculate_metric(
 
     # Get result cube with correct dimensional metadata by using dummy
     # operation (max)
-    res_cube = cube.collapsed(coords, iris.analysis.MAX)
+    with ignore_iris_vague_metadata_warnings():
+        res_cube = cube.collapsed(coords, iris.analysis.MAX)
     res_cube.data = res_data
     res_cube.metadata = res_metadata
     res_cube.cell_methods = [*cube.cell_methods, CellMethod(metric, coords)]

--- a/esmvalcore/preprocessor/_compare_with_refs.py
+++ b/esmvalcore/preprocessor/_compare_with_refs.py
@@ -25,6 +25,7 @@ from esmvalcore.preprocessor._shared import (
     get_all_coords,
     get_array_module,
     get_weights,
+    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
 )
 
@@ -387,6 +388,7 @@ def distance_metric(
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def _calculate_metric(
     cube: Cube,
     reference: Cube,

--- a/esmvalcore/preprocessor/_compare_with_refs.py
+++ b/esmvalcore/preprocessor/_compare_with_refs.py
@@ -17,7 +17,10 @@ from iris.coords import CellMethod, Coord
 from iris.cube import Cube, CubeList
 from scipy.stats import wasserstein_distance
 
-from esmvalcore.iris_helpers import rechunk_cube
+from esmvalcore.iris_helpers import (
+    ignore_iris_vague_metadata_warnings,
+    rechunk_cube,
+)
 from esmvalcore.preprocessor._io import concatenate
 from esmvalcore.preprocessor._other import histogram
 from esmvalcore.preprocessor._shared import (
@@ -25,7 +28,6 @@ from esmvalcore.preprocessor._shared import (
     get_all_coords,
     get_array_module,
     get_weights,
-    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
 )
 

--- a/esmvalcore/preprocessor/_cycles.py
+++ b/esmvalcore/preprocessor/_cycles.py
@@ -10,7 +10,6 @@ from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 logger = logging.getLogger(__name__)
 
 
-@ignore_iris_vague_metadata_warnings
 def amplitude(cube, coords):
     """Calculate amplitude of cycles by aggregating over coordinates.
 
@@ -72,8 +71,9 @@ def amplitude(cube, coords):
             )
 
     # Calculate amplitude
-    max_cube = cube.aggregated_by(coords, iris.analysis.MAX)
-    min_cube = cube.aggregated_by(coords, iris.analysis.MIN)
+    with ignore_iris_vague_metadata_warnings():
+        max_cube = cube.aggregated_by(coords, iris.analysis.MAX)
+        min_cube = cube.aggregated_by(coords, iris.analysis.MIN)
     amplitude_cube = max_cube - min_cube
     amplitude_cube.metadata = cube.metadata
 

--- a/esmvalcore/preprocessor/_cycles.py
+++ b/esmvalcore/preprocessor/_cycles.py
@@ -5,9 +5,12 @@ import logging
 import iris
 import iris.coord_categorisation
 
+from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+
 logger = logging.getLogger(__name__)
 
 
+@ignore_iris_vague_metadata_warnings
 def amplitude(cube, coords):
     """Calculate amplitude of cycles by aggregating over coordinates.
 

--- a/esmvalcore/preprocessor/_cycles.py
+++ b/esmvalcore/preprocessor/_cycles.py
@@ -5,7 +5,7 @@ import logging
 import iris
 import iris.coord_categorisation
 
-from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 
 logger = logging.getLogger(__name__)
 

--- a/esmvalcore/preprocessor/_derive/_shared.py
+++ b/esmvalcore/preprocessor/_derive/_shared.py
@@ -8,9 +8,12 @@ import numpy as np
 from iris import NameConstraint
 from scipy import constants
 
+from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+
 logger = logging.getLogger(__name__)
 
 
+@ignore_iris_vague_metadata_warnings
 def cloud_area_fraction(cubes, tau_constraint, plev_constraint):
     """Calculate cloud area fraction for different parameters."""
     clisccp_cube = cubes.extract_cube(NameConstraint(var_name="clisccp"))
@@ -31,6 +34,7 @@ def cloud_area_fraction(cubes, tau_constraint, plev_constraint):
     return new_cube
 
 
+@ignore_iris_vague_metadata_warnings
 def column_average(cube, hus_cube, zg_cube, ps_cube):
     """Calculate column-averaged mole fractions.
 

--- a/esmvalcore/preprocessor/_derive/_shared.py
+++ b/esmvalcore/preprocessor/_derive/_shared.py
@@ -8,7 +8,7 @@ import numpy as np
 from iris import NameConstraint
 from scipy import constants
 
-from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 
 logger = logging.getLogger(__name__)
 

--- a/esmvalcore/preprocessor/_derive/_shared.py
+++ b/esmvalcore/preprocessor/_derive/_shared.py
@@ -13,7 +13,6 @@ from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 logger = logging.getLogger(__name__)
 
 
-@ignore_iris_vague_metadata_warnings
 def cloud_area_fraction(cubes, tau_constraint, plev_constraint):
     """Calculate cloud area fraction for different parameters."""
     clisccp_cube = cubes.extract_cube(NameConstraint(var_name="clisccp"))
@@ -24,17 +23,17 @@ def cloud_area_fraction(cubes, tau_constraint, plev_constraint):
         for coord in new_cube.coords()
         if len(coord.points) > 1
     ]
-    if "atmosphere_optical_thickness_due_to_cloud" in coord_names:
-        new_cube = new_cube.collapsed(
-            "atmosphere_optical_thickness_due_to_cloud", iris.analysis.SUM
-        )
-    if "air_pressure" in coord_names:
-        new_cube = new_cube.collapsed("air_pressure", iris.analysis.SUM)
+    with ignore_iris_vague_metadata_warnings():
+        if "atmosphere_optical_thickness_due_to_cloud" in coord_names:
+            new_cube = new_cube.collapsed(
+                "atmosphere_optical_thickness_due_to_cloud", iris.analysis.SUM
+            )
+        if "air_pressure" in coord_names:
+            new_cube = new_cube.collapsed("air_pressure", iris.analysis.SUM)
 
     return new_cube
 
 
-@ignore_iris_vague_metadata_warnings
 def column_average(cube, hus_cube, zg_cube, ps_cube):
     """Calculate column-averaged mole fractions.
 
@@ -112,11 +111,12 @@ def column_average(cube, hus_cube, zg_cube, ps_cube):
     cube.data = cube.core_data() * n_dry.core_data()
 
     # Column-average
-    cube = cube.collapsed("air_pressure", iris.analysis.SUM)
-    cube.data = (
-        cube.core_data()
-        / n_dry.collapsed("air_pressure", iris.analysis.SUM).core_data()
-    )
+    with ignore_iris_vague_metadata_warnings():
+        cube = cube.collapsed("air_pressure", iris.analysis.SUM)
+        cube.data = (
+            cube.core_data()
+            / n_dry.collapsed("air_pressure", iris.analysis.SUM).core_data()
+        )
     return cube
 
 

--- a/esmvalcore/preprocessor/_derive/amoc.py
+++ b/esmvalcore/preprocessor/_derive/amoc.py
@@ -3,7 +3,7 @@
 import iris
 import numpy as np
 
-from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 
 from ._baseclass import DerivedVariableBase
 

--- a/esmvalcore/preprocessor/_derive/amoc.py
+++ b/esmvalcore/preprocessor/_derive/amoc.py
@@ -29,7 +29,6 @@ class DerivedVariable(DerivedVariableBase):
         return required
 
     @staticmethod
-    @ignore_iris_vague_metadata_warnings
     def calculate(cubes):
         """Compute Atlantic meriodinal overturning circulation.
 
@@ -89,9 +88,7 @@ class DerivedVariable(DerivedVariableBase):
         cube = cube.extract(constraint=rapid_constraint)
 
         # 4: find the maximum in the water column along the time axis.
-        cube = cube.collapsed(
-            ["depth", "region"],
-            iris.analysis.MAX,
-        )
+        with ignore_iris_vague_metadata_warnings():
+            cube = cube.collapsed(["depth", "region"], iris.analysis.MAX)
 
         return cube

--- a/esmvalcore/preprocessor/_derive/amoc.py
+++ b/esmvalcore/preprocessor/_derive/amoc.py
@@ -3,6 +3,8 @@
 import iris
 import numpy as np
 
+from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+
 from ._baseclass import DerivedVariableBase
 
 
@@ -27,6 +29,7 @@ class DerivedVariable(DerivedVariableBase):
         return required
 
     @staticmethod
+    @ignore_iris_vague_metadata_warnings
     def calculate(cubes):
         """Compute Atlantic meriodinal overturning circulation.
 

--- a/esmvalcore/preprocessor/_derive/toz.py
+++ b/esmvalcore/preprocessor/_derive/toz.py
@@ -7,6 +7,7 @@ import iris
 from scipy import constants
 
 from esmvalcore.cmor.table import CMOR_TABLES
+from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
 
 from .._regrid import extract_levels, regrid
 from ._baseclass import DerivedVariableBase
@@ -78,6 +79,7 @@ class DerivedVariable(DerivedVariableBase):
         return required
 
     @staticmethod
+    @ignore_iris_vague_metadata_warnings
     def calculate(cubes):
         """Compute total column ozone.
 

--- a/esmvalcore/preprocessor/_derive/toz.py
+++ b/esmvalcore/preprocessor/_derive/toz.py
@@ -1,7 +1,5 @@
 """Derivation of variable ``toz``."""
 
-import warnings
-
 import cf_units
 import iris
 from scipy import constants
@@ -79,7 +77,6 @@ class DerivedVariable(DerivedVariableBase):
         return required
 
     @staticmethod
-    @ignore_iris_vague_metadata_warnings
     def calculate(cubes):
         """Compute total column ozone.
 
@@ -106,7 +103,8 @@ class DerivedVariable(DerivedVariableBase):
         # have correct shapes
         if not o3_cube.coords("longitude"):
             o3_cube = add_longitude_coord(o3_cube)
-            ps_cube = ps_cube.collapsed("longitude", iris.analysis.MEAN)
+            with ignore_iris_vague_metadata_warnings():
+                ps_cube = ps_cube.collapsed("longitude", iris.analysis.MEAN)
             ps_cube.remove_coord("longitude")
             ps_cube = add_longitude_coord(ps_cube)
 
@@ -119,12 +117,7 @@ class DerivedVariable(DerivedVariableBase):
         # widths
         p_layer_widths = pressure_level_widths(o3_cube, ps_cube, top_limit=0.0)
         toz_cube = o3_cube * p_layer_widths / STANDARD_GRAVITY * MW_O3 / MW_AIR
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                category=UserWarning,
-                message="Collapsing a non-contiguous coordinate",
-            )
+        with ignore_iris_vague_metadata_warnings():
             toz_cube = toz_cube.collapsed("air_pressure", iris.analysis.SUM)
         toz_cube.units = (
             o3_cube.units

--- a/esmvalcore/preprocessor/_derive/toz.py
+++ b/esmvalcore/preprocessor/_derive/toz.py
@@ -7,7 +7,7 @@ import iris
 from scipy import constants
 
 from esmvalcore.cmor.table import CMOR_TABLES
-from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 
 from .._regrid import extract_levels, regrid
 from ._baseclass import DerivedVariableBase

--- a/esmvalcore/preprocessor/_derive/troz.py
+++ b/esmvalcore/preprocessor/_derive/troz.py
@@ -3,6 +3,8 @@
 import dask.array as da
 import iris
 
+from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+
 from ._baseclass import DerivedVariableBase
 from .soz import STRATOSPHERIC_O3_THRESHOLD
 from .toz import DerivedVariable as Toz
@@ -18,6 +20,7 @@ class DerivedVariable(DerivedVariableBase):
         return Toz.required(project)
 
     @staticmethod
+    @ignore_iris_vague_metadata_warnings
     def calculate(cubes):
         """Compute tropospheric column ozone.
 

--- a/esmvalcore/preprocessor/_derive/troz.py
+++ b/esmvalcore/preprocessor/_derive/troz.py
@@ -20,7 +20,6 @@ class DerivedVariable(DerivedVariableBase):
         return Toz.required(project)
 
     @staticmethod
-    @ignore_iris_vague_metadata_warnings
     def calculate(cubes):
         """Compute tropospheric column ozone.
 
@@ -48,7 +47,8 @@ class DerivedVariable(DerivedVariableBase):
         # have correct shapes
         if not o3_cube.coords("longitude"):
             o3_cube = add_longitude_coord(o3_cube)
-            ps_cube = ps_cube.collapsed("longitude", iris.analysis.MEAN)
+            with ignore_iris_vague_metadata_warnings():
+                ps_cube = ps_cube.collapsed("longitude", iris.analysis.MEAN)
             ps_cube.remove_coord("longitude")
             ps_cube = add_longitude_coord(ps_cube)
 

--- a/esmvalcore/preprocessor/_derive/troz.py
+++ b/esmvalcore/preprocessor/_derive/troz.py
@@ -3,7 +3,7 @@
 import dask.array as da
 import iris
 
-from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 
 from ._baseclass import DerivedVariableBase
 from .soz import STRATOSPHERIC_O3_THRESHOLD

--- a/esmvalcore/preprocessor/_derive/uajet.py
+++ b/esmvalcore/preprocessor/_derive/uajet.py
@@ -4,7 +4,7 @@ import cf_units
 import iris
 import numpy as np
 
-from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 
 from ._baseclass import DerivedVariableBase
 

--- a/esmvalcore/preprocessor/_derive/uajet.py
+++ b/esmvalcore/preprocessor/_derive/uajet.py
@@ -4,6 +4,8 @@ import cf_units
 import iris
 import numpy as np
 
+from esmvalcore.preprocessor._shared import ignore_iris_vague_metadata_warnings
+
 from ._baseclass import DerivedVariableBase
 
 # Constants (Southern hemisphere at 850 hPa)
@@ -21,6 +23,7 @@ class DerivedVariable(DerivedVariableBase):
         return required
 
     @staticmethod
+    @ignore_iris_vague_metadata_warnings
     def calculate(cubes):
         """Compute latitude of maximum meridional wind speed."""
         # Load cube, extract correct region and perform zonal mean

--- a/esmvalcore/preprocessor/_derive/uajet.py
+++ b/esmvalcore/preprocessor/_derive/uajet.py
@@ -23,7 +23,6 @@ class DerivedVariable(DerivedVariableBase):
         return required
 
     @staticmethod
-    @ignore_iris_vague_metadata_warnings
     def calculate(cubes):
         """Compute latitude of maximum meridional wind speed."""
         # Load cube, extract correct region and perform zonal mean
@@ -34,7 +33,8 @@ class DerivedVariable(DerivedVariableBase):
         ua_cube = ua_cube.extract(
             iris.Constraint(latitude=lambda cell: LAT[0] <= cell <= LAT[1])
         )
-        ua_cube = ua_cube.collapsed("longitude", iris.analysis.MEAN)
+        with ignore_iris_vague_metadata_warnings():
+            ua_cube = ua_cube.collapsed("longitude", iris.analysis.MEAN)
 
         # Calculate maximum jet position
         uajet_vals = []

--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -342,7 +342,6 @@ def _mask_with_shp(cube, shapefilename, region_indices=None):
     return cube
 
 
-@ignore_iris_vague_metadata_warnings
 def count_spells(
     data: np.ndarray | da.Array,
     threshold: float | None,
@@ -400,12 +399,13 @@ def count_spells(
     # if you want overlapping windows set the step to be m*spell_length
     # where m is a float
     ###############################################################
-    hit_windows = rolling_window(
-        data_hits,
-        window=spell_length,
-        step=spell_length,
-        axis=axis,
-    )
+    with ignore_iris_vague_metadata_warnings():
+        hit_windows = rolling_window(
+            data_hits,
+            window=spell_length,
+            step=spell_length,
+            axis=axis,
+        )
     # Find the windows "full of True-s" (along the added 'window axis').
     full_windows = array_module.all(hit_windows, axis=axis + 1)
     # Count points fulfilling the condition (along the time axis).
@@ -692,7 +692,6 @@ def mask_fillvalues(
     return products
 
 
-@ignore_iris_vague_metadata_warnings
 def _get_fillvalues_mask(
     cube: iris.cube.Cube,
     threshold_fraction: float,
@@ -731,12 +730,13 @@ def _get_fillvalues_mask(
     )
 
     # Calculate the statistic.
-    counts_windowed_cube = cube.collapsed(
-        "time",
-        spell_count,
-        threshold=min_value,
-        spell_length=time_window,
-    )
+    with ignore_iris_vague_metadata_warnings():
+        counts_windowed_cube = cube.collapsed(
+            "time",
+            spell_count,
+            threshold=min_value,
+            spell_length=time_window,
+        )
 
     # Create mask
     mask = counts_windowed_cube.core_data() < counts_threshold

--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -342,6 +342,7 @@ def _mask_with_shp(cube, shapefilename, region_indices=None):
     return cube
 
 
+@ignore_iris_vague_metadata_warnings
 def count_spells(
     data: np.ndarray | da.Array,
     threshold: float | None,

--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -21,7 +21,10 @@ from iris.analysis import Aggregator
 from iris.cube import Cube
 from iris.util import rolling_window
 
-from esmvalcore.preprocessor._shared import apply_mask
+from esmvalcore.preprocessor._shared import (
+    apply_mask,
+    ignore_iris_vague_metadata_warnings,
+)
 
 from ._supplementary_vars import register_supplementaries
 
@@ -688,6 +691,7 @@ def mask_fillvalues(
     return products
 
 
+@ignore_iris_vague_metadata_warnings
 def _get_fillvalues_mask(
     cube: iris.cube.Cube,
     threshold_fraction: float,

--- a/esmvalcore/preprocessor/_mask.py
+++ b/esmvalcore/preprocessor/_mask.py
@@ -21,9 +21,9 @@ from iris.analysis import Aggregator
 from iris.cube import Cube
 from iris.util import rolling_window
 
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 from esmvalcore.preprocessor._shared import (
     apply_mask,
-    ignore_iris_vague_metadata_warnings,
 )
 
 from ._supplementary_vars import register_supplementaries

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -25,11 +25,13 @@ from iris.cube import Cube, CubeList
 from iris.exceptions import MergeError
 from iris.util import equalise_attributes, new_axis
 
-from esmvalcore.iris_helpers import date2num
+from esmvalcore.iris_helpers import (
+    date2num,
+    ignore_iris_vague_metadata_warnings,
+)
 from esmvalcore.preprocessor._shared import (
     _group_products,
     get_iris_aggregator,
-    ignore_iris_vague_metadata_warnings,
 )
 from esmvalcore.preprocessor._supplementary_vars import (
     remove_supplementary_variables,

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -507,7 +507,6 @@ def _compute_eager(
     return result_cube
 
 
-@ignore_iris_vague_metadata_warnings
 def _compute(
     cube: iris.cube.Cube,
     *,
@@ -516,7 +515,8 @@ def _compute(
 ):
     """Compute statistic."""
     # This will always return a masked array
-    result_cube = cube.collapsed(CONCAT_DIM, operator, **kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result_cube = cube.collapsed(CONCAT_DIM, operator, **kwargs)
 
     # Remove concatenation dimension added by _combine
     result_cube.remove_coord(CONCAT_DIM)

--- a/esmvalcore/preprocessor/_other.py
+++ b/esmvalcore/preprocessor/_other.py
@@ -15,14 +15,16 @@ from iris.coords import Coord, DimCoord
 from iris.cube import Cube
 from iris.exceptions import CoordinateMultiDimError
 
-from esmvalcore.iris_helpers import rechunk_cube
+from esmvalcore.iris_helpers import (
+    ignore_iris_vague_metadata_warnings,
+    rechunk_cube,
+)
 from esmvalcore.preprocessor._shared import (
     get_all_coord_dims,
     get_all_coords,
     get_array_module,
     get_coord_weights,
     get_weights,
-    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
 )
 

--- a/esmvalcore/preprocessor/_other.py
+++ b/esmvalcore/preprocessor/_other.py
@@ -450,7 +450,6 @@ def _calculate_histogram_eager(
     return hist
 
 
-@ignore_iris_vague_metadata_warnings
 def _get_histogram_cube(
     cube: Cube,
     data: np.ndarray | da.Array,
@@ -474,7 +473,8 @@ def _get_histogram_cube(
     # Get result cube with correct dimensional metadata by using dummy
     # operation (max)
     cell_methods = cube.cell_methods
-    cube = cube.collapsed(coords, iris.analysis.MAX)
+    with ignore_iris_vague_metadata_warnings():
+        cube = cube.collapsed(coords, iris.analysis.MAX)
 
     # Get histogram cube
     long_name_suffix = (

--- a/esmvalcore/preprocessor/_other.py
+++ b/esmvalcore/preprocessor/_other.py
@@ -22,6 +22,7 @@ from esmvalcore.preprocessor._shared import (
     get_array_module,
     get_coord_weights,
     get_weights,
+    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
 )
 
@@ -447,6 +448,7 @@ def _calculate_histogram_eager(
     return hist
 
 
+@ignore_iris_vague_metadata_warnings
 def _get_histogram_cube(
     cube: Cube,
     data: np.ndarray | da.Array,

--- a/esmvalcore/preprocessor/_rolling_window.py
+++ b/esmvalcore/preprocessor/_rolling_window.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def rolling_window_statistics(
     cube: Cube,
     coordinate: str,
@@ -48,6 +47,7 @@ def rolling_window_statistics(
 
     """
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
-    cube = cube.rolling_window(coordinate, agg, window_length, *agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        cube = cube.rolling_window(coordinate, agg, window_length, *agg_kwargs)
 
     return cube

--- a/esmvalcore/preprocessor/_rolling_window.py
+++ b/esmvalcore/preprocessor/_rolling_window.py
@@ -4,12 +4,17 @@ import logging
 
 from iris.cube import Cube
 
-from ._shared import get_iris_aggregator, preserve_float_dtype
+from ._shared import (
+    get_iris_aggregator,
+    ignore_iris_vague_metadata_warnings,
+    preserve_float_dtype,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def rolling_window_statistics(
     cube: Cube,
     coordinate: str,

--- a/esmvalcore/preprocessor/_rolling_window.py
+++ b/esmvalcore/preprocessor/_rolling_window.py
@@ -4,9 +4,10 @@ import logging
 
 from iris.cube import Cube
 
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
+
 from ._shared import (
     get_iris_aggregator,
-    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
 )
 

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -40,7 +40,6 @@ def guess_bounds(cube, coords):
     return cube
 
 
-@ignore_iris_vague_metadata_warnings
 def get_iris_aggregator(
     operator: str,
     **operator_kwargs,
@@ -96,7 +95,8 @@ def get_iris_aggregator(
         aggregator, aggregator_kwargs, np.array([1.0])
     )
     try:
-        cube.collapsed("x", aggregator, **test_kwargs)
+        with ignore_iris_vague_metadata_warnings():
+            cube.collapsed("x", aggregator, **test_kwargs)
     except (ValueError, TypeError) as exc:
         raise ValueError(
             f"Invalid kwargs for operator '{operator}': {str(exc)}"

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -27,6 +27,27 @@ from esmvalcore.typing import DataType
 logger = logging.getLogger(__name__)
 
 
+def ignore_iris_vague_metadata_warnings(func: Callable) -> Callable:
+    """Ignore specific warnings.
+
+    This can be used as a decorator.
+
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=iris.warnings.IrisVagueMetadataWarning,
+                module="iris",
+            )
+            result = func(*args, **kwargs)
+        return result
+
+    return wrapper
+
+
 def guess_bounds(cube, coords):
     """Guess bounds of a cube, or not."""
     # check for bounds just in case
@@ -36,6 +57,7 @@ def guess_bounds(cube, coords):
     return cube
 
 
+@ignore_iris_vague_metadata_warnings
 def get_iris_aggregator(
     operator: str,
     **operator_kwargs,

--- a/esmvalcore/preprocessor/_shared.py
+++ b/esmvalcore/preprocessor/_shared.py
@@ -21,31 +21,13 @@ from iris.cube import Cube
 from iris.exceptions import CoordinateMultiDimError, CoordinateNotFoundError
 from iris.util import broadcast_to_shape
 
-from esmvalcore.iris_helpers import has_regular_grid
+from esmvalcore.iris_helpers import (
+    has_regular_grid,
+    ignore_iris_vague_metadata_warnings,
+)
 from esmvalcore.typing import DataType
 
 logger = logging.getLogger(__name__)
-
-
-def ignore_iris_vague_metadata_warnings(func: Callable) -> Callable:
-    """Ignore specific warnings.
-
-    This can be used as a decorator.
-
-    """
-
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                category=iris.warnings.IrisVagueMetadataWarning,
-                module="iris",
-            )
-            result = func(*args, **kwargs)
-        return result
-
-    return wrapper
 
 
 def guess_bounds(cube, coords):

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -458,7 +458,6 @@ def _aggregate_time_fx(result_cube, source_cube):
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def hourly_statistics(
     cube: Cube,
     hours: int,
@@ -503,9 +502,10 @@ def hourly_statistics(
         iris.coord_categorisation.add_year(cube, "time")
 
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
-    result = cube.aggregated_by(
-        ["hour_group", "day_of_year", "year"], agg, **agg_kwargs
-    )
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.aggregated_by(
+            ["hour_group", "day_of_year", "year"], agg, **agg_kwargs
+        )
 
     result.remove_coord("hour_group")
     result.remove_coord("day_of_year")
@@ -515,7 +515,6 @@ def hourly_statistics(
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def daily_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -548,7 +547,8 @@ def daily_statistics(
         iris.coord_categorisation.add_year(cube, "time")
 
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
-    result = cube.aggregated_by(["day_of_year", "year"], agg, **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.aggregated_by(["day_of_year", "year"], agg, **agg_kwargs)
 
     result.remove_coord("day_of_year")
     result.remove_coord("year")
@@ -556,7 +556,6 @@ def daily_statistics(
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def monthly_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -589,13 +588,15 @@ def monthly_statistics(
         iris.coord_categorisation.add_year(cube, "time")
 
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
-    result = cube.aggregated_by(["month_number", "year"], agg, **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.aggregated_by(
+            ["month_number", "year"], agg, **agg_kwargs
+        )
     _aggregate_time_fx(result, cube)
     return result
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def seasonal_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -655,9 +656,10 @@ def seasonal_statistics(
         )
 
     (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
-    result = cube.aggregated_by(
-        ["clim_season", "season_year"], agg, **agg_kwargs
-    )
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.aggregated_by(
+            ["clim_season", "season_year"], agg, **agg_kwargs
+        )
 
     # CMOR Units are days so we are safe to operate on days
     # Ranging on [29, 31] days makes this calendar-independent
@@ -694,7 +696,6 @@ def seasonal_statistics(
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def annual_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -730,13 +731,13 @@ def annual_statistics(
 
     if not cube.coords("year"):
         iris.coord_categorisation.add_year(cube, "time")
-    result = cube.aggregated_by("year", agg, **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.aggregated_by("year", agg, **agg_kwargs)
     _aggregate_time_fx(result, cube)
     return result
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def decadal_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -780,13 +781,13 @@ def decadal_statistics(
         iris.coord_categorisation.add_categorised_coord(
             cube, "decade", "time", get_decade
         )
-    result = cube.aggregated_by("decade", agg, **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.aggregated_by("decade", agg, **agg_kwargs)
     _aggregate_time_fx(result, cube)
     return result
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def climate_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -847,7 +848,8 @@ def climate_statistics(
                 category=UserWarning,
                 module="iris",
             )
-            clim_cube = cube.collapsed("time", agg, **agg_kwargs)
+            with ignore_iris_vague_metadata_warnings():
+                clim_cube = cube.collapsed("time", agg, **agg_kwargs)
 
         # Make sure input and output cubes do not have auxiliary coordinate
         if cube.coords("_time_weights_"):
@@ -859,7 +861,8 @@ def climate_statistics(
     else:
         clim_coord = _get_period_coord(cube, period, seasons)
         (agg, agg_kwargs) = get_iris_aggregator(operator, **operator_kwargs)
-        clim_cube = cube.aggregated_by(clim_coord, agg, **agg_kwargs)
+        with ignore_iris_vague_metadata_warnings():
+            clim_cube = cube.aggregated_by(clim_coord, agg, **agg_kwargs)
         clim_cube.remove_coord("time")
         _aggregate_time_fx(clim_cube, cube)
         if clim_cube.coord(clim_coord.name()).is_monotonic():
@@ -1219,7 +1222,6 @@ def low_pass_weights(window, cutoff):
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def timeseries_filter(
     cube: Cube,
     window: int,
@@ -1302,7 +1304,8 @@ def timeseries_filter(
         # Ensure the cube data chunktype is np.MaskedArray so rolling_window
         # does not ignore a potential mask.
         cube.data = da.ma.masked_array(cube.core_data())
-    cube = cube.rolling_window("time", agg, len(wgts), **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        cube = cube.rolling_window("time", agg, len(wgts), **agg_kwargs)
 
     return cube
 

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -32,11 +32,14 @@ from iris.util import broadcast_to_shape
 from numpy.typing import DTypeLike
 
 from esmvalcore.cmor.fixes import get_next_month, get_time_bounds
-from esmvalcore.iris_helpers import date2num, rechunk_cube
+from esmvalcore.iris_helpers import (
+    date2num,
+    ignore_iris_vague_metadata_warnings,
+    rechunk_cube,
+)
 from esmvalcore.preprocessor._shared import (
     get_coord_weights,
     get_iris_aggregator,
-    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
     update_weights_kwargs,
 )

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -36,6 +36,7 @@ from esmvalcore.iris_helpers import date2num, rechunk_cube
 from esmvalcore.preprocessor._shared import (
     get_coord_weights,
     get_iris_aggregator,
+    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
     update_weights_kwargs,
 )
@@ -454,6 +455,7 @@ def _aggregate_time_fx(result_cube, source_cube):
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def hourly_statistics(
     cube: Cube,
     hours: int,
@@ -510,6 +512,7 @@ def hourly_statistics(
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def daily_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -550,6 +553,7 @@ def daily_statistics(
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def monthly_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -588,6 +592,7 @@ def monthly_statistics(
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def seasonal_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -686,6 +691,7 @@ def seasonal_statistics(
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def annual_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -727,6 +733,7 @@ def annual_statistics(
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def decadal_statistics(
     cube: Cube,
     operator: str = "mean",
@@ -776,6 +783,7 @@ def decadal_statistics(
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def climate_statistics(
     cube: Cube,
     operator: str = "mean",

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -1216,6 +1216,7 @@ def low_pass_weights(window, cutoff):
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def timeseries_filter(
     cube: Cube,
     window: int,

--- a/esmvalcore/preprocessor/_trend.py
+++ b/esmvalcore/preprocessor/_trend.py
@@ -7,8 +7,8 @@ import iris
 import numpy as np
 from cf_units import Unit
 
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 from esmvalcore.preprocessor._shared import (
-    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
 )
 

--- a/esmvalcore/preprocessor/_trend.py
+++ b/esmvalcore/preprocessor/_trend.py
@@ -85,7 +85,6 @@ def _set_trend_units(cube, coord):
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def linear_trend(cube, coordinate="time"):
     """Calculate linear trend of data along a given coordinate.
 
@@ -130,7 +129,8 @@ def linear_trend(cube, coordinate="time"):
     aggregator = iris.analysis.Aggregator(
         "trend", call_func, lazy_func=lazy_func, x_data=coord.points
     )
-    cube = cube.collapsed(coord, aggregator)
+    with ignore_iris_vague_metadata_warnings():
+        cube = cube.collapsed(coord, aggregator)
 
     # Adapt units
     _set_trend_units(cube, coord)
@@ -139,7 +139,6 @@ def linear_trend(cube, coordinate="time"):
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def linear_trend_stderr(cube, coordinate="time"):
     """Calculate standard error of linear trend along a given coordinate.
 
@@ -189,7 +188,8 @@ def linear_trend_stderr(cube, coordinate="time"):
     aggregator = iris.analysis.Aggregator(
         "trend_stderr", call_func, lazy_func=lazy_func, x_data=coord.points
     )
-    cube = cube.collapsed(coord, aggregator)
+    with ignore_iris_vague_metadata_warnings():
+        cube = cube.collapsed(coord, aggregator)
 
     # Adapt units
     _set_trend_units(cube, coord)

--- a/esmvalcore/preprocessor/_trend.py
+++ b/esmvalcore/preprocessor/_trend.py
@@ -7,7 +7,10 @@ import iris
 import numpy as np
 from cf_units import Unit
 
-from esmvalcore.preprocessor._shared import preserve_float_dtype
+from esmvalcore.preprocessor._shared import (
+    ignore_iris_vague_metadata_warnings,
+    preserve_float_dtype,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +85,7 @@ def _set_trend_units(cube, coord):
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def linear_trend(cube, coordinate="time"):
     """Calculate linear trend of data along a given coordinate.
 
@@ -135,6 +139,7 @@ def linear_trend(cube, coordinate="time"):
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def linear_trend_stderr(cube, coordinate="time"):
     """Calculate standard error of linear trend along a given coordinate.
 

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -7,7 +7,6 @@ depth or height regions; constructing volumetric averages;
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import Iterable, Literal, Optional, Sequence
 
 import dask.array as da
@@ -224,7 +223,6 @@ def _try_adding_calculated_ocean_volume(cube: Cube) -> None:
     required="prefer_at_least_one",
 )
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def volume_statistics(
     cube: Cube,
     operator: str,
@@ -302,7 +300,8 @@ def volume_statistics(
         _try_adding_calculated_ocean_volume,
     )
 
-    result = cube.collapsed([z_axis, y_axis, x_axis], agg, **agg_kwargs)
+    with ignore_iris_vague_metadata_warnings():
+        result = cube.collapsed([z_axis, y_axis, x_axis], agg, **agg_kwargs)
     if normalize is not None:
         result = get_normalized_cube(cube, result, normalize)
 
@@ -314,7 +313,6 @@ def volume_statistics(
 
 
 @preserve_float_dtype
-@ignore_iris_vague_metadata_warnings
 def axis_statistics(
     cube: Cube,
     axis: str,
@@ -387,16 +385,7 @@ def axis_statistics(
         coord=coord,
     )
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message=(
-                "Cannot check if coordinate is contiguous: Invalid "
-                "operation for '_axis_statistics_weights_'"
-            ),
-            category=UserWarning,
-            module="iris",
-        )
+    with ignore_iris_vague_metadata_warnings():
         result = cube.collapsed(coord, agg, **agg_kwargs)
 
     if normalize is not None:

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -21,6 +21,7 @@ from esmvalcore.preprocessor._shared import (
     get_coord_weights,
     get_iris_aggregator,
     get_normalized_cube,
+    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
     try_adding_calculated_cell_area,
     update_weights_kwargs,
@@ -223,6 +224,7 @@ def _try_adding_calculated_ocean_volume(cube: Cube) -> None:
     required="prefer_at_least_one",
 )
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def volume_statistics(
     cube: Cube,
     operator: str,
@@ -312,6 +314,7 @@ def volume_statistics(
 
 
 @preserve_float_dtype
+@ignore_iris_vague_metadata_warnings
 def axis_statistics(
     cube: Cube,
     axis: str,

--- a/esmvalcore/preprocessor/_volume.py
+++ b/esmvalcore/preprocessor/_volume.py
@@ -17,11 +17,11 @@ from iris.coords import AuxCoord, CellMeasure
 from iris.cube import Cube
 from iris.util import broadcast_to_shape
 
+from esmvalcore.iris_helpers import ignore_iris_vague_metadata_warnings
 from esmvalcore.preprocessor._shared import (
     get_coord_weights,
     get_iris_aggregator,
     get_normalized_cube,
-    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
     try_adding_calculated_cell_area,
     update_weights_kwargs,

--- a/tests/unit/preprocessor/test_shared.py
+++ b/tests/unit/preprocessor/test_shared.py
@@ -23,7 +23,6 @@ from esmvalcore.preprocessor._shared import (
     get_array_module,
     get_coord_weights,
     get_iris_aggregator,
-    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
     try_adding_calculated_cell_area,
 )
@@ -681,18 +680,3 @@ def test_get_coord_weights_triangular_bound_fail():
     )
     with pytest.raises(ValueError, match=msg):
         get_coord_weights(cube, "latitude")
-
-
-def test_ignore_iris_vague_metadata_warnings():
-    """Test ``ignore_iris_vague_metadata_warnings``."""
-
-    @ignore_iris_vague_metadata_warnings
-    def func():
-        # Collapse non-contiguous coord to check if warning has been raised
-        x_coord = DimCoord([0, 3], bounds=[[-1, 1], [2, 4]], var_name="x")
-        cube = Cube([1, 1], dim_coords_and_dims=[(x_coord, 0)])
-        return cube.collapsed("x", iris.analysis.MEAN)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        func()

--- a/tests/unit/preprocessor/test_shared.py
+++ b/tests/unit/preprocessor/test_shared.py
@@ -5,6 +5,7 @@ import warnings
 
 import dask.array as da
 import iris.analysis
+import iris.warnings
 import numpy as np
 import pytest
 from cf_units import Unit
@@ -22,6 +23,7 @@ from esmvalcore.preprocessor._shared import (
     get_array_module,
     get_coord_weights,
     get_iris_aggregator,
+    ignore_iris_vague_metadata_warnings,
     preserve_float_dtype,
     try_adding_calculated_cell_area,
 )
@@ -679,3 +681,18 @@ def test_get_coord_weights_triangular_bound_fail():
     )
     with pytest.raises(ValueError, match=msg):
         get_coord_weights(cube, "latitude")
+
+
+def test_ignore_iris_vague_metadata_warnings():
+    """Test ``ignore_iris_vague_metadata_warnings``."""
+
+    @ignore_iris_vague_metadata_warnings
+    def func():
+        # Collapse non-contiguous coord to check if warning has been raised
+        x_coord = DimCoord([0, 3], bounds=[[-1, 1], [2, 4]], var_name="x")
+        cube = Cube([1, 1], dim_coords_and_dims=[(x_coord, 0)])
+        return cube.collapsed("x", iris.analysis.MEAN)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        func()

--- a/tests/unit/preprocessor/test_shared.py
+++ b/tests/unit/preprocessor/test_shared.py
@@ -5,7 +5,6 @@ import warnings
 
 import dask.array as da
 import iris.analysis
-import iris.warnings
 import numpy as np
 import pytest
 from cf_units import Unit

--- a/tests/unit/test_iris_helpers.py
+++ b/tests/unit/test_iris_helpers.py
@@ -635,14 +635,9 @@ def test_safe_convert_units(
 
 def test_ignore_iris_vague_metadata_warnings():
     """Test ``ignore_iris_vague_metadata_warnings``."""
-
-    @ignore_iris_vague_metadata_warnings
-    def func():
-        # Collapse non-contiguous coord to check if warning has been raised
-        x_coord = DimCoord([0, 3], bounds=[[-1, 1], [2, 4]], var_name="x")
-        cube = Cube([1, 1], dim_coords_and_dims=[(x_coord, 0)])
-        return cube.collapsed("x", iris.analysis.MEAN)
-
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        func()
+        x_coord = DimCoord([0, 3], bounds=[[-1, 1], [2, 4]], var_name="x")
+        cube = Cube([1, 1], dim_coords_and_dims=[(x_coord, 0)])
+        with ignore_iris_vague_metadata_warnings():
+            cube.collapsed("x", iris.analysis.MEAN)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

See https://github.com/ESMValGroup/ESMValCore/pull/2625#issuecomment-2609185527. This ignores all potential [`iris.warnings.IrisVagueMetadataWarning`](https://scitools-iris.readthedocs.io/en/latest/generated/api/iris.warnings.html#iris.warnings.IrisVagueMetadataWarning) that can appear when collapsing/aggregating cubes in our preprocessors. This should be safe because we extensively check the corresponding coordinates in our CMOR checks.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


***
## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
