### PR TITLE
Remove failing test `test_load_zarr_local_not_zarr_file` due to zarr version changes

### DIFF
--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 import cf_units
 import pytest
-from zarr.errors import GroupNotFoundError
 
 from esmvalcore.preprocessor._io import load
 
@@ -202,24 +201,4 @@ def test_load_zarr_local_not_file():
     # Zarr keeps changing the exception string so matching
     # is bound to fail the test
     with pytest.raises(FileNotFoundError):
-        load(zarr_path)
-
-
-def test_load_zarr_local_not_zarr_file():
-    """
-    Test loading something that has a zarr extension.
-
-    But file is plaintext (on local FS).
-    """
-    zarr_path = (
-        Path(importlib_files("tests"))
-        / "sample_data"
-        / "zarr-sample-data"
-        / "example_field_0.zarr17"
-    )
-
-    # "Unable to find group" or "No group found"
-    # Zarr keeps changing the exception string so matching
-    # is bound to fail the test
-    with pytest.raises(GroupNotFoundError):
         load(zarr_path)


### PR DESCRIPTION
## Description

The following test `test_load_zarr_local_not_zarr_file` in `/tests/integration/preprocessor/_io/test_zarr.py` fails when done with different `zarr` versions. Decision is to remove it for now for the release and add it back up later if the behavior of `zarr` is more stable across versions (test passing with version 3.1.1 but not with 3.1.2).

Traceback when failing is:
```
______________________ test_load_zarr_local_not_zarr_file ______________________
[gw3] linux -- Python 3.13.5 /opt/conda/envs/esmvaltool/bin/python3.13

    def test_load_zarr_local_not_zarr_file():
        """
        Test loading something that has a zarr extension.
    
        But file is plaintext (on local FS).
        """
        zarr_path = (
            Path(importlib_files("tests"))
            / "sample_data"
            / "zarr-sample-data"
            / "example_field_0.zarr17"
        )
    
        # "Unable to find group" or "No group found"
        # Zarr keeps changing the exception string so matching
        # is bound to fail the test
        with pytest.raises(GroupNotFoundError):
>           load(zarr_path)

tests/integration/preprocessor/_io/test_zarr.py:225:
...
E           FileExistsError: [Errno 17] File exists: '/root/project/tests/sample_data/zarr-sample-data/example_field_0.zarr17'
```

Follow up to #2823