### PR TITLE
Add preprocessor `align_metadata`

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -2919,6 +2919,49 @@ Other
 
 Miscellaneous functions that do not belong to any of the other categories.
 
+.. _align_metadata:
+
+``_align_metadata``
+------------------
+
+This function sets cube metadata to entries from a specific target project.
+This is useful to align variable metadata of different projects prior to
+performing multi-model operations (e.g., :ref:`multi-model statistic`).
+For example, standard names differ for some variables between CMIP5 and CMIP6
+which would prevent the calculation of multi-model statistics between CMIP5 and
+CMIP6 data.
+
+The ``_align_metadata`` preprocessor supports the following arguments in the
+recipe:
+
+* ``target_project`` (:obj:`str`): Project from which target metadata is read.
+* ``target_mip`` (:obj:`str`; optional): MIP table from which target metadata
+  is read.
+  If not given, use the MIP tables of the corresponding variables defined in
+  the recipe.
+* ``target_short_name`` (:obj:`str`; optional): Variable short name from which
+  target metadata is read.
+  If not given, use the short names of the corresponding variables defined in
+  the recipe.
+* ``strict`` (:obj:`str`; optional, default: ``True``): If ``True``, raise an
+  error if desired metadata cannot be read for variable ``target_short_name``
+  of MIP table ``target_mip`` and project ``target_project``.
+  If ``False``, no error is raised.
+
+Example:
+
+.. code-block:: yaml
+
+    preprocessors:
+      calculate_multi_model_statistics:
+        align_metadata:
+          target_project: CMIP6
+        multi_model_statistics:
+          span: overlap
+          statistics: [mean, median]
+
+See also :func:`esmvalcore.preprocessor.align_metadata`.
+
 .. _cumulative_sum:
 
 ``cumulative_sum``

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -2921,8 +2921,8 @@ Miscellaneous functions that do not belong to any of the other categories.
 
 .. _align_metadata:
 
-``_align_metadata``
--------------------
+``align_metadata``
+------------------
 
 This function sets cube metadata to entries from a specific target project.
 This is useful to align variable metadata of different projects prior to
@@ -2931,7 +2931,7 @@ For example, standard names differ for some variables between CMIP5 and CMIP6
 which would prevent the calculation of multi-model statistics between CMIP5 and
 CMIP6 data.
 
-The ``_align_metadata`` preprocessor supports the following arguments in the
+The ``align_metadata`` preprocessor supports the following arguments in the
 recipe:
 
 * ``target_project`` (:obj:`str`): Project from which target metadata is read.

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -2926,7 +2926,7 @@ Miscellaneous functions that do not belong to any of the other categories.
 
 This function sets cube metadata to entries from a specific target project.
 This is useful to align variable metadata of different projects prior to
-performing multi-model operations (e.g., :ref:`multi-model statistic`).
+performing multi-model operations (e.g., :ref:`multi-model statistics`).
 For example, standard names differ for some variables between CMIP5 and CMIP6
 which would prevent the calculation of multi-model statistics between CMIP5 and
 CMIP6 data.

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -2911,48 +2911,8 @@ See also :func:`esmvalcore.preprocessor.distance_metric`.
 .. _Weighted Earth mover's distance: https://pythonot.github.io/
   quickstart.html#computing-wasserstein-distance
 
-
-.. _Memory use:
-
-Information on maximum memory required
-======================================
-In the most general case, we can set upper limits on the maximum memory the
-analysis will require:
-
-
-``Ms = (R + N) x F_eff - F_eff`` - when no multi-model analysis is performed;
-
-``Mm = (2R + N) x F_eff - 2F_eff`` - when multi-model analysis is performed;
-
-where
-
-* ``Ms``: maximum memory for non-multimodel module
-* ``Mm``: maximum memory for multi-model module
-* ``R``: computational efficiency of module; `R` is typically 2-3
-* ``N``: number of datasets
-* ``F_eff``: average size of data per dataset where ``F_eff = e x f x F``
-  where ``e`` is the factor that describes how lazy the data is (``e = 1`` for
-  fully realized data) and ``f`` describes how much the data was shrunk by the
-  immediately previous module, e.g. time extraction, area selection or level
-  extraction; note that for fix_data ``f`` relates only to the time extraction,
-  if data is exact in time (no time selection) ``f = 1`` for fix_data so for
-  cases when we deal with a lot of datasets ``R + N \approx N``, data is fully
-  realized, assuming an average size of 1.5GB for 10 years of `3D` netCDF data,
-  ``N`` datasets will require:
-
-
-``Ms = 1.5 x (N - 1)`` GB
-
-``Mm = 1.5 x (N - 2)`` GB
-
-As a rule of thumb, the maximum required memory at a certain time for
-multi-model analysis could be estimated by multiplying the number of datasets by
-the average file size of all the datasets; this memory intake is high but also
-assumes that all data is fully realized in memory; this aspect will gradually
-change and the amount of realized data will decrease with the increase of
-``dask`` use.
-
 .. _Other:
