### PR TITLE
Add fix for CMIP6 CNRM-ESM2-1 (variable o3)

### DIFF
--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
@@ -104,6 +104,7 @@ class Omon(Fix):
 
 Cli = Cl
 
+
 Clw = Cl
 
 
@@ -111,6 +112,8 @@ class O3(Cl):
     """Fixes of ozone variable (mip: AERmon only)."""
 
     def fix_metadata(self, cubes):
-        if cubes[0].attributes["table_id"] == "AERmon":
-            cubes = Cl.fix_metadata(self, cubes)
+        for cube in cubes:
+            if "table_id" in cube.attributes:
+                if cube.attributes["table_id"] == "AERmon":
+                    cubes = Cl.fix_metadata(self, cubes)
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
@@ -105,3 +105,5 @@ class Omon(Fix):
 Cli = Cl
 
 Clw = Cl
+
+O3 = Cl

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
@@ -116,4 +116,5 @@ class O3(Cl):
             if "table_id" in cube.attributes:
                 if cube.attributes["table_id"] == "AERmon":
                     cubes = Cl.fix_metadata(self, cubes)
+                    break
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_cm6_1.py
@@ -106,4 +106,11 @@ Cli = Cl
 
 Clw = Cl
 
-O3 = Cl
+
+class O3(Cl):
+    """Fixes of ozone variable (mip: AERmon only)."""
+
+    def fix_metadata(self, cubes):
+        if cubes[0].attributes["table_id"] == "AERmon":
+            cubes = Cl.fix_metadata(self, cubes)
+        return cubes

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_esm2_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_esm2_1.py
@@ -1,10 +1,10 @@
 """Fixes for CNRM-ESM2-1 model."""
 
+from .cnrm_cm6_1 import O3 as BaseO3  # noqa: N811
 from .cnrm_cm6_1 import Cl as BaseCl
 from .cnrm_cm6_1 import Clcalipso as BaseClcalipso
 from .cnrm_cm6_1 import Cli as BaseCli
 from .cnrm_cm6_1 import Clw as BaseClw
-from .cnrm_cm6_1 import O3 as BaseO3
 from .cnrm_cm6_1 import Omon as BaseOmon
 
 Cl = BaseCl

--- a/esmvalcore/cmor/_fixes/cmip6/cnrm_esm2_1.py
+++ b/esmvalcore/cmor/_fixes/cmip6/cnrm_esm2_1.py
@@ -4,6 +4,7 @@ from .cnrm_cm6_1 import Cl as BaseCl
 from .cnrm_cm6_1 import Clcalipso as BaseClcalipso
 from .cnrm_cm6_1 import Cli as BaseCli
 from .cnrm_cm6_1 import Clw as BaseClw
+from .cnrm_cm6_1 import O3 as BaseO3
 from .cnrm_cm6_1 import Omon as BaseOmon
 
 Cl = BaseCl
@@ -16,6 +17,9 @@ Cli = BaseCli
 
 
 Clw = BaseClw
+
+
+O3 = BaseO3
 
 
 Omon = BaseOmon

--- a/tests/integration/cmor/_fixes/cmip6/test_cnrm_cm6_1.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cnrm_cm6_1.py
@@ -157,7 +157,23 @@ def test_get_thetao_fix():
     assert fix == [Omon(None), GenericFix(None)]
 
 
-def test_o3_fix():
+def test_o3_fix_metadata(test_data_path):
     """Test fix for ``o3`` from mip: AERmon."""
-    fix = Fix.get_fixes("CMIP6", "CNRM-CM6-1", "AERmon", "o3")
-    assert fix == [O3(None), GenericFix(None)]
+    nc_path = test_data_path / "cnrm_cm6_1_cl.nc"
+    cubes = iris.load(str(nc_path))
+    # change cl cube from test data to an o3 cube
+    # (reusing vertical hybrid coordinates for testing)
+    o3_cube = cubes.extract_cube("cloud_area_fraction_in_atmosphere_layer")
+    o3_cube.long_name = "Mole Fraction of O3"
+    o3_cube.standard_name = "mole_fraction_of_ozone_in_air"
+    o3_cube.units = "mol mol-1"
+    o3_cube.attributes["table_id"] = "AERmon"
+    o3_cube.var_name = "o3"
+    # test o3 fix_metadata
+    vardef = get_var_info("CMIP6", "AERmon", "o3")
+    fix = O3(vardef)
+    fixed_cubes = fix.fix_metadata(cubes)
+    # make sure the fixed cube has a coordinate "air_pressure"
+    cube = fixed_cubes.extract_cube("mole_fraction_of_ozone_in_air")
+    air_pressure_coord = cube.coord("air_pressure")
+    assert air_pressure_coord.points is not None

--- a/tests/integration/cmor/_fixes/cmip6/test_cnrm_cm6_1.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_cnrm_cm6_1.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from esmvalcore.cmor._fixes.cmip6.cnrm_cm6_1 import (
+    O3,
     Cl,
     Clcalipso,
     Cli,
@@ -154,3 +155,9 @@ def test_get_thetao_fix():
     """Test getting of fix."""
     fix = Fix.get_fixes("CMIP6", "CNRM-CM6-1", "Omon", "thetao")
     assert fix == [Omon(None), GenericFix(None)]
+
+
+def test_o3_fix():
+    """Test fix for ``o3`` from mip: AERmon."""
+    fix = Fix.get_fixes("CMIP6", "CNRM-CM6-1", "AERmon", "o3")
+    assert fix == [O3(None), GenericFix(None)]


### PR DESCRIPTION
## Description

Add fix for CMIP6 model CNRM-ESM2-1 to allow handling of vertical hybrid coordiantes for variable o3 (ozone mixing ratio).

This fix is needed to process the CMIP6 example data for the REF ozone diagnostics.

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] ~~[🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available~~
- [ ] ~~[🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added~~
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [ ] ~~[🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly~~
- [ ] ~~[🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date~~
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful
