### PR TITLE
Fix for obs4MIPs dataset C3S-GTO-ECV-9-0 (toz)

### DIFF
--- a/esmvalcore/cmor/_fixes/obs4mips/c3s_gto_ecv_9_0.py
+++ b/esmvalcore/cmor/_fixes/obs4mips/c3s_gto_ecv_9_0.py
@@ -1,6 +1,7 @@
 """Fixes for obs4MIPs dataset C3S-GTO-ECV-9-0."""
 
 import dask.array as da
+from iris.cube import Cube
 
 from ..fix import Fix
 
@@ -8,19 +9,19 @@ from ..fix import Fix
 class Toz(Fix):
     """Fixes for toz."""
 
-    def fix_data(self, cube):
+    def fix_data(self, cube: Cube) -> Cube:
         """Fix data.
 
-        Convert nan's to fill missing values.
+        Mask nan's.
 
         Parameters
         ----------
-        cube: iris.cube
+        cube:
             Input cube.
 
         Returns
         -------
-        iris.cube
+        iris.cube.Cube
             Fixed cube.
 
         """

--- a/esmvalcore/cmor/_fixes/obs4mips/c3s_gto_ecv_9_0.py
+++ b/esmvalcore/cmor/_fixes/obs4mips/c3s_gto_ecv_9_0.py
@@ -1,0 +1,28 @@
+"""Fixes for obs4MIPs dataset C3S-GTO-ECV-9-0."""
+
+import dask.array as da
+
+from ..fix import Fix
+
+
+class Toz(Fix):
+    """Fixes for toz."""
+
+    def fix_data(self, cube):
+        """Fix data.
+
+        Convert nan's to fill missing values.
+
+        Parameters
+        ----------
+        cube: iris.cube
+            Input cube.
+
+        Returns
+        -------
+        iris.cube
+            Fixed cube.
+
+        """
+        cube.data = da.ma.fix_invalid(cube.core_data())
+        return cube

--- a/tests/integration/cmor/_fixes/obs4mips/test_c3s_gto_ecv_9_0.py
+++ b/tests/integration/cmor/_fixes/obs4mips/test_c3s_gto_ecv_9_0.py
@@ -1,0 +1,17 @@
+"""Test C3S-GTO-ECV-9-0 fixes."""
+
+import numpy as np
+from iris.cube import Cube
+
+from esmvalcore.cmor.fix import fix_data
+from tests import assert_array_equal
+
+
+def test_fix_data_toz():
+    """Test ``fix_data`` for toz."""
+    cube = Cube([np.nan, 2.0])
+
+    fixed_cube = fix_data(cube, "toz", "obs4MIPs", "C3S-GTO-ECV-9-0", "Amon")
+
+    assert not np.isnan(fixed_cube.data).any()
+    assert_array_equal(fixed_cube.data, np.ma.array([np.ma.masked, 2.0]))


### PR DESCRIPTION
## Description

This fix converts any nan's in the obs4MIPs dataset "GTO-ECV-9-0" (total ozone columns, toz) into missing values. This is needed to allow for e.g. applying the area statistics preprocessor.

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful