### PR TITLE
Improve error message if cubes do not overlap in time in `multi_model_statistics` with `span=overlap`

### DIFF
--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from functools import reduce
+from pprint import pformat
 from typing import TYPE_CHECKING
 
 import cf_units
@@ -228,9 +229,14 @@ def _align_time_coord(cubes, span):
             f"Invalid argument for span: {span!r}"
             "Must be one of 'overlap', 'full'."
         )
-        raise ValueError(
-            msg,
+        raise ValueError(msg)
+
+    if new_time_points.size == 0:
+        msg = (
+            f"Cannot align time coordinates with strategy '{span}', resulting "
+            f"time coordinate is empty. Input cubes:\n{pformat(cubes)}"
         )
+        raise ValueError(msg)
 
     new_cubes = [_map_to_new_time(cube, new_time_points) for cube in cubes]
 

--- a/esmvalcore/preprocessor/_multimodel.py
+++ b/esmvalcore/preprocessor/_multimodel.py
@@ -105,9 +105,7 @@ def _unify_time_coordinates(cubes):
                 "Multimodel statistics preprocessor currently does not "
                 "support sub-daily data."
             )
-            raise ValueError(
-                msg,
-            )
+            raise ValueError(msg)
 
         # Update the cubes' time coordinate (both point values and the units!)
         cube.coord("time").points = date2num(dates, t_unit, coord.dtype)
@@ -195,9 +193,7 @@ def _map_to_new_time(cube, time_points):
             f"Tried to align cubes in multi-model statistics, but failed for "
             f"cube {cube}\n and time points {time_points}.{additional_info}"
         )
-        raise ValueError(
-            msg,
-        ) from excinfo
+        raise ValueError(msg) from excinfo
 
     # Change the dtype of int_time_coords to their original values
     for coord_name in int_time_coords:

--- a/tests/sample_data/multimodel_statistics/test_multimodel.py
+++ b/tests/sample_data/multimodel_statistics/test_multimodel.py
@@ -359,7 +359,12 @@ def test_multimodel_0d_1d_time_no_ignore_scalars(timeseries_cubes_month, span):
     cubes = [cube[:, 0] for cube in timeseries_cubes_month]  # remove Z-dim
     cubes[1] = cubes[1][0]  # use 0D time dim for one cube
 
-    msg = "Tried to align cubes in multi-model statistics, but failed for cube"
+    if span == "overlap":
+        msg = r"Cannot align time coordinates with strategy 'overlap'"
+    elif span == "full":
+        msg = r"Tried to align cubes in multi-model statistics"
+    else:
+        pytest.fail(f"Invalid span '{span}' given")
     with pytest.raises(ValueError, match=msg):
         multimodel_test(cubes, span=span, statistic="mean")
 
@@ -435,7 +440,12 @@ def test_multimodel_diff_scalar_time_fail(timeseries_cubes_month, span):
     cubes[1].coord("time").points = 20.0
     cubes[1].coord("time").bounds = [0.0, 40.0]
 
-    msg = "Tried to align cubes in multi-model statistics, but failed for cube"
+    if span == "overlap":
+        msg = r"Cannot align time coordinates with strategy 'overlap'"
+    elif span == "full":
+        msg = r"Tried to align cubes in multi-model statistics"
+    else:
+        pytest.fail(f"Invalid span '{span}' given")
     with pytest.raises(ValueError, match=msg):
         multimodel_test(cubes, span=span, statistic="mean")
 

--- a/tests/unit/preprocessor/_multimodel/test_multimodel.py
+++ b/tests/unit/preprocessor/_multimodel/test_multimodel.py
@@ -531,6 +531,20 @@ def test_align(span):
     assert next(iter(shapes)) == (len_data,)
 
 
+def test_align_no_overlap():
+    """Test _align function."""
+    # Create two cubes that do not overlap in time
+    cubes = [
+        generate_cube_from_dates("monthly"),
+        generate_cube_from_dates("monthly"),
+    ]
+    cubes[0].coord("time").points = cubes[0].coord("time").points + 100.0
+
+    msg = r"Cannot align time coordinates with strategy 'overlap'"
+    with pytest.raises(ValueError, match=msg):
+        mm._align_time_coord(cubes, "overlap")
+
+
 @pytest.mark.parametrize("span", SPAN_OPTIONS)
 def test_combine_same_shape(span):
     """Test _combine with same shape of cubes."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Currently, the following error is raised if `multi_model_statistics` with `span=overlap`  is used and there is no time overlap in the input data:

```
ValueError: Cannot guess bounds for a coordinate of length 1.
```

This PR improves this error to

```
ValueError: Cannot align time coordinates with strategy 'overlap', resulting time coordinate is empty. Input cubes:
[<iris 'Cube' of air_temperature / (K) (time: 12; latitude: 90; longitude: 180)>,
 <iris 'Cube' of air_temperature / (K) (time: 12; latitude: 90; longitude: 180)>]
```

Recipe to reproduce this:

```yml
documentation:
  description: Test
  authors:
    - schlund_manuel
  title: Test.

datasets:
  - {dataset: CanESM5, project: CMIP6, ensemble: r1i1p1f1, grid: gn, timerange: 1999/1999}
  - {dataset: CESM2, project: CMIP6, ensemble: r1i1p1f1, grid: gn, timerange: 2010/2010}

preprocessors:
  test:
    multi_model_statistics:
      span: overlap
      statistics: [mean]
    regrid:
      target_grid: 2x2
      scheme: linear

diagnostics:
  test:
    scripts:
      null
    variables:
      tas:
        preprocessor: test
        mip: Amon
        exp: historical
```

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [ ] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
