### PR TITLE
Fix test for upstream iris version

### DIFF
--- a/tests/unit/test_iris_helpers.py
+++ b/tests/unit/test_iris_helpers.py
@@ -23,7 +23,7 @@ from iris.coords import (
 )
 from iris.cube import Cube, CubeList
 from iris.exceptions import CoordinateMultiDimError, UnitConversionError
-from iris.warnings import IrisUnknownCellMethodWarning
+from iris.warnings import IrisLoadWarning, IrisUnknownCellMethodWarning
 
 from esmvalcore.iris_helpers import (
     add_leading_dim_to_cube,
@@ -732,9 +732,20 @@ def test_dataset_to_iris_ignore_warnings(conversion_func, dummy_cubes):
     else:
         dataset.variables["ta"].attributes["units"] = "invalid_units"
 
+    ignore_warnings = [
+        {
+            "message": (
+                r"Not all file objects were parsed correctly. See "
+                r"iris.loading.LOAD_PROBLEMS for details."
+            ),
+            "category": IrisLoadWarning,
+            "module": "iris",
+        },
+    ]
+
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        dataset_to_iris(dataset)
+        dataset_to_iris(dataset, ignore_warnings=ignore_warnings)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

See https://app.circleci.com/pipelines/github/ESMValGroup/ESMValCore/13212/workflows/bcd3a837-8165-4855-ba6c-3b4f54b9e951/jobs/54704.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
