### PR TITLE
Use `netCDF4.Dataset` to read start and end date from files

### DIFF
--- a/esmvalcore/local.py
+++ b/esmvalcore/local.py
@@ -70,8 +70,8 @@ def _get_var_name(variable: Variable) -> str:
     """Get variable name (following Iris' Cube.name())."""
     for attr in ("standard_name", "long_name"):
         if attr in variable.ncattrs():
-            return variable.getncattr(attr)
-    return variable.name
+            return str(variable.getncattr(attr))
+    return str(variable.name)
 
 
 def _get_start_end_date(

--- a/tests/unit/local/test_time.py
+++ b/tests/unit/local/test_time.py
@@ -166,7 +166,7 @@ def test_read_years_from_cube(tmp_path):
     temp_file = LocalFile(tmp_path / "test.nc")
     cube = iris.cube.Cube([0, 0, 0, 0], var_name="var")
     time = iris.coords.DimCoord(
-        [0, 100, 200, 366], "time", units="days since 1990-01-01"
+        [0, 100, 200, 366], standard_name="time", units="days since 1990-01-01"
     )
     cube.add_dim_coord(time, 0)
     iris.save(cube, temp_file)
@@ -180,7 +180,11 @@ def test_read_datetime_from_cube(tmp_path):
     temp_file = tmp_path / "test.nc"
     cube = iris.cube.Cube([0, 0, 0, 0], var_name="var")
     time = iris.coords.DimCoord(
-        [0, 100, 200, 366], "time", units="days since 1990-01-01"
+        [0, 100, 200, 366],
+        standard_name=None,
+        long_name="time",
+        var_name="t",
+        units="days since 1990-01-01",
     )
     cube.add_dim_coord(time, 0)
     iris.save(cube, temp_file)
@@ -193,6 +197,13 @@ def test_raises_if_unable_to_deduce_no_time(tmp_path):
     """Try to get time from cube if no date in filename."""
     temp_file = tmp_path / "test.nc"
     cube = iris.cube.Cube([0, 0], var_name="var")
+    not_time = iris.coords.DimCoord(
+        [0, 366],
+        var_name="time",
+        long_name="not_time",
+        units="days since 2000-01-01",
+    )
+    cube.add_dim_coord(not_time, 0)
     iris.save(cube, temp_file)
     with pytest.raises(ValueError):
         _get_start_end_date(temp_file)

--- a/tests/unit/local/test_time.py
+++ b/tests/unit/local/test_time.py
@@ -161,10 +161,9 @@ def test_get_start_end_date(case):
         assert case_end == end
 
 
-def test_read_years_from_cube(monkeypatch, tmp_path):
+def test_read_years_from_cube(tmp_path):
     """Try to get years from cube if no date in filename."""
-    monkeypatch.chdir(tmp_path)
-    temp_file = LocalFile("test.nc")
+    temp_file = LocalFile(tmp_path / "test.nc")
     cube = iris.cube.Cube([0, 0], var_name="var")
     time = iris.coords.DimCoord(
         [0, 366], "time", units="days since 1990-01-01"
@@ -176,10 +175,9 @@ def test_read_years_from_cube(monkeypatch, tmp_path):
     assert end == 1991
 
 
-def test_read_datetime_from_cube(monkeypatch, tmp_path):
+def test_read_datetime_from_cube(tmp_path):
     """Try to get datetime from cube if no date in filename."""
-    monkeypatch.chdir(tmp_path)
-    temp_file = "test.nc"
+    temp_file = tmp_path / "test.nc"
     cube = iris.cube.Cube([0, 0], var_name="var")
     time = iris.coords.DimCoord(
         [0, 366], "time", units="days since 1990-01-01"
@@ -191,11 +189,23 @@ def test_read_datetime_from_cube(monkeypatch, tmp_path):
     assert end == "19910102"
 
 
-def test_raises_if_unable_to_deduce(monkeypatch, tmp_path):
+def test_raises_if_unable_to_deduce_no_time(tmp_path):
     """Try to get time from cube if no date in filename."""
-    monkeypatch.chdir(tmp_path)
-    temp_file = "test.nc"
+    temp_file = tmp_path / "test.nc"
     cube = iris.cube.Cube([0, 0], var_name="var")
+    iris.save(cube, temp_file)
+    with pytest.raises(ValueError):
+        _get_start_end_date(temp_file)
+    with pytest.raises(ValueError):
+        _get_start_end_year(temp_file)
+
+
+def test_raises_if_unable_to_deduce_no_time_units(tmp_path):
+    """Try to get time from cube if no date in filename."""
+    temp_file = tmp_path / "test.nc"
+    cube = iris.cube.Cube([0, 0], var_name="var")
+    time = iris.coords.DimCoord([0, 366], "time")
+    cube.add_dim_coord(time, 0)
     iris.save(cube, temp_file)
     with pytest.raises(ValueError):
         _get_start_end_date(temp_file)

--- a/tests/unit/local/test_time.py
+++ b/tests/unit/local/test_time.py
@@ -164,9 +164,9 @@ def test_get_start_end_date(case):
 def test_read_years_from_cube(tmp_path):
     """Try to get years from cube if no date in filename."""
     temp_file = LocalFile(tmp_path / "test.nc")
-    cube = iris.cube.Cube([0, 0], var_name="var")
+    cube = iris.cube.Cube([0, 0, 0, 0], var_name="var")
     time = iris.coords.DimCoord(
-        [0, 366], "time", units="days since 1990-01-01"
+        [0, 100, 200, 366], "time", units="days since 1990-01-01"
     )
     cube.add_dim_coord(time, 0)
     iris.save(cube, temp_file)
@@ -178,9 +178,9 @@ def test_read_years_from_cube(tmp_path):
 def test_read_datetime_from_cube(tmp_path):
     """Try to get datetime from cube if no date in filename."""
     temp_file = tmp_path / "test.nc"
-    cube = iris.cube.Cube([0, 0], var_name="var")
+    cube = iris.cube.Cube([0, 0, 0, 0], var_name="var")
     time = iris.coords.DimCoord(
-        [0, 366], "time", units="days since 1990-01-01"
+        [0, 100, 200, 366], "time", units="days since 1990-01-01"
     )
     cube.add_dim_coord(time, 0)
     iris.save(cube, temp_file)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

If start and end dates cannot be read from a file's name, we currently use [Iris to load the file and determine the dates from the time coordinate](https://github.com/ESMValGroup/ESMValCore/blob/0533aa1fcf9ba7610870ce6fe28627d0e19dc258/esmvalcore/local.py#L132-L154). This is particular relevant for native model output where the date in the filename can have arbitrary formats.

This native model output (in my particular case data from ICON and EMAC) usually contains lots of variables (sometimes hundreds) in a single netCDF file, and also consists of hundreds of netCDF files per dataset (sometimes one file only contains a single time step). Since reading netCDF files with many variables can be [very slow with Iris](https://github.com/SciTools/iris/issues/6223), this can lead to enormous run times (I've see logs where ESMValTool spent hours to read the dates from the files).

To make this process MUCH faster, this PR here uses `netCDF4.Dataset` to extract the dates from the files. Since those files are loaded just once for this one particular purpose, we don't need any fancy features of Iris but can simply rely on netCDF4. Here's an overview of the different load times (the file, which is an actual EMAC output file, contains 855 variables):

```py
path = "/path/to/real_EMAC_file_with_855_variables.nc"

%%timeit
iris.load(path)
# 1min 47s ± 446 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
xr.open_dataset(path, chunks="auto")
# 277 ms ± 8.14 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%%timeit
netCDF4.Dataset(path, mode="r")
# 5.2 ms ± 23.7 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

As you can see, using netCDF4.Dataset instead of Iris is over 21000 times faster!

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