+
 
 Other
 =====
@@ -3085,3 +3045,44 @@ Example:
           normalization: sum
 
 See also :func:`esmvalcore.preprocessor.histogram`.
+
+
+.. _Memory use:
+
+Information on maximum memory required
+======================================
+In the most general case, we can set upper limits on the maximum memory the
+analysis will require:
+
+
+``Ms = (R + N) x F_eff - F_eff`` - when no multi-model analysis is performed;
+
+``Mm = (2R + N) x F_eff - 2F_eff`` - when multi-model analysis is performed;
+
+where
+
+* ``Ms``: maximum memory for non-multimodel module
+* ``Mm``: maximum memory for multi-model module
+* ``R``: computational efficiency of module; `R` is typically 2-3
+* ``N``: number of datasets
+* ``F_eff``: average size of data per dataset where ``F_eff = e x f x F``
+  where ``e`` is the factor that describes how lazy the data is (``e = 1`` for
+  fully realized data) and ``f`` describes how much the data was shrunk by the
+  immediately previous module, e.g. time extraction, area selection or level
+  extraction; note that for fix_data ``f`` relates only to the time extraction,
+  if data is exact in time (no time selection) ``f = 1`` for fix_data so for
+  cases when we deal with a lot of datasets ``R + N \approx N``, data is fully
+  realized, assuming an average size of 1.5GB for 10 years of `3D` netCDF data,
+  ``N`` datasets will require:
+
+
+``Ms = 1.5 x (N - 1)`` GB
+
+``Mm = 1.5 x (N - 2)`` GB
+
+As a rule of thumb, the maximum required memory at a certain time for
+multi-model analysis could be estimated by multiplying the number of datasets by
+the average file size of all the datasets; this memory intake is high but also
+assumes that all data is fully realized in memory; this aspect will gradually
+change and the amount of realized data will decrease with the increase of
+``dask`` use.

--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -2922,7 +2922,7 @@ Miscellaneous functions that do not belong to any of the other categories.
 .. _align_metadata:
 
 ``_align_metadata``
-------------------
+-------------------
 
 This function sets cube metadata to entries from a specific target project.
 This is useful to align variable metadata of different projects prior to

--- a/esmvalcore/_recipe/recipe.py
+++ b/esmvalcore/_recipe/recipe.py
@@ -592,10 +592,28 @@ def update_ancestors(
                 settings[key] = value
 
 
+def _update_align_metadata(
+    settings: PreprocessorSettings,
+    dataset: Dataset,
+) -> None:
+    """Update settings for ``align_metadata``."""
+    if "align_metadata" in settings:
+        settings["align_metadata"].setdefault(
+            "target_mip",
+            dataset.facets["mip"],
+        )
+        settings["align_metadata"].setdefault(
+            "target_short_name",
+            dataset.facets["short_name"],
+        )
+        check.align_metadata(settings["align_metadata"])
+
+
 def _update_extract_shape(
     settings: PreprocessorSettings,
     session: Session,
 ) -> None:
+    """Update settings for ``extract_shape``."""
     if "extract_shape" in settings:
         shapefile = settings["extract_shape"].get("shapefile")
         if shapefile:
@@ -785,6 +803,7 @@ def _update_preproc_functions(
     missing_vars: set[str],
 ) -> None:
     session = dataset.session
+    _update_align_metadata(settings, dataset)
     _update_extract_shape(settings, session)
     _update_weighting_settings(settings, dataset.facets)
     try:

--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -53,9 +53,7 @@ def _update_cmor_facets(facets):
             f"Unable to load CMOR table (project) '{project}' for variable "
             f"'{short_name}' with mip '{mip}'"
         )
-        raise RecipeError(
-            msg,
-        )
+        raise RecipeError(msg)
     facets["original_short_name"] = table_entry.short_name
     for key in _CMOR_KEYS:
         if key not in facets:
@@ -115,9 +113,7 @@ def get_var_info(
             f"No CMOR tables available for project '{project}'. The following "
             f"tables are available: {', '.join(CMOR_TABLES)}."
         )
