### PR TITLE
Make sure all input arrays passed to `dask.array.apply_gufunc` are Dask arrays

### DIFF
--- a/esmvalcore/preprocessor/_compare_with_refs.py
+++ b/esmvalcore/preprocessor/_compare_with_refs.py
@@ -552,6 +552,10 @@ def _calculate_emd(
 
     # Data
     if cube.has_lazy_data() and reference.has_lazy_data():
+        # da.apply_gufunc internally casts all input arrays to Dask, which
+        # might produce misaligned chunks. To avoid this, convert bin_centers
+        # to a dask array with one single chunk.
+        bin_centers = da.from_array(bin_centers, chunks=bin_centers.shape)
         emd = da.apply_gufunc(
             _get_emd,
             "(i),(i),(i)->()",

--- a/esmvalcore/preprocessor/_compare_with_refs.py
+++ b/esmvalcore/preprocessor/_compare_with_refs.py
@@ -553,8 +553,13 @@ def _calculate_emd(
     # Data
     if cube.has_lazy_data() and reference.has_lazy_data():
         # da.apply_gufunc internally casts all input arrays to Dask, which
-        # might produce misaligned chunks. To avoid this, convert bin_centers
-        # to a dask array with one single chunk.
+        # might produce misaligned chunks. To avoid this, make sure
+        # `bin_centers` is also a Dask array which is similarly chunked as
+        # `pmf.lazy_data()` and `pmf_ref.lazy_data()` along the shared
+        # dimension `i`. Since `pmf.lazy_data()` and `pmf_ref.lazy_data()` are
+        # not chunked along the shared dimension `i` (see `rechunk_cube()`
+        # function above) and `bin_centers` has shape (i,), `bin_centers` must
+        # not be chunked at all.
         bin_centers = da.from_array(bin_centers, chunks=bin_centers.shape)
         emd = da.apply_gufunc(
             _get_emd,

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -1801,8 +1801,11 @@ def _transform_to_lst_lazy(
     `mask` is 2D with shape (time, lon) that will be applied to the final data.
     """
     # da.apply_gufunc internally casts all input arrays to Dask, which might
-    # produce misaligned chunks. To avoid this, convert time_index and mask to
-    # dask arrays with one single chunk.
+    # produce misaligned chunks. To avoid this, make sure `time_index` and
+    # `mask` are also Dask arrays which are similarly chunked as `data` along
+    # the shared dimensions (time, lon). Since `data` is not chunked along the
+    # shared dimensions (time, lon) and `time_index` and `mask` have shape
+    # (time, lon), `time_index` and `mask` must not be chunked at all.
     time_index = da.from_array(time_index, chunks=time_index.shape)
     mask = da.from_array(mask, chunks=time_index.shape)
     return da.apply_gufunc(

--- a/esmvalcore/preprocessor/_time.py
+++ b/esmvalcore/preprocessor/_time.py
@@ -1800,6 +1800,11 @@ def _transform_to_lst_lazy(
 
     `mask` is 2D with shape (time, lon) that will be applied to the final data.
     """
+    # da.apply_gufunc internally casts all input arrays to Dask, which might
+    # produce misaligned chunks. To avoid this, convert time_index and mask to
+    # dask arrays with one single chunk.
+    time_index = da.from_array(time_index, chunks=time_index.shape)
+    mask = da.from_array(mask, chunks=time_index.shape)
     return da.apply_gufunc(
         _transform_to_lst_eager,
         "(t,x),(t,x),(t,x)->(t,x)",


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

`dask.array.apply_gufunc` implicitly [casts all input arrays to Dask arrays](https://github.com/dask/dask/blob/e5a9087bdbc5514740531c7602e9ee806abb6b58/dask/array/gufunc.py#L375). Currently, we currently pass Numpy arrays to it in some cases, which might lead to inconsistent chunks sizes and errors like:

```bash
ValueError: Dimension `'t'` with different chunksize present
```

This PR fixes this problem by casting all input arrays to Dask arrays with a single chunk.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
