### PR TITLE
Remove mention of Julia in documentation ahead of discontinued support in v2.13

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -941,7 +941,7 @@ built correctly by
 1. checking that the version tag is available on `Dockerhub`_ and the ``stable``
    tag has been updated,
 2. running some recipes with the ``stable`` tag Docker container, for example one
-   recipe for Python, NCL, R, and Julia,
+   recipe for Python, NCL, and R,
 3. running a recipe with a Singularity container built from the ``stable`` tag.
 
 If there is a problem with the automatically built container image, you can fix

--- a/doc/recipe/overview.rst
+++ b/doc/recipe/overview.rst
@@ -493,7 +493,7 @@ Depending on the installation configuration, you may get an error of
 using relative paths. If this happens, use an absolute path instead.
 
 Note that the script should either have the extension for a supported language,
-i.e. ``.py``, ``.R``, ``.ncl``, or ``.jl`` for Python, R, NCL, and Julia diagnostics
+i.e. ``.py``, ``.R``, or ``.ncl`` for Python, R, and NCL diagnostics
 respectively, or be executable if it is written in any other language.
 
 .. _ancestor-tasks:


### PR DESCRIPTION
## Description

Removes mentions of Julia in the documentation ahead the discontinued support for Julia in v2.13.
Support in the ESMValCore code is kept for now.

Address [#4132](https://github.com/ESMValGroup/ESMValTool/issues/4132)