-        raise KeyError(
-            msg,
-        )
+        raise KeyError(msg)
 
     # CORDEX X-hourly tables define the mip as ending in 'h' instead of 'hr'
     if project == "CORDEX" and mip.endswith("hr"):
@@ -444,9 +440,7 @@ class CMIP6Info(InfoBase):
         if os.path.isdir(cmor_tables_path):
             return cmor_tables_path
         msg = f"CMOR tables not found in {cmor_tables_path}"
-        raise ValueError(
-            msg,
-        )
+        raise ValueError(msg)
 
     def _load_table(self, json_file):
         with open(json_file, encoding="utf-8") as inf:
@@ -1060,9 +1054,7 @@ class CustomInfo(CMIP5Info):
                     f"Custom CMOR tables path {self._user_table_folder} is "
                     f"not a directory"
                 )
-                raise ValueError(
-                    msg,
-                )
+                raise ValueError(msg)
             self._read_table_dir(self._user_table_folder)
         else:
             self._user_table_folder = None

--- a/esmvalcore/preprocessor/__init__.py
+++ b/esmvalcore/preprocessor/__init__.py
@@ -51,7 +51,12 @@ from esmvalcore.preprocessor._multimodel import (
     ensemble_statistics,
     multi_model_statistics,
 )
-from esmvalcore.preprocessor._other import clip, cumulative_sum, histogram
+from esmvalcore.preprocessor._other import (
+    align_metadata,
+    clip,
+    cumulative_sum,
+    histogram,
+)
 from esmvalcore.preprocessor._regrid import (
     extract_coordinate_points,
     extract_levels,
@@ -115,7 +120,7 @@ __all__ = [
     # Concatenate all cubes in one
     "concatenate",
     "cmor_check_metadata",
-    # Extract years given by dataset keys (start_year and end_year)
+    # Extract years given by dataset keys (timerange/start_year and end_year)
     "clip_timerange",
     # Data reformatting/CMORization
     "fix_data",
@@ -124,6 +129,8 @@ __all__ = [
     "add_supplementary_variables",
     # Derive variable
     "derive",
+    # Align metadata
+    "align_metadata",
     # Time extraction (as defined in the preprocessor section)
     "extract_time",
     "extract_season",

--- a/esmvalcore/preprocessor/_other.py
+++ b/esmvalcore/preprocessor/_other.py
@@ -69,7 +69,7 @@ def align_metadata(
 
     Returns
     -------
-    Cube
+    iris.cube.Cube
         Cube with updated metadata.
 
     Raises

--- a/esmvalcore/preprocessor/_other.py
+++ b/esmvalcore/preprocessor/_other.py
@@ -33,35 +33,42 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def clip(cube, minimum=None, maximum=None):
+def clip(
+    cube: Cube,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> Cube:
     """Clip values at a specified minimum and/or maximum value.
 
-    Values lower than minimum are set to minimum and values
-    higher than maximum are set to maximum.
+    Values lower than minimum are set to minimum and values higher than maximum
+    are set to maximum.
 
     Parameters
     ----------
-    cube: iris.cube.Cube
-        iris cube to be clipped
-    minimum: float
-        lower threshold to be applied on input cube data.
-    maximum: float
-        upper threshold to be applied on input cube data.
+    cube:
+        Input cube.
+    minimum:
+        Lower threshold to be applied on input cube data.
+    maximum:
+        Upper threshold to be applied on input cube data.
 
     Returns
     -------
     iris.cube.Cube
-        clipped cube.
+        Clipped cube.
+
+    Raises
+    ------
+    ValueError
+        ``minimum`` and ``maximum`` are set to ``None``.
+
     """
     if minimum is None and maximum is None:
-        msg = "Either minimum, maximum or both have to be\
-                          specified."
-        raise ValueError(
-            msg,
-        )
+        msg = "Either minimum, maximum or both have to be specified"
+        raise ValueError(msg)
     if minimum is not None and maximum is not None:
         if maximum < minimum:
-            msg = "Maximum should be equal or larger than minimum."
+            msg = "Maximum should be equal or larger than minimum"
             raise ValueError(msg)
     cube.data = da.clip(cube.core_data(), minimum, maximum)
     return cube
@@ -235,18 +242,14 @@ def histogram(
             f"bins cannot be a str (got '{bins}'), must be int or Sequence of "
             f"int"
         )
-        raise TypeError(
-            msg,
-        )
+        raise TypeError(msg)
     allowed_norms = (None, "sum", "integral")
     if normalization is not None and normalization not in allowed_norms:
         msg = (
             f"Expected one of {allowed_norms} for normalization, got "
             f"'{normalization}'"
         )
-        raise ValueError(
-            msg,
-        )
+        raise ValueError(msg)
 
     # If histogram is calculated over all coordinates, we can use
     # dask.array.histogram and do not need to worry about chunks; otherwise,
@@ -309,9 +312,7 @@ def _get_bins(
             f"Cannot calculate histogram for bin_range={bin_range} (or for "
             f"fully masked data when `bin_range` is not given)"
         )
-        raise ValueError(
-            msg,
-        )
+        raise ValueError(msg)
 
     return (bin_range, bin_edges)
 

--- a/tests/integration/cmor/test_table.py
+++ b/tests/integration/cmor/test_table.py
@@ -2,6 +2,7 @@
 
 import os
 import unittest
+from pathlib import Path
 
 import pytest
 
@@ -157,6 +158,12 @@ class TestCMIP6Info(unittest.TestCase):
         """Get activity for experiment 1pctCO2."""
         activity = self.variables_info.activities["1pctCO2"]
         self.assertListEqual(activity, ["CMIP"])
+
+    def test_invalid_path(self):
+        path = Path(__file__) / "path" / "does" / "not" / "exist"
+        msg = r"CMOR tables not found in"
+        with pytest.raises(ValueError, match=msg):
+            CMIP6Info(path)
 
 
 class Testobs4mipsInfo(unittest.TestCase):

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -3699,3 +3699,183 @@ def test_automatic_already_regrid_era5_grib(
         "target_grid": "1x1",
         "scheme": "nearest",
     }
+
+
+def test_align_metadata(tmp_path, patched_datafinder, session):
+    content = dedent("""
+        preprocessors:
+          test:
+            align_metadata:
+              target_project: CMIP6
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: test
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                timerange: '20000101/20001231'
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+
+            scripts: null
+        """)
+    recipe = get_recipe(tmp_path, content, session)
+
+    # Check align_metadata settings have been updated
+    tasks = {t for task in recipe.tasks for t in task.flatten()}
+    assert len(tasks) == 1
+    task = next(iter(tasks))
+    products = task.products
+    assert len(products) == 1
+    product = next(iter(task.products))
+    assert "align_metadata" in product.settings
+    assert product.settings["align_metadata"]["target_project"] == "CMIP6"
+    assert product.settings["align_metadata"]["target_mip"] == "Amon"
+    assert product.settings["align_metadata"]["target_short_name"] == "tas"
+
+
+def test_align_metadata_invalid_project(tmp_path, patched_datafinder, session):
+    content = dedent("""
+        preprocessors:
+          test:
+            align_metadata:
+              target_project: ZZZ
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: test
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                timerange: '20000101/20001231'
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+
+            scripts: null
+        """)
+    msg = (
+        "align_metadata failed: \"No CMOR tables available for project 'ZZZ'. "
+        "The following tables are available: custom, CMIP6, CMIP5, CMIP3, OBS, "
+        "OBS6, native6, obs4MIPs, ana4mips, EMAC, CORDEX, IPSLCM, ICON, CESM, "
+        'ACCESS."'
+    )
+    with pytest.raises(RecipeError) as exc:
+        get_recipe(tmp_path, content, session)
+    assert str(exc.value) == INITIALIZATION_ERROR_MSG
+    assert exc.value.failed_tasks[0].message == msg
+
+
+def test_align_metadata_invalid_name(tmp_path, patched_datafinder, session):
+    content = dedent("""
+        preprocessors:
+          test:
+            align_metadata:
+              target_project: CMIP6
+              target_short_name: zzz
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: test
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                timerange: '20000101/20001231'
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+
+            scripts: null
+        """)
+    msg = (
+        "align_metadata failed: Variable 'zzz' not available for table 'Amon' "
+        "of project 'CMIP6'. Set `strict=False` to ignore this."
+    )
+    with pytest.raises(RecipeError) as exc:
+        get_recipe(tmp_path, content, session)
+    assert str(exc.value) == INITIALIZATION_ERROR_MSG
+    assert exc.value.failed_tasks[0].message == msg
+
+
+def test_align_metadata_invalid_short_name_not_strict(
+    tmp_path,
+    patched_datafinder,
+    session,
+):
+    content = dedent("""
+        preprocessors:
+          test:
+            align_metadata:
+              target_project: CMIP6
+              target_short_name: zzz
+              strict: false
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: test
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                timerange: '20000101/20001231'
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+
+            scripts: null
+        """)
+    recipe = get_recipe(tmp_path, content, session)
+
+    # Check align_metadata settings have been updated
+    tasks = {t for task in recipe.tasks for t in task.flatten()}
+    assert len(tasks) == 1
+    task = next(iter(tasks))
+    products = task.products
+    assert len(products) == 1
+    product = next(iter(task.products))
+    assert "align_metadata" in product.settings
+    assert product.settings["align_metadata"]["target_project"] == "CMIP6"
+    assert product.settings["align_metadata"]["target_mip"] == "Amon"
+    assert product.settings["align_metadata"]["target_short_name"] == "zzz"
+    assert product.settings["align_metadata"]["strict"] is False
+
+
+def test_align_metadata_missing_arg(tmp_path, patched_datafinder, session):
+    content = dedent("""
+        preprocessors:
+          test:
+            align_metadata:
+              target_short_name: tas
+
+        diagnostics:
+          diagnostic_name:
+            variables:
+              tas:
+                preprocessor: test
+                project: CMIP6
+                mip: Amon
+                exp: historical
+                timerange: '20000101/20001231'
+                ensemble: r1i1p1f1
+                grid: gn
+                additional_datasets:
+                  - {dataset: CanESM5}
+
+            scripts: null
+        """)
+    msg = "Missing required argument"
+    with pytest.raises(ValueError, match=msg):
+        get_recipe(tmp_path, content, session)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR adds the preprocessor `align_metadata` which aligns cube metadata with a specific target project. This is useful to perform multi-model analysis across different projects (e.g., CMIP5 and CMIP6).

Example recipe:

```yml
# ESMValTool
---
documentation:
  description: Test
  authors:
    - schlund_manuel
  title: Test.

preprocessors:
  test:
    align_metadata:
      target_project: CMIP6
    regrid:
      target_grid: 2x2
      scheme: linear
    multi_model_statistics:
      span: overlap
      statistics: [mean]

diagnostics:
  test:
    scripts:
      null
    variables:
      clivi:
        preprocessor: test
        mip: Amon
        additional_datasets:
          - {project: OBS, dataset: CLARA-AVHRR, type: sat, version: V002-01, tier: 3, alias: MultiObsMean, timerange: 19990101/20181231}
          - {project: OBS, dataset: CLOUDSAT-L2, type: sat, version: P1-R05-gridbox-average-noprecip, tier: 3, alias: MultiObsMean, timerange: 20060101/20171231}
          - {project: native6, dataset: ERA5, type: reanaly, version: v1, tier: 3, alias: MultiObsMean, timerange: 20000101/20191231}
          - {project: OBS, dataset: ESACCI-CLOUD, type: sat, version: AVHRR-AMPM-fv3.0, tier: 2, alias: MultiObsMean, timerange: 19970101/20161231}
          - {project: OBS6, dataset: MERRA2, type: reanaly, version: 5.12.4, tier: 3, alias: MultiObsMean, timerange: 20020101/20211231}
          - {project: OBS, dataset: MODIS, type: sat, version: MYD08-M3, tier: 3, alias: MultiObsMean, timerange: 20030101/20181231}
      clwvi:
        preprocessor: test
        mip: Amon
        additional_datasets:
          - {project: OBS, dataset: CLARA-AVHRR, type: sat, version: V002-01, tier: 3, alias: MultiObsMean, timerange: 19990101/20181231}
          - {project: OBS, dataset: CLOUDSAT-L2, type: sat, version: P1-R05-gridbox-average-noprecip, tier: 3, alias: MultiObsMean, timerange: 20060101/20171231}
          - {project: native6, dataset: ERA5, type: reanaly, version: v1, tier: 3, alias: MultiObsMean, timerange: 20000101/20191231}
          - {project: OBS, dataset: ESACCI-CLOUD, type: sat, version: AVHRR-AMPM-fv3.0, tier: 2, alias: MultiObsMean, timerange: 19970101/20161231}
          - {project: OBS6, dataset: MERRA2, type: reanaly, version: 5.12.4, tier: 3, alias: MultiObsMean, timerange: 20030101/20221231}
          - {project: OBS, dataset: MODIS, type: sat, version: MYD08-M3, tier: 3, alias: MultiObsMean, timerange: 20030101/20181231}
```


<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/1985

Link to documentation: https://esmvaltool--2789.org.readthedocs.build/projects/ESMValCore/en/2789/recipe/preprocessor.html#align-metadata

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
