### PR TITLE
Always write target coordinates to source cube after regridding

### DIFF
--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -860,12 +860,17 @@ def regrid(
     # -> Return source cube with target coordinates
     if _horizontal_grid_is_close(cube, target_grid_cube):
         for coord in ["latitude", "longitude"]:
-            cube.coord(coord).points = target_grid_cube.coord(
-                coord
-            ).core_points()
-            cube.coord(coord).bounds = target_grid_cube.coord(
-                coord
-            ).core_bounds()
+            if cube.coords(coord, dim_coords=True):
+                is_dim_coord = True
+            else:
+                is_dim_coord = False
+            coord_dims = cube.coord_dims(coord)
+            cube.remove_coord(coord)
+            target_coord = target_grid_cube.coord(coord).copy()
+            if is_dim_coord:
+                cube.add_dim_coord(target_coord, coord_dims)
+            else:
+                cube.add_aux_coord(target_coord, coord_dims)
         return cube
 
     # Load scheme and reuse existing regridder if possible

--- a/esmvalcore/preprocessor/_regrid.py
+++ b/esmvalcore/preprocessor/_regrid.py
@@ -876,10 +876,7 @@ def regrid(
     if cube.coords("latitude") and cube.coords("longitude"):
         if _horizontal_grid_is_close(cube, target_grid_cube):
             for coord in ["latitude", "longitude"]:
-                if cube.coords(coord, dim_coords=True):
-                    is_dim_coord = True
-                else:
-                    is_dim_coord = False
+                is_dim_coord = cube.coords(coord, dim_coords=True)
                 coord_dims = cube.coord_dims(coord)
                 cube.remove_coord(coord)
                 target_coord = target_grid_cube.coord(coord).copy()

--- a/tests/unit/preprocessor/_regrid/test_regrid.py
+++ b/tests/unit/preprocessor/_regrid/test_regrid.py
@@ -226,17 +226,34 @@ def test_horizontal_grid_is_close(cube2_spec: dict, expected: bool):
     assert _horizontal_grid_is_close(cube1, cube2) == expected
 
 
-def test_regrid_is_skipped_if_grids_are_the_same():
+def test_regrid_is_skipped_if_grids_are_the_same_dim_coord():
     """Test that regridding is skipped if the grids are the same."""
     cube = _make_cube(lat=LAT_SPEC1, lon=LON_SPEC1)
-    scheme = "linear"
-
-    # regridding to the same spec returns the same cube
-    expected_same_cube = regrid(cube, target_grid="10x10", scheme=scheme)
+    expected_same_cube = regrid(cube, target_grid="10x10", scheme="linear")
     assert expected_same_cube is cube
+    assert cube.coords("latitude", dim_coords=True)
+    assert cube.coords("longitude", dim_coords=True)
 
-    # regridding to a different spec returns a different cube
-    expected_different_cube = regrid(cube, target_grid="5x5", scheme=scheme)
+
+def test_regrid_is_skipped_if_grids_are_the_same_aux_coord():
+    """Test that regridding is skipped if the grids are the same."""
+    cube = _make_cube(lat=LAT_SPEC1, lon=LON_SPEC1)
+    lat = cube.coord("latitude")
+    lon = cube.coord("longitude")
+    cube.remove_coord(lat)
+    cube.remove_coord(lon)
+    cube.add_aux_coord(lat, 0)
+    cube.add_aux_coord(lon, 1)
+    expected_same_cube = regrid(cube, target_grid="10x10", scheme="linear")
+    assert expected_same_cube is cube
+    assert cube.coords("latitude", dim_coords=False)
+    assert cube.coords("longitude", dim_coords=False)
+
+
+def test_regrid_is_not_skipped_if_grids_are_different():
+    """Test that regridding is not skipped if the grids are different."""
+    cube = _make_cube(lat=LAT_SPEC1, lon=LON_SPEC1)
+    expected_different_cube = regrid(cube, target_grid="5x5", scheme="linear")
     assert expected_different_cube is not cube
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

If the source grid and target grid for regridding are sufficiently similar, [the operation is skipped](https://github.com/ESMValGroup/ESMValCore/blob/always_overwrite_coords_after_regrid/esmvalcore/preprocessor/_regrid.py#L861). Currently, in this case, the target grid coordinates' points and bounds are written to the source cube, but **not** other metadata. This might lead to problems in subsequent preprocessor functions (e.g., `distance_metric`) or diagnostics that expect cubes to have identical coordinate metadata.

Here, this is fixed by always assigning the target coordinates themselves to the source cube, not only their points and bounds.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
