### PR TITLE
Fix sign of ERA5 rlut and rlutcs

### DIFF
--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -337,6 +337,18 @@ class Rlns(Fix):
         return cubes
 
 
+class Rls(Fix):
+    """Fixes for Rls."""
+
+    def fix_metadata(self, cubes):
+        """Fix metadata."""
+        for cube in cubes:
+            fix_hourly_time_coordinate(cube)
+            cube.attributes["positive"] = "down"
+
+        return cubes
+
+
 class Rlus(Fix):
     """Fixes for Rlus."""
 
@@ -350,16 +362,22 @@ class Rlus(Fix):
         return cubes
 
 
-class Rls(Fix):
-    """Fixes for Rls."""
+class Rlut(Fix):
+    """Fixes for Rlut."""
 
-    def fix_metadata(self, cubes):
-        """Fix metadata."""
-        for cube in cubes:
-            fix_hourly_time_coordinate(cube)
-            cube.attributes["positive"] = "down"
+    def fix_data(self, cube):
+        """Fix data."""
+        cube.attributes["positive"] = "up"
+        return -cube
 
-        return cubes
+
+class Rlutcs(Fix):
+    """Fixes for Rlutcs."""
+
+    def fix_data(self, cube):
+        """Fix data."""
+        cube.attributes["positive"] = "up"
+        return -cube
 
 
 class Rsds(Fix):

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -5,6 +5,7 @@ import logging
 
 import iris
 import numpy as np
+from iris.cube import CubeList
 from iris.util import reverse
 
 from esmvalcore.cmor._fixes.fix import Fix
@@ -235,7 +236,7 @@ class Orog(Fix):
             cube = remove_time_coordinate(cube)
             divide_by_gravity(cube)
             fixed_cubes.append(cube)
-        return iris.cube.CubeList(fixed_cubes)
+        return CubeList(fixed_cubes)
 
 
 class Pr(Fix):
@@ -365,19 +366,27 @@ class Rlus(Fix):
 class Rlut(Fix):
     """Fixes for Rlut."""
 
-    def fix_data(self, cube):
-        """Fix data."""
-        cube.attributes["positive"] = "up"
-        return -cube
+    def fix_metadata(self, cubes):
+        """Fix metadata."""
+        fixed_cubes = CubeList()
+        for cube in cubes:
+            cube.attributes["positive"] = "up"
+            fixed_cubes.append(-cube)
+
+        return fixed_cubes
 
 
 class Rlutcs(Fix):
     """Fixes for Rlutcs."""
 
-    def fix_data(self, cube):
-        """Fix data."""
-        cube.attributes["positive"] = "up"
-        return -cube
+    def fix_metadata(self, cubes):
+        """Fix metadata."""
+        fixed_cubes = CubeList()
+        for cube in cubes:
+            cube.attributes["positive"] = "up"
+            fixed_cubes.append(-cube)
+
+        return fixed_cubes
 
 
 class Rsds(Fix):
@@ -591,7 +600,7 @@ class AllVars(Fix):
 
     def fix_metadata(self, cubes):
         """Fix metadata."""
-        fixed_cubes = iris.cube.CubeList()
+        fixed_cubes = CubeList()
         for cube in cubes:
             cube.var_name = self.vardef.short_name
             if self.vardef.standard_name:

--- a/tests/integration/cmor/_fixes/native6/test_era5.py
+++ b/tests/integration/cmor/_fixes/native6/test_era5.py
@@ -915,11 +915,42 @@ def rlut_cmor_amon():
 
 
 def rlutcs_era5_monthly():
-    return rlut_era5_monthly()
+    freq = "monthly"
+    cube = Cube(
+        _era5_data(freq),
+        long_name=None,
+        var_name=None,
+        units="W m**-2",
+        dim_coords_and_dims=[
+            (_era5_time(freq), 0),
+            (_era5_latitude(), 1),
+            (_era5_longitude(), 2),
+        ],
+    )
+    return CubeList([cube])
 
 
 def rlutcs_cmor_amon():
