### PR TITLE
Ignore user configuration in configuration reload test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,8 +136,11 @@ addopts = [
     "--cov-report=html:test-reports/coverage_html",
     "--html=test-reports/report.html",
 ]
-log_cli_level = "INFO"
 env = {MPLBACKEND = "Agg"}
+filterwarnings = [
+    "ignore:Do not instantiate `Config` objects directly:UserWarning"
+]
+log_cli_level = "INFO"
 log_level = "WARNING"
 minversion = "6"
 markers = [

--- a/tests/unit/config/test_config_object.py
+++ b/tests/unit/config/test_config_object.py
@@ -63,8 +63,17 @@ def test_config_key_error():
         config["invalid_key"]
 
 
-def test_reload(cfg_default):
+def test_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    cfg_default: Config,
+) -> None:
     """Test `Config.reload`."""
+    monkeypatch.setattr(
+        esmvalcore.config._config_object,
+        "USER_CONFIG_DIR",
+        tmp_path,
+    )
     cfg = Config()
 
     cfg.reload()


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

The test `tests/unit/config/test_config_object.py::test_reload` picks up data sources from the user's configuration directory (if available) and subsequently fails because this configuration is different from the default. This pull request fixes the issue.

Also, ignore the warnings coming from creating `esmvalcore.config.Config` objects directly as part of the tests.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
