### PR TITLE
Allow forcing the usage of new configuration system with environment variable

### DIFF
--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -399,7 +399,9 @@ class ESMValTool:
         # https://github.com/ESMValGroup/ESMValCore/issues/2280), but no error
         # has been raised if the file does not exist. Thus, reload the file
         # here with `load_from_file` to make sure a proper error is raised.
-        if "config_file" in kwargs:
+        if "config_file" in kwargs and not os.environ.get(
+            "ESMVALTOOL_USE_NEW_CONFIG"
+        ):
             cli_config_dir = kwargs["config_file"]
             CFG.load_from_file(kwargs["config_file"])
 

--- a/esmvalcore/config/_config_object.py
+++ b/esmvalcore/config/_config_object.py
@@ -388,16 +388,20 @@ class Config(ValidatedConfig):
         # TODO: remove in v2.14.0
         self.clear()
         _deprecated_config_user_path = Config._get_config_user_path()
-        if _deprecated_config_user_path.is_file():
+        if _deprecated_config_user_path.is_file() and not os.environ.get(
+            "ESMVALTOOL_USE_NEW_CONFIG"
+        ):
             deprecation_msg = (
                 f"Usage of the single configuration file "
                 f"~/.esmvaltool/config-user.yml or specifying it via CLI "
                 f"argument `--config_file` has been deprecated in ESMValCore "
                 f"version 2.12.0 and is scheduled for removal in version "
-                f"2.14.0. Please run `mkdir -p ~/.config/esmvaltool && mv "
+                f"2.14.0. To switch to the new configuration system, (1) run "
+                f"`mkdir -p ~/.config/esmvaltool && mv "
                 f"{_deprecated_config_user_path} ~/.config/esmvaltool` (or "
                 f"alternatively use a custom `--config_dir`) and omit "
-                f"`--config_file`."
+                f"`--config_file`, or (2) set the environment variable "
+                f"ESMVALTOOL_USE_NEW_CONFIG=1."
             )
             warnings.warn(
                 deprecation_msg, ESMValCoreDeprecationWarning, stacklevel=2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,9 @@ from esmvalcore.config._config_object import _get_global_config
 
 
 @pytest.fixture
-def cfg_default():
+def cfg_default(monkeypatch):
     """Create a configuration object with default values."""
+    monkeypatch.setenv("ESMVALTOOL_USE_NEW_CONFIG", "1")
     cfg = _get_global_config()
     cfg.load_from_dirs([])
     return cfg

--- a/tests/unit/config/test_config_object.py
+++ b/tests/unit/config/test_config_object.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from collections.abc import MutableMapping
 from pathlib import Path
 from textwrap import dedent
@@ -395,8 +396,30 @@ def test_get_user_config_dir_with_env_fail(tmp_path, monkeypatch):
 
 
 # TODO: remove in v2.14.0
-def test_get_global_config_deprecated(mocker, tmp_path):
+def test_get_global_config_force_new_config(mocker, tmp_path, monkeypatch):
     """Test ``_get_global_config``."""
+    monkeypatch.setenv("ESMVALTOOL_USE_NEW_CONFIG", "1")
+
+    # Create invalid old config file to ensure that this is not used
+    config_file = tmp_path / "old_config_user.yml"
+    config_file.write_text("invalid_option: /new/output/dir")
+    mocker.patch.object(
+        esmvalcore.config._config_object.Config,
+        "_get_config_user_path",
+        return_value=config_file,
+    )
+
+    # No deprecation message should be raised
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        esmvalcore.config._config_object._get_global_config()
+
+
+# TODO: remove in v2.14.0
+def test_get_global_config_deprecated(mocker, tmp_path, monkeypatch):
+    """Test ``_get_global_config``."""
+    monkeypatch.delenv("ESMVALTOOL_USE_NEW_CONFIG", raising=False)
+
     config_file = tmp_path / "old_config_user.yml"
     config_file.write_text("output_dir: /new/output/dir")
     mocker.patch.object(
@@ -472,9 +495,7 @@ def _setup_config_dirs(tmp_path):
         ),
     ],
 )
-def test_load_from_dirs_always_default(
-    dirs, output_file_type, rootpath, tmp_path
-):
+def test_load_from_dirs(dirs, output_file_type, rootpath, tmp_path):
     """Test `Config.load_from_dirs`."""
     _setup_config_dirs(tmp_path)
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR makes it possible to force using our [new configuration system](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/quickstart/configure.html#configuration) via the environment variable `ESMVALTOOL_USE_NEW_CONFIG`.

This is important feature for "encapsulated" ESMValTool runs (e.g., when used within the REF) that should work independently from the user's personal ESMValTool configuration. 

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
