### PR TITLE
run s3 zarr tests only if s3 object store is online

### DIFF
--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -31,12 +31,10 @@ def s3_url_exists(url):
             url,
             timeout=10,  # seconds
         )
-        return response.status_code == 200  # noqa: TRY300
-    except requests.exceptions.Timeout:
-        return False
     except requests.exceptions.RequestException:
         return False
-
+    else:
+        return response.status_code == 200    
 
 jasmin_online = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk")
 

--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -64,7 +64,7 @@ def test_load_zarr2_local(input_type):
 
 
 @pytest.mark.online
-@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
+@pytest.mark.skipif(not JASMIN_ONLINE, reason="CEDA S3 object store offline.")
 def test_load_zarr2_remote():
     """Test loading a Zarr2 store from a https Object Store."""
     zarr_path = (
@@ -106,7 +106,7 @@ def test_load_zarr2_remote():
 
 
 @pytest.mark.online
-@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
+@pytest.mark.skipif(not JASMIN_ONLINE, reason="CEDA S3 object store offline.")
 def test_load_zarr3_remote():
     """Test loading a Zarr3 store from a https Object Store."""
     zarr_path = (
@@ -134,7 +134,7 @@ def test_load_zarr3_remote():
 
 
 @pytest.mark.online
-@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
+@pytest.mark.skipif(not JASMIN_ONLINE, reason="CEDA S3 object store offline.")
 def test_load_zarr3_cmip6_metadata():
     """
     Test loading a Zarr3 store from a https Object Store.
@@ -170,7 +170,7 @@ def test_load_zarr3_cmip6_metadata():
     assert cube.has_lazy_data()
 
 
-@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
+@pytest.mark.skipif(not JASMIN_ONLINE, reason="CEDA S3 object store offline.")
 def test_load_zarr_remote_not_zarr_file():
     """
     Test loading a Zarr store from a https Object Store.
@@ -191,7 +191,7 @@ def test_load_zarr_remote_not_zarr_file():
         load(zarr_path)
 
 
-@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
+@pytest.mark.skipif(not JASMIN_ONLINE, reason="CEDA S3 object store offline.")
 def test_load_zarr_remote_not_file():
     """
     Test loading a Zarr store from a https Object Store.

--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -20,9 +20,24 @@ from pathlib import Path
 
 import cf_units
 import pytest
+import requests
 
 from esmvalcore.preprocessor._io import load
 
+
+def s3_url_exists(url):
+    try:
+        response = requests.get(url,
+        timeout=10  # seconds
+    )
+        return response.status_code == 200
+    except requests.exceptions.Timeout:
+        return False
+    except requests.exceptions.RequestException as e:
+        return False
+
+
+jasmin_online = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk")
 
 @pytest.mark.parametrize("input_type", [str, Path])
 def test_load_zarr2_local(input_type):
@@ -49,6 +64,7 @@ def test_load_zarr2_local(input_type):
 
 
 @pytest.mark.online
+@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
 def test_load_zarr2_remote():
     """Test loading a Zarr2 store from a https Object Store."""
     zarr_path = (
@@ -90,6 +106,7 @@ def test_load_zarr2_remote():
 
 
 @pytest.mark.online
+@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
 def test_load_zarr3_remote():
     """Test loading a Zarr3 store from a https Object Store."""
     zarr_path = (
@@ -117,6 +134,7 @@ def test_load_zarr3_remote():
 
 
 @pytest.mark.online
+@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
 def test_load_zarr3_cmip6_metadata():
     """
     Test loading a Zarr3 store from a https Object Store.
@@ -152,6 +170,7 @@ def test_load_zarr3_cmip6_metadata():
     assert cube.has_lazy_data()
 
 
+@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
 def test_load_zarr_remote_not_zarr_file():
     """
     Test loading a Zarr store from a https Object Store.
@@ -172,6 +191,7 @@ def test_load_zarr_remote_not_zarr_file():
         load(zarr_path)
 
 
+@pytest.mark.skipif(not jasmin_online, reason="CEDA S3 object store offline.")
 def test_load_zarr_remote_not_file():
     """
     Test loading a Zarr store from a https Object Store.

--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -31,7 +31,7 @@ def s3_url_exists(url):
             url,
             timeout=10,  # seconds
         )
-        return response.status_code == 200
+        return response.status_code == 200  # noqa: TRY300
     except requests.exceptions.Timeout:
         return False
     except requests.exceptions.RequestException:

--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -36,7 +36,7 @@ def s3_url_exists(url):
     else:
         return response.status_code == 200    
 
-jasmin_online = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk")
+JASMIN_ONLINE = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk")
 
 
 @pytest.mark.parametrize("input_type", [str, Path])

--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -34,7 +34,8 @@ def s3_url_exists(url: str) -> bool:
     except requests.exceptions.RequestException:
         return False
     else:
-        return response.status_code == 200    
+        return response.status_code == 200
+
 
 JASMIN_ONLINE = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk")
 

--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -27,17 +27,19 @@ from esmvalcore.preprocessor._io import load
 
 def s3_url_exists(url):
     try:
-        response = requests.get(url,
-        timeout=10  # seconds
-    )
+        response = requests.get(
+            url,
+            timeout=10,  # seconds
+        )
         return response.status_code == 200
     except requests.exceptions.Timeout:
         return False
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         return False
 
 
 jasmin_online = s3_url_exists("https://uor-aces-o.s3-ext.jc.rl.ac.uk")
+
 
 @pytest.mark.parametrize("input_type", [str, Path])
 def test_load_zarr2_local(input_type):

--- a/tests/integration/preprocessor/_io/test_zarr.py
+++ b/tests/integration/preprocessor/_io/test_zarr.py
@@ -25,7 +25,7 @@ import requests
 from esmvalcore.preprocessor._io import load
 
 
-def s3_url_exists(url):
+def s3_url_exists(url: str) -> bool:
     try:
         response = requests.get(
             url,


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

I promised @bouweandela I'd take care of this :beer: 

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
