### PR TITLE
Avoid hardcoded time coordinate names in CMOR check

### DIFF
--- a/esmvalcore/cmor/_fixes/fix.py
+++ b/esmvalcore/cmor/_fixes/fix.py
@@ -882,18 +882,18 @@ class GenericFix(Fix):
 
     def _fix_time_bounds(self, cube: Cube, cube_coord: Coord) -> None:
         """Fix time bounds."""
-        times = {"time", "time1", "time2", "time3"}
-        key = times.intersection(self.vardef.coordinates)
-        if not key:  # cube has time, but CMOR variable does not
-            return
-        cmor = self.vardef.coordinates[" ".join(key)]
-        if cmor.must_have_bounds == "yes" and not cube_coord.has_bounds():
-            cube_coord.bounds = get_time_bounds(cube_coord, self.frequency)
-            self._warning_msg(
-                cube,
-                "Added guessed bounds to coordinate %s",
-                cube_coord.var_name,
-            )
+        for cmor_coord in self.vardef.coordinates.values():
+            if (
+                cmor_coord.axis == "T"
+                and cmor_coord.must_have_bounds == "yes"
+                and not cube_coord.has_bounds()
+            ):
+                cube_coord.bounds = get_time_bounds(cube_coord, self.frequency)
+                self._warning_msg(
+                    cube,
+                    "Added guessed bounds to coordinate %s",
+                    cube_coord.var_name,
+                )
 
     def _fix_time_coord(self, cube: Cube) -> Cube:
         """Fix time coordinate."""

--- a/esmvalcore/cmor/check.py
+++ b/esmvalcore/cmor/check.py
@@ -632,16 +632,21 @@ class CMORCheck:
                 var_name,
             )
 
-    def _check_time_bounds(self, time):
-        times = {"time", "time1", "time2", "time3"}
-        key = times.intersection(self._cmor_var.coordinates)
-        cmor = self._cmor_var.coordinates[" ".join(key)]
-        if cmor.must_have_bounds == "yes" and not time.has_bounds():
-            self.report_warning(
-                "Coordinate {0} from var {1} does not have bounds",
-                time.var_name,
-                self._cmor_var.short_name,
-            )
+    def _check_time_bounds(
+        self,
+        time: iris.coords.DimCoord | iris.coords.AuxCoord,
+    ) -> None:
+        for cmor_coord in self._cmor_var.coordinates.values():
+            if (
+                cmor_coord.axis == "T"
+                and cmor_coord.must_have_bounds == "yes"
+                and not time.has_bounds()
+            ):
+                self.report_warning(
+                    "Coordinate {0} from var {1} does not have bounds",
+                    time.var_name,
+                    self._cmor_var.short_name,
+                )
 
     def _check_coord_monotonicity_and_direction(  # noqa: C901
         self,

--- a/tests/unit/cmor/test_cmor_check.py
+++ b/tests/unit/cmor/test_cmor_check.py
@@ -61,7 +61,14 @@ class CoordinateInfoMock:
         self.name = name
         self.generic_level = False
 
-        self.axis = ""
+        axis = {
+            "time": "T",
+            "lat": "Y",
+            "lon": "X",
+            "depth": "Z",
+            "air_pressure": "Z",
+        }
+        self.axis = axis.get(name, "")
         self.value = ""
         standard_names = {"lat": "latitude", "lon": "longitude"}
         self.standard_name = standard_names.get(name, name)
@@ -814,6 +821,12 @@ class TestCMORCheck(unittest.TestCase):
         """Test fail for incompatible time units."""
         self.cube.coord("time").units = "K"
         self._check_fails_in_metadata()
+
+    def test_missing_time_bounds(self):
+        """Test fail for incompatible time units."""
+        self.cube.coord("time").bounds = None
+        self.var_info.coordinates["time"].must_have_bounds = "yes"
+        self._check_warnings_on_metadata()
 
     def test_time_non_monotonic(self):
         """Test fail for non monotonic times."""


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Avoid hardcoded time coordinate names in CMOR check. The CMIP7 CMOR tables contain a coordinate called "time4", which results in a crash of the CMOR checker because it only recognizes times up to "time3". This affects the use of the variables `sfcWind` with branding suffix `tmaxavg-h10m-hxy-u`, `tas` with branding `tmaxavg-h2m-hxy-u` (aka `tasmax` in CMIP6), and `tas` with branding suffix `tminavg-h2m-hxy-u` (aka `tasmin` in CMIP6).

This prevents the recipe `ref/recipe_ref_fire.yml` from running with CMIP7 data.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
