### PR TITLE
Update CMIP5 EC-EARTH pr fix

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
+++ b/esmvalcore/cmor/_fixes/cmip5/ec_earth.py
@@ -1,5 +1,7 @@
 """Fixes for EC-Earth model."""
 
+from collections.abc import Iterable
+
 import iris
 import numpy as np
 from dask import array as da
@@ -132,7 +134,9 @@ class Areacello(Fix):
 class Pr(Fix):
     """Fixes for pr."""
 
-    def fix_metadata(self, cubes):
+    def fix_metadata(
+        self, cubes: Iterable[iris.cube.Cube]
+    ) -> iris.cube.CubeList:
         """Fix time coordinate.
 
         Last file (2000-2009) has erroneously duplicated points
@@ -160,6 +164,8 @@ class Pr(Fix):
                 else:
                     # erase erroneously copy-pasted points
                     select = np.unique(time_coord.points, return_index=True)[1]
-                    new_list.append(cube[select])
+                    new_cube = cube[select]
+                    iris.util.promote_aux_coord_to_dim_coord(new_cube, "time")
+                    new_list.append(new_cube)
 
         return new_list

--- a/tests/integration/cmor/_fixes/cmip5/test_ec_earth.py
+++ b/tests/integration/cmor/_fixes/cmip5/test_ec_earth.py
@@ -187,7 +187,7 @@ class TestPr(unittest.TestCase):
             units="days since 1850-01-01",
         )
 
-        correct_time_coord = AuxCoord(
+        correct_time_coord = DimCoord(
             points=[1.0, 2.0, 3.0],
             var_name="time",
             standard_name="time",
@@ -216,7 +216,7 @@ class TestPr(unittest.TestCase):
         self.correct_cube = CubeList(
             [Cube(np.ones(3), var_name="pr", units="kg m-2 s-1")]
         )
-        self.correct_cube[0].add_aux_coord(correct_time_coord, 0)
+        self.correct_cube[0].add_dim_coord(correct_time_coord, 0)
 
         self.fix = Pr(None)
 
@@ -232,10 +232,10 @@ class TestPr(unittest.TestCase):
         out_wrong_cube = self.fix.fix_metadata(self.wrong_cube)
         out_correct_cube = self.fix.fix_metadata(self.correct_cube)
 
-        time = out_wrong_cube[0].coord("time")
+        time = out_wrong_cube[0].coord("time", dim_coords=True)
         assert time == self.time_coord
 
-        time = out_correct_cube[0].coord("time")
+        time = out_correct_cube[0].coord("time", dim_coords=True)
         assert time == self.time_coord
 
     def test_pr_fix_metadata_no_time(self):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

It looks like Iris loading changed so non-monotonic time coordinates are now added as `AuxCoord`s instead of `DimCoord`s and this broke the CMIP5 EC-EARTH pr fix.

This should fix recipe_impact.yml.

Related to ESMValGroup/ESMValTool#3916


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [ ] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [ ] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [ ] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [ ] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [ ] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
