### PR TITLE
Avoid too wide supplementary file search

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.12.2"
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/esmvalcore/_recipe/to_datasets.py
+++ b/esmvalcore/_recipe/to_datasets.py
@@ -9,7 +9,7 @@ from numbers import Number
 from typing import TYPE_CHECKING, Any
 
 from esmvalcore.cmor.table import _CMOR_KEYS, _update_cmor_facets
-from esmvalcore.dataset import Dataset, _isglob
+from esmvalcore.dataset import INHERITED_FACETS, Dataset, _isglob
 from esmvalcore.esgf.facets import FACETS
 from esmvalcore.exceptions import RecipeError
 from esmvalcore.local import LocalFile, _replace_years_with_timerange
@@ -249,7 +249,7 @@ def _append_missing_supplementaries(
             supplementary_facets: Facets = {
                 facet: "*"
                 for facet in FACETS.get(project, ["mip"])
-                if facet not in _CMOR_KEYS
+                if facet not in _CMOR_KEYS + tuple(INHERITED_FACETS)
             }
             if "version" in facets:
                 supplementary_facets["version"] = "*"

--- a/tests/unit/recipe/test_to_datasets.py
+++ b/tests/unit/recipe/test_to_datasets.py
@@ -253,6 +253,7 @@ def test_merge_supplementaries_combine_dataset_with_variable(session):
     assert len(datasets) == 1
     assert len(datasets[0].supplementaries) == 2
     assert datasets[0].supplementaries[0].facets["short_name"] == "areacella"
+    assert datasets[0].supplementaries[0].facets["dataset"] == "AWI-ESM-1-1-LR"
     assert datasets[0].supplementaries[1].facets["short_name"] == "sftlf"
 
 
@@ -404,9 +405,12 @@ def test_append_missing_supplementaries():
         facets,
         settings,
     )
-
     short_names = {f["short_name"] for f in supplementaries}
     assert short_names == {"areacella", "sftlf"}
+    sftlf = supplementaries[1]
+    assert (
+        "dataset" not in sftlf
+    )  # dataset will be inherited from the main variable
 
 
 def test_report_unexpanded_globs(mocker):


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Since #2755, automatic addition of supplementary variables searches for too many supplementary variables (also those belonging to other datasets, grids, etc). This happens because the automatically added supplementary variables have a `"*"` for all facet values which are no longer overwritten by the values from the main variable since #2755.

Closes #issue_number

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
