### PR TITLE
Add the option to ignore the `branding_suffix` for derived CMIP7 and custom variables

### DIFF
--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -559,8 +559,14 @@ class InfoBase:
                 except KeyError:
                     pass
 
-        # If that didn't work, look in all tables (i.e., other MIPs) if
-        # cmor_strict=False or derived=True
+        # If that didn't work, look in all tables (i.e., other MIPs) and
+        # optionally ignore the branding suffix if cmor_strict=False or
+        # derived=True.
+        if branding_suffix:
+            # Append the unbranded short names to the list of alternatives as
+            # a fallback option. This allows to find the variable even if it
+            # does not have a branding suffix.
+            alt_names_list += self._get_alt_names_list(short_name)
         var_info = self._look_in_all_tables(derived, alt_names_list)
 
         # If that didn't work either, look in default table if

--- a/tests/integration/cmor/test_read_cmor_tables.py
+++ b/tests/integration/cmor/test_read_cmor_tables.py
@@ -79,7 +79,9 @@ def test_read_cmor_tables_from_config_developer(monkeypatch):
     ),
     [
         ("CMIP7", "atmos", "tas", "tavg-h2m-hxy-u"),
-        ("CMIP7", "Amon", "alb", None),  # custom derived variable
+        ("CMIP7", "atmos", "alb", None),  # custom derived variable
+        # custom derived variable with branding suffix of input variables:
+        ("CMIP7", "atmos", "rtnt", "tavg-u-hxy-u"),
         ("CMIP6", "Amon", "tas", None),
         ("CMIP6", "Amon", "alb", None),  # custom derived variable
         ("CMIP6", "Amon", "ch4", "Clim"),  # table entry != short_name
@@ -122,7 +124,7 @@ def test_get_tables(
         mip,
         short_name,
         branding_suffix=branding_suffix,
-        derived=short_name in ("alb", "lwcre"),
+        derived=short_name in ("alb", "lwcre", "rtnt"),
     )
     assert isinstance(vardef, VariableInfo)
     assert vardef.short_name


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Add the option to ignore the branding_suffix when looking up CMIP7 derived and custom variables in the CMOR tables. This enables using derived variables with the branding_suffix of their source variables and adds the convienience of only having to define a custom variable once for use it with any branding suffix.

Closes #2980


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
