### PR TITLE
Fix test that loads realistic GRIB file

### DIFF
--- a/doc/develop/preprocessor_function.rst
+++ b/doc/develop/preprocessor_function.rst
@@ -244,11 +244,12 @@ and add the following content:
     """Test function `esmvalcore.preprocessor.example_preprocessor_function`."""
     from pathlib import Path
 
-    import esmvaltool_sample_data
     import iris
     import pytest
 
     from esmvalcore.preprocessor import example_preprocessor_function
+
+    esmvaltool_sample_data = pytest.importorskip("esmvaltool_sample_data")
 
 
     @pytest.mark.use_sample_data

--- a/tests/integration/preprocessor/_io/test_load.py
+++ b/tests/integration/preprocessor/_io/test_load.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 import warnings
+from importlib.resources import files as importlib_files
 from pathlib import Path
 
 import iris
@@ -11,7 +12,6 @@ import numpy as np
 from iris.coords import DimCoord
 from iris.cube import Cube, CubeList
 
-import esmvalcore
 from esmvalcore.preprocessor._io import load
 
 
@@ -56,12 +56,11 @@ class TestLoad(unittest.TestCase):
 
     def test_load_grib(self):
         """Test loading a grib file."""
-        grib_path = Path(
-            Path(esmvalcore.__file__).parents[1],
-            "tests",
-            "sample_data",
-            "iris-sample-data",
-            "polar_stereo.grib2",
+        grib_path = (
+            Path(importlib_files("tests"))
+            / "sample_data"
+            / "iris-sample-data"
+            / "polar_stereo.grib2"
         )
         cubes = load(grib_path)
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Fixes test that loads GRIB files on conda-forge. I am not sure how to test this properly, since the test worked fine on CircleCI before, but I am pretty confident that it works because we use that code for [another test](https://github.com/ESMValGroup/ESMValCore/blob/dd1e29cc1b28e396601b6d4463d8a65f558f8688/tests/unit/config/test_config.py#L40-L41) which seems to work fine on conda-forge.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/2664


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
