### PR TITLE
Avoid reading configuration from disk for every single test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def cfg_default():
 @pytest.fixture(autouse=True)
 def ignore_existing_user_config(monkeypatch, cfg_default):
     """Ignore user's configuration when running tests."""
-    monkeypatch.setattr(CFG, "_mapping", cfg_default)
+    monkeypatch.setattr(CFG, "_mapping", cfg_default._mapping)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,10 @@ def cfg_default():
 @pytest.fixture(autouse=True)
 def ignore_existing_user_config(monkeypatch, cfg_default):
     """Ignore user's configuration when running tests."""
-    monkeypatch.setattr(esmvalcore.config, "CFG", cfg_default)
+    for key in CFG:
+        monkeypatch.delitem(CFG, key)
+    for key, value in cfg_default.items():
+        monkeypatch.setitem(CFG, key, value)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import warnings
 from copy import deepcopy
+from functools import lru_cache
 from pathlib import Path
 
 import numpy as np
@@ -18,8 +19,8 @@ import esmvalcore.config._dask
 from esmvalcore.config import CFG, Config
 
 
-@pytest.fixture
-def cfg_default():
+@lru_cache
+def _load_default_config():
     """Create a configuration object with default values."""
     with warnings.catch_warnings():
         warnings.filterwarnings(
@@ -33,20 +34,22 @@ def cfg_default():
     return cfg
 
 
+@pytest.fixture
+def cfg_default():
+    """Create a configuration object with default values."""
+    cfg = _load_default_config()
+    return deepcopy(cfg)
+
+
 @pytest.fixture(autouse=True)
 def ignore_existing_user_config(monkeypatch, cfg_default):
     """Ignore user's configuration when running tests."""
-    for key in CFG:
-        monkeypatch.delitem(CFG, key)
-    for key, value in cfg_default.items():
-        monkeypatch.setitem(CFG, key, deepcopy(value))
+    monkeypatch.setattr(esmvalcore.config, "CFG", cfg_default)
 
 
 @pytest.fixture
-def session(tmp_path: Path, cfg_default, monkeypatch):
+def session(tmp_path: Path, ignore_existing_user_config, monkeypatch):
     """Session object with default settings."""
-    for key, value in cfg_default.items():
-        monkeypatch.setitem(CFG, key, deepcopy(value))
     monkeypatch.setitem(CFG, "rootpath", {"default": {tmp_path: "default"}})
     monkeypatch.setitem(CFG, "output_dir", tmp_path / "esmvaltool_output")
     return CFG.start_session("recipe_test")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,10 +44,7 @@ def cfg_default():
 @pytest.fixture(autouse=True)
 def ignore_existing_user_config(monkeypatch, cfg_default):
     """Ignore user's configuration when running tests."""
-    for key in CFG:
-        monkeypatch.delitem(CFG, key)
-    for key, value in cfg_default.items():
-        monkeypatch.setitem(CFG, key, value)
+    monkeypatch.setitem(CFG, "_mapping", cfg_default)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def cfg_default():
 @pytest.fixture(autouse=True)
 def ignore_existing_user_config(monkeypatch, cfg_default):
     """Ignore user's configuration when running tests."""
-    monkeypatch.setitem(CFG, "_mapping", cfg_default)
+    monkeypatch.setattr(CFG, "_mapping", cfg_default)
 
 
 @pytest.fixture

--- a/tests/unit/main/test_esmvaltool.py
+++ b/tests/unit/main/test_esmvaltool.py
@@ -194,11 +194,6 @@ def test_run_invalid_config_dir(tmp_path):
 
 def test_run_invalid_cli_arg(monkeypatch, tmp_path):
     """Test `ESMValTool.run`."""
-    monkeypatch.delitem(  # TODO: remove in v2.14.0
-        esmvalcore.config.CFG._mapping,
-        "config_file",
-        raising=False,
-    )
     program = ESMValTool()
 
     msg = r"Invalid command line argument given:"

--- a/tests/unit/main/test_esmvaltool.py
+++ b/tests/unit/main/test_esmvaltool.py
@@ -194,6 +194,11 @@ def test_run_invalid_config_dir(tmp_path):
 
 def test_run_invalid_cli_arg(monkeypatch, tmp_path):
     """Test `ESMValTool.run`."""
+    monkeypatch.delitem(  # TODO: remove in v2.14.0
+        esmvalcore.config.CFG._mapping,
+        "config_file",
+        raising=False,
+    )
     program = ESMValTool()
 
     msg = r"Invalid command line argument given:"


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Avoid reading configuration from disk for every single test, which was introduced in #2736, and caused a slowdown in the tests.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