-    return rlut_cmor_amon()
+    mip = "Amon"
+    short_name = "rlutcs"
+    cmor_table = CMOR_TABLES["native6"]
+    vardef = cmor_table.get_variable(mip, short_name)
+    time = _cmor_time(mip, shifted=True, bounds=True)
+    data = -_cmor_data(mip)
+    cube = Cube(
+        data.astype("float32"),
+        long_name=vardef.long_name,
+        var_name=vardef.short_name,
+        standard_name=vardef.standard_name,
+        units=Unit(vardef.units),
+        dim_coords_and_dims=[
+            (time, 0),
+            (_cmor_latitude(), 1),
+            (_cmor_longitude(), 2),
+        ],
+        attributes={"comment": COMMENT, "positive": "up"},
+    )
+    return CubeList([cube])
 
 
 def rls_era5_hourly():
@@ -1490,7 +1521,7 @@ VARIABLES = [
         (rlns_era5_hourly(), rlns_cmor_e1hr(), "rlns", "E1hr"),
         (rlus_era5_hourly(), rlus_cmor_e1hr(), "rlus", "E1hr"),
         (rlut_era5_monthly(), rlut_cmor_amon(), "rlut", "Amon"),
-        (rlutcs_era5_monthly(), rlutcs_cmor_amon(), "rlut", "Amon"),
+        (rlutcs_era5_monthly(), rlutcs_cmor_amon(), "rlutcs", "Amon"),
         (rls_era5_hourly(), rls_cmor_e1hr(), "rls", "E1hr"),
         (rsds_era5_hourly(), rsds_cmor_e1hr(), "rsds", "E1hr"),
         (rsns_era5_hourly(), rsns_cmor_e1hr(), "rsns", "E1hr"),

--- a/tests/integration/cmor/_fixes/native6/test_era5.py
+++ b/tests/integration/cmor/_fixes/native6/test_era5.py
@@ -17,9 +17,9 @@ from esmvalcore.cmor._fixes.native6.era5 import (
     fix_accumulated_units,
     get_frequency,
 )
-from esmvalcore.cmor.fix import fix_data, fix_metadata
+from esmvalcore.cmor.fix import fix_metadata
 from esmvalcore.cmor.table import CMOR_TABLES, get_var_info
-from esmvalcore.preprocessor import cmor_check_data, cmor_check_metadata
+from esmvalcore.preprocessor import cmor_check_metadata
 
 COMMENT = (
     "Contains modified Copernicus Climate Change Service Information "
@@ -1519,7 +1519,7 @@ VARIABLES = [
 @pytest.mark.parametrize(("era5_cubes", "cmor_cubes", "var", "mip"), VARIABLES)
 def test_cmorization(era5_cubes, cmor_cubes, var, mip):
     """Verify that cmorization results in the expected target cube."""
-    fixed_cubes = fix_metadata(era5_cubes, var, "native6", "ERA5", mip)
+    fixed_cubes = fix_metadata(era5_cubes, var, "native6", "era5", mip)
 
     assert len(fixed_cubes) == 1
     fixed_cube = fixed_cubes[0]
@@ -1527,11 +1527,6 @@ def test_cmorization(era5_cubes, cmor_cubes, var, mip):
 
     # Test that CMOR checks are passing
     fixed_cubes = cmor_check_metadata(fixed_cube, "native6", mip, var)
-
-    fixed_cube = fix_data(fixed_cube, var, "native6", "ERA5", mip)
-
-    # Test that CMOR checks are passing
-    fixed_cube = cmor_check_data(fixed_cube, "native6", mip, var)
 
     if fixed_cube.coords("time"):
         for cube in [fixed_cube, cmor_cube]:


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

ERA5's rlut and rlutcs are negative, but need to be positive. Here is an example plot of the LWCRE (rlutcs - rlut):

![grafik](https://github.com/user-attachments/assets/a9bfedb0-f37d-46e4-b455-e946e7a85dbc)

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->



***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
