### PR TITLE
Add option to ignore horizontal coordinates if there are multiple when regridding

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -887,6 +887,24 @@ The arguments are defined below:
   Otherwise, it cuts off at the previous value.
 * ``step_longitude``: Longitude distance between the centers of two neighbouring cells.
 
+Regridding input data with multiple horizontal coordinates
+----------------------------------------------------------
+
+When there are multiple horizontal coordinates available in the input data, the
+standard names of the coordinates to use need to be specified. By default, these
+are ``[latitude, longitude]``. To use a the coordinates from a
+`rotated pole grid <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#grid-mappings-and-projections>`__,
+one would specify:
+
+.. code-block:: yaml
+
+    preprocessors:
+      regrid_preprocessor:
+        regrid:
+          target_grid: 1x1
+          scheme: linear
+          use_src_coords: [grid_latitude, grid_longitude]
+
 Regridding (interpolation, extrapolation) schemes
 -------------------------------------------------
 

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -892,7 +892,7 @@ Regridding input data with multiple horizontal coordinates
 
 When there are multiple horizontal coordinates available in the input data, the
 standard names of the coordinates to use need to be specified. By default, these
-are ``[latitude, longitude]``. To use a the coordinates from a
+are ``[latitude, longitude]``. To use the coordinates from a
 `rotated pole grid <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#grid-mappings-and-projections>`__,
 one would specify:
 

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -10,6 +10,7 @@ import os
 import re
 import ssl
 import warnings
+from collections.abc import Iterable
 from copy import deepcopy
 from decimal import Decimal
 from pathlib import Path
@@ -745,6 +746,7 @@ def regrid(
     lat_offset: bool = True,
     lon_offset: bool = True,
     cache_weights: bool = False,
+    use_src_coords: Iterable[str] = ("latitude", "longitude"),
 ) -> Cube:
     """Perform horizontal regridding.
 
@@ -800,6 +802,9 @@ def regrid(
         support weights caching. More details on this are given in the section
         on :ref:`caching_regridding_weights`. To clear the cache, use
         :func:`esmvalcore.preprocessor.regrid.cache_clear`.
+    use_src_coords:
+        If there are multiple horizontal coordinates available in the source
+        cube, only use horizontal coordinates with these standard names.
 
     Returns
     -------
@@ -848,6 +853,16 @@ def regrid(
             scheme:
               reference: esmf_regrid.schemes:ESMFAreaWeighted
     """
+    # Remove unwanted coordinates from the source cube.
+    cube = cube.copy()
+    use_src_coords = set(use_src_coords)
+    for axis in ("X", "Y"):
+        coords = cube.coords(axis=axis)
+        if len(coords) > 1:
+            for coord in coords:
+                if coord.standard_name not in use_src_coords:
+                    cube.remove_coord(coord)
+
     # Load target grid and select appropriate scheme
     target_grid_cube = _get_target_grid_cube(
         cube,
@@ -858,15 +873,16 @@ def regrid(
 
     # Horizontal grids from source and target (almost) match
     # -> Return source cube with target coordinates
-    if _horizontal_grid_is_close(cube, target_grid_cube):
-        for coord in ["latitude", "longitude"]:
-            cube.coord(coord).points = target_grid_cube.coord(
-                coord
-            ).core_points()
-            cube.coord(coord).bounds = target_grid_cube.coord(
-                coord
-            ).core_bounds()
-        return cube
+    if cube.coords("latitude") and cube.coords("longitude"):
+        if _horizontal_grid_is_close(cube, target_grid_cube):
+            for coord in ["latitude", "longitude"]:
+                cube.coord(coord).points = target_grid_cube.coord(
+                    coord
+                ).core_points()
+                cube.coord(coord).bounds = target_grid_cube.coord(
+                    coord
+                ).core_bounds()
+            return cube
 
     # Load scheme and reuse existing regridder if possible
     if isinstance(scheme, str):

--- a/tests/unit/preprocessor/_regrid/__init__.py
+++ b/tests/unit/preprocessor/_regrid/__init__.py
@@ -37,12 +37,12 @@ def _make_vcoord(data, dtype=None):
 
 
 def _make_cube(
-    data,
-    aux_coord=True,
-    dim_coord=True,
+    data: np.ndarray,
+    aux_coord: bool = True,
+    dim_coord: bool = True,
     dtype=None,
     grid: Literal["regular", "rotated", "mesh"] = "regular",
-):
+) -> iris.cube.Cube:
     """Create a 3d synthetic test cube."""
     if dtype is None:
         dtype = np.int32

--- a/tests/unit/preprocessor/_regrid/test_regrid.py
+++ b/tests/unit/preprocessor/_regrid/test_regrid.py
@@ -233,7 +233,7 @@ def test_regrid_is_skipped_if_grids_are_the_same():
 
     # regridding to the same spec returns the same cube
     expected_same_cube = regrid(cube, target_grid="10x10", scheme=scheme)
-    assert expected_same_cube is cube
+    assert expected_same_cube == cube
 
     # regridding to a different spec returns a different cube
     expected_different_cube = regrid(cube, target_grid="5x5", scheme=scheme)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Add an option to ignore horizontal coordinates if there are multiple when regridding.

For example, some files provide both 'latitude' and 'grid_latitude'. This uses 'latitude' by default, but 'grid_latitude' can be selected from the recipe.

Related to https://github.com/ESMValGroup/ESMValTool/issues/3916#issuecomment-2671272258

Link to documentation:
- https://esmvaltool--2672.org.readthedocs.build/projects/ESMValCore/en/2672/api/esmvalcore.preprocessor.html#esmvalcore.preprocessor.regrid
- https://esmvaltool--2672.org.readthedocs.build/projects/ESMValCore/en/2672/recipe/preprocessor.html#regridding-input-data-with-multiple-horizontal-coordinates

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
