### PR TITLE
test codacy ruff

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -12,8 +12,10 @@ engines:
         enabled: true
     duplication:
         enabled: true
+    # introduced 5 March 2025
     ruff:
         enabled: true
+    # to be removed when all Ruff integration done
     prospector:
         enabled: true
     pylint:


### PR DESCRIPTION
Test PR where we can test all the bits and bobs related to the new codacy-ruff integration and fix things all along. Ruff is now integrated and configured in our Codacy, but there may be issues.