### PR TITLE
Pass `chunks={}` to Xarray dataset loader for Zarr stores

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -166,8 +166,7 @@ def _load_zarr(
     # note on ``chunks`` kwarg to ``xr.open_dataset()``
     # docs.xarray.dev/en/stable/generated/xarray.open_dataset.html
     # this is very important because with ``chunks=None`` (default)
-    # data will be realized as Numpy arrays and transferred in memory
-    # both for remote and local Zarr stores;
+    # data will be realized as Numpy arrays and transferred in memory;
     # ``chunks={}`` loads the data with dask using the engine preferred
     # chunk size, generally identical to the formats chunk size. If not
     # available, a single chunk for all arrays; testing shows this is the

--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -216,6 +216,12 @@ def _load_zarr(
             backend_kwargs=backend_kwargs,
         )
 
+    # avoid possible
+    # ValueError: Object has inconsistent chunks along dimension time.
+    # This can be fixed by calling unify_chunks().
+    # when trying to access the ``chunks`` store
+    zarr_xr = zarr_xr.unify_chunks()
+
     return dataset_to_iris(zarr_xr, ignore_warnings=ignore_warnings)
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #2790 

There was quite a bit of investigation down about this in https://github.com/pp-mo/ncdata/issues/139 and in https://github.com/pydata/xarray/issues/10612 and in my own GH repo at  https://github.com/valeriupredoi/esmvaltool_zarr_tests and, with help from @pp-mo and @kmuehlbauer we managed to get the performance of Zarr loading go up by a big notch though keeping all data lazy, both for remote bucket and local Zarr stores. So far, a generic `chunks={}` should work OK, maybe we want to have smart chunking done in the future, but at this stage, this setting helps a LOT with memory consumption and runtime. Cheers very much, gents! :beers: 

EDIT (thanks, @schlunma ) `chunks="auto"` does not work for some files `NotImplementedError: Can not use auto rechunking with object dtype. We are unable to estimate the size in bytes of object data`

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
