### PR TITLE
Change zarr exception test to GroupNotFoundError

### DIFF
--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import cf_units
 import pytest
+from zarr.errors import GroupNotFoundError
 
 from esmvalcore.preprocessor._io import load
 
@@ -220,5 +221,5 @@ def test_load_zarr_local_not_zarr_file():
     # "Unable to find group" or "No group found"
     # Zarr keeps changing the exception string so matching
     # is bound to fail the test
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(GroupNotFoundError):
         load(zarr_path)


### PR DESCRIPTION
## Description

The test `tests/integration/preprocessor/_io/test_zarr.py::test_load_zarr_local_not_zarr_file` was failing due to a change in the exception used in zarr:
`FAILED tests/integration/preprocessor/_io/test_zarr.py::test_load_zarr_local_not_zarr_file - FileExistsError: [Errno 17] File exists: '/root/project/tests/sample_data/zarr-sample-data/example_field_0.zarr17'`

This is solved by replacing
https://github.com/ESMValGroup/ESMValCore/blob/dcf9179d35264d39b0c8b3ba5f8fa76f54e1c24e/tests/integration/preprocessor/_io/test_zarr.py#L220-L224
with
```
with pytest.raises(GroupNotFoundError):
    load(zarr_path)
```

Test pipeline now passing https://app.circleci.com/pipelines/github/ESMValGroup/ESMValCore/13642/workflows/9624418d-8022-41b2-a4d1-0e912388450a
***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
