### PR TITLE
Gracefully handle the case of missing facets required by ``esmvalcore.io.local.LocalDataSource``

### DIFF
--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import shutil
@@ -326,17 +327,14 @@ class IconFix(NativeDatasetFix):
 
     def _get_grid_from_rootpath(self, grid_name: str) -> CubeList | None:
         """Try to get grid from the ICON rootpath."""
-        glob_patterns: list[Path] = []
         for data_source in _get_data_sources(self.session, "ICON"):  # type: ignore[arg-type]
             if isinstance(data_source, esmvalcore.io.local.LocalDataSource):
-                glob_patterns.extend(
-                    data_source._get_glob_patterns(**self.extra_facets),  # noqa: SLF001
-                )
-        possible_grid_paths = [d.parent / grid_name for d in glob_patterns]
-        for grid_path in possible_grid_paths:
-            if grid_path.is_file():
-                logger.debug("Using ICON grid file '%s'", grid_path)
-                return self._load_cubes(grid_path)
+                ds = copy.deepcopy(data_source)
+                ds.filename_template = grid_name
+                files = ds.find_data(**self.extra_facets)
+                if files:
+                    logger.debug("Using ICON grid file '%s'", files[0])
+                    return files[0].to_iris()
         return None
 
     def _get_downloaded_grid(self, grid_url: str, grid_name: str) -> CubeList:

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -331,7 +331,10 @@ class IconFix(NativeDatasetFix):
             if isinstance(data_source, esmvalcore.io.local.LocalDataSource):
                 ds = copy.deepcopy(data_source)
                 ds.filename_template = grid_name
-                files = ds.find_data(**self.extra_facets)
+                icon_grid_facets = dict(self.extra_facets)
+                icon_grid_facets.pop("timerange", None)
+                icon_grid_facets["frequency"] = "fx"
+                files = ds.find_data(**icon_grid_facets)
                 if files:
                     logger.debug("Using ICON grid file '%s'", files[0])
                     return files[0].to_iris()
@@ -514,21 +517,8 @@ class IconFix(NativeDatasetFix):
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
-                message="Ignoring netCDF variable .* invalid units .*",
-                category=UserWarning,
-                module="iris",
-            )  # iris < 3.8
-            warnings.filterwarnings(
-                "ignore",
-                message="Ignoring invalid units .* on netCDF variable .*",
-                category=UserWarning,
-                module="iris",
-            )  # iris >= 3.8
-            warnings.filterwarnings(
-                "ignore",
                 message="Failed to create 'height' dimension coordinate: The "
-                "'height' DimCoord bounds array must be strictly "
-                "monotonic.",
+                "'height' DimCoord bounds array must be strictly monotonic.",
                 category=UserWarning,
                 module="iris",
             )

--- a/esmvalcore/config/configurations/data-native-icon.yml
+++ b/esmvalcore/config/configurations/data-native-icon.yml
@@ -7,6 +7,9 @@ projects:
         rootpath: ~/climate_data
         dirname_template: "{exp}"
         filename_template: "{exp}_{var_type}*.nc"
+        ignore_warnings:
+          - message: "Failed to create 'height' dimension coordinate: The 'height' DimCoord bounds array must be strictly monotonic."
+            module: iris
       icon-outdata:
         <<: *icon
         dirname_template: "{exp}/outdata"

--- a/esmvalcore/io/local.py
+++ b/esmvalcore/io/local.py
@@ -61,7 +61,7 @@ import esmvalcore.io.protocol
 from esmvalcore.iris_helpers import ignore_warnings_context
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Iterable
+    from collections.abc import Iterable
 
     from netCDF4 import Variable
 
@@ -420,28 +420,28 @@ def _select_files(
     return selection
 
 
-class MissingFacetError(KeyError):
+class _MissingFacetError(KeyError):
     """Error raised when a facet required for filling the template is missing."""
 
 
-def format_collection(collection: Collection[Any]) -> str:
-    """Format a collection of items as a string for use in messages.
+def _format_iterable(iterable: Iterable[Any]) -> str:
+    """Format an iterable as a string for use in messages.
 
     Parameters
     ----------
-    collection:
-        The collection of items to format.
+    iterable:
+        The iterable to format.
 
     Returns
     -------
     :
         The formatted string.
     """
-    items = [f"'{item}'" for item in sorted(collection)]
+    items = [f"'{item}'" for item in sorted(iterable)]
     if len(items) > 1:
         items[-1] = f"and {items[-1]}"
-    txt = ", ".join(items)
-    return f"s {txt}" if len(collection) > 1 else f" {txt}"
+    txt = " ".join(items) if len(items) == 2 else ", ".join(items)
+    return f"s {txt}" if len(items) > 1 else f" {txt}"
 
 
 def _replace_tags(
@@ -483,12 +483,12 @@ def _replace_tags(
         pathset = _replace_tag(pathset, original_tag, replacewith)
     if failed:
         msg = (
-            f"Unable to complete path{format_collection(pathset)} because "
-            f"the facet{format_collection(failed)}"
+            f"Unable to complete path{_format_iterable(pathset)} because "
+            f"the facet{_format_iterable(failed)}"
             + (" has" if len(failed) == 1 else " have")
             + " not been specified."
         )
-        raise MissingFacetError(msg)
+        raise _MissingFacetError(msg)
     return [Path(p) for p in pathset]
 
 
@@ -597,7 +597,7 @@ class LocalDataSource(esmvalcore.io.protocol.DataSource):
 
         try:
             globs = self._get_glob_patterns(**facets)
-        except MissingFacetError as exc:
+        except _MissingFacetError as exc:
             self.debug_info = exc.args[0]
             return []
         self.debug_info = "No files found matching glob pattern " + "\n".join(

--- a/esmvalcore/io/local.py
+++ b/esmvalcore/io/local.py
@@ -598,8 +598,7 @@ class LocalDataSource(esmvalcore.io.protocol.DataSource):
         try:
             globs = self._get_glob_patterns(**facets)
         except MissingFacetError as exc:
-            self.debug_info = str(exc)
-            logger.debug(self.debug_info)
+            self.debug_info = exc.args[0]
             return []
         self.debug_info = "No files found matching glob pattern " + "\n".join(
             str(g) for g in globs

--- a/esmvalcore/io/local.py
+++ b/esmvalcore/io/local.py
@@ -58,11 +58,10 @@ from cf_units import Unit
 from netCDF4 import Dataset
 
 import esmvalcore.io.protocol
-from esmvalcore.exceptions import RecipeError
 from esmvalcore.iris_helpers import ignore_warnings_context
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Collection, Iterable
 
     from netCDF4 import Variable
 
@@ -421,6 +420,30 @@ def _select_files(
     return selection
 
 
+class MissingFacetError(KeyError):
+    """Error raised when a facet required for filling the template is missing."""
+
+
+def format_collection(collection: Collection[Any]) -> str:
+    """Format a collection of items as a string for use in messages.
+
+    Parameters
+    ----------
+    collection:
+        The collection of items to format.
+
+    Returns
+    -------
+    :
+        The formatted string.
+    """
+    items = [f"'{item}'" for item in sorted(collection)]
+    if len(items) > 1:
+        items[-1] = f"and {items[-1]}"
+    txt = ", ".join(items)
+    return f"s {txt}" if len(collection) > 1 else f" {txt}"
+
+
 def _replace_tags(
     paths: str | list[str],
     variable: Facets,
@@ -446,6 +469,7 @@ def _replace_tags(
             tlist.add("sub_experiment")
         pathset = new_paths
 
+    failed = set()
     for original_tag in tlist:
         tag, _, _ = _get_caps_options(original_tag)
 
@@ -454,12 +478,17 @@ def _replace_tags(
         elif tag == "version":
             replacewith = "*"
         else:
-            msg = (
-                f"Dataset key '{tag}' must be specified for {variable}, check "
-                f"your recipe entry and/or extra facet file(s)"
-            )
-            raise RecipeError(msg)
+            failed.add(tag)
+            continue
         pathset = _replace_tag(pathset, original_tag, replacewith)
+    if failed:
+        msg = (
+            f"Unable to complete path{format_collection(pathset)} because "
+            f"the facet{format_collection(failed)}"
+            + (" has" if len(failed) == 1 else " have")
+            + " not been specified."
+        )
+        raise MissingFacetError(msg)
     return [Path(p) for p in pathset]
 
 
@@ -566,7 +595,12 @@ class LocalDataSource(esmvalcore.io.protocol.DataSource):
         if "original_short_name" in facets:
             facets["short_name"] = facets["original_short_name"]
 
-        globs = self._get_glob_patterns(**facets)
+        try:
+            globs = self._get_glob_patterns(**facets)
+        except MissingFacetError as exc:
+            self.debug_info = str(exc)
+            logger.debug(self.debug_info)
+            return []
         self.debug_info = "No files found matching glob pattern " + "\n".join(
             str(g) for g in globs
         )

--- a/esmvalcore/local.py
+++ b/esmvalcore/local.py
@@ -164,7 +164,10 @@ class DataSource(LocalDataSource):
 
     def get_glob_patterns(self, **facets: FacetValue) -> list[Path]:
         """Compose the globs that will be used to look for files."""
-        return self._get_glob_patterns(**facets)
+        try:
+            return self._get_glob_patterns(**facets)
+        except _MissingFacetError as exc:
+            raise RecipeError(exc.args[0]) from exc
 
     def path2facets(self, path: Path, add_timerange: bool) -> dict[str, str]:
         """Extract facets from path."""
@@ -273,7 +276,10 @@ def find_files(
     if debug:
         globs = []
         for data_source in data_sources:
-            globs.extend(data_source._get_glob_patterns(**facets))  # noqa: SLF001
+            try:
+                globs.extend(data_source._get_glob_patterns(**facets))  # noqa: SLF001
+            except _MissingFacetError as exc:
+                raise RecipeError(exc.args[0]) from exc
         return files, sorted(globs)
     return files
 

--- a/esmvalcore/local.py
+++ b/esmvalcore/local.py
@@ -21,10 +21,12 @@ from esmvalcore.config._config import (
     get_project_config,
     load_config_developer,
 )
+from esmvalcore.exceptions import RecipeError
 from esmvalcore.io.local import (
     LocalDataSource,
     LocalFile,
     _filter_versions_called_latest,
+    _MissingFacetError,
     _replace_tags,
     _select_latest_version,
 )
@@ -300,7 +302,10 @@ def _get_output_file(variable: dict[str, Any], preproc_dir: Path) -> Path:
     if isinstance(variable.get("exp"), (list, tuple)):
         variable = dict(variable)
         variable["exp"] = "-".join(variable["exp"])
-    outfile = _replace_tags(cfg["output_file"], variable)[0]
+    try:
+        outfile = _replace_tags(cfg["output_file"], variable)[0]
+    except _MissingFacetError as exc:
+        raise RecipeError(exc.args[0]) from exc
     if "timerange" in variable:
         timerange = variable["timerange"].replace("/", "-")
         outfile = Path(f"{outfile}_{timerange}")

--- a/tests/integration/io/test_local.py
+++ b/tests/integration/io/test_local.py
@@ -232,7 +232,7 @@ def test_find_data_facet_missing() -> None:
         "exp": ["historical", "ssp585"],
     }
     expected_message = (
-        "Unable to complete paths 'test-dataset/historical/{ensemble}', and "
+        "Unable to complete paths 'test-dataset/historical/{ensemble}' and "
         "'test-dataset/ssp585/{ensemble}' because the facet 'ensemble' has "
         "not been specified."
     )

--- a/tests/integration/io/test_local.py
+++ b/tests/integration/io/test_local.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import os
 import pprint
+import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 import yaml
@@ -21,6 +23,9 @@ from esmvalcore.io.local import (
     _parse_period,
 )
 from esmvalcore.local import _get_output_file, _select_drs, find_files
+
+if TYPE_CHECKING:
+    import pytest_mock
 
 # Load test configuration
 with open(
@@ -171,6 +176,34 @@ def test_find_files(monkeypatch, root, cfg, mocker):
     assert [Path(f) for f in input_filelist] == sorted(ref_files)
     assert [Path(g) for g in globs] == sorted(ref_globs)
     esmvalcore.local._ensure_config_developer_drs.assert_called_once()
+
+
+def test_find_files_missing_facets(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """Test that a RecipeError is raised if a required facet is missing."""
+    mocker.patch.object(esmvalcore.local, "_ensure_config_developer_drs")
+    monkeypatch.setattr(esmvalcore.cmor.table, "CMOR_TABLES", {})
+    monkeypatch.setitem(
+        CFG,
+        "config_developer_file",
+        Path(esmvalcore.__path__[0], "config-developer.yml"),
+    )
+    monkeypatch.setitem(CFG, "drs", {"CMIP6": "default"})
+    monkeypatch.setitem(CFG, "rootpath", {"CMIP6": "/data/cmip6"})
+    facets = {
+        "project": "CMIP6",
+        "mip": "Amon",
+        "short_name": "tas",
+    }
+    expected_message = (
+        "Unable to complete path 'tas_Amon_{dataset}_{exp}_{ensemble}_{grid}*."
+        "nc' because the facets 'dataset', 'ensemble', 'exp', and 'grid' have "
+        "not been specified."
+    )
+    with pytest.raises(RecipeError, match=re.escape(expected_message)):
+        find_files(debug=True, **facets)
 
 
 def test_find_files_with_facets(monkeypatch, root):

--- a/tests/integration/io/test_local.py
+++ b/tests/integration/io/test_local.py
@@ -14,6 +14,7 @@ import esmvalcore.cmor.table
 import esmvalcore.config._config
 import esmvalcore.local
 from esmvalcore.config import CFG
+from esmvalcore.exceptions import RecipeError
 from esmvalcore.io.local import (
     LocalDataSource,
     LocalFile,
@@ -81,6 +82,30 @@ def test_get_output_file(monkeypatch, cfg):
     output_file = _get_output_file(cfg["variable"], cfg["preproc_dir"])
     expected = Path(cfg["output_file"])
     assert output_file == expected
+
+
+def test_get_output_file_missing_facets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a RecipeError is raised if a required facet is missing."""
+    monkeypatch.setattr(esmvalcore.cmor.table, "CMOR_TABLES", {})
+    monkeypatch.setitem(
+        CFG,
+        "config_developer_file",
+        Path(esmvalcore.__path__[0], "config-developer.yml"),
+    )
+    facets = {
+        "project": "CMIP6",
+        "mip": "Amon",
+        "short_name": "tas",
+    }
+    expected_message = (
+        "Unable to complete path 'CMIP6_{dataset}_Amon_{exp}_{ensemble}_tas"
+        "_{grid}' because the facets 'dataset', 'ensemble', 'exp', and 'grid' "
+        "have not been specified."
+    )
+    with pytest.raises(RecipeError, match=expected_message):
+        _get_output_file(facets, Path("/preproc/dir"))
 
 
 @pytest.mark.parametrize("cfg", CONFIG["get_output_file"])

--- a/tests/integration/io/test_local.py
+++ b/tests/integration/io/test_local.py
@@ -216,6 +216,31 @@ def test_find_data(root, cfg):
         assert str(pattern) in data_source.debug_info
 
 
+def test_find_data_facet_missing() -> None:
+    """Test that a MissingFacetError is raised if a required facet is missing."""
+    data_source = LocalDataSource(
+        name="test-data-source",
+        project="CMIP6",
+        rootpath=Path("/data/cmip6"),
+        priority=1,
+        dirname_template="{dataset}/{exp}/{ensemble}",
+        filename_template="{short_name}.nc",
+    )
+    facets = {
+        "short_name": "tas",
+        "dataset": "test-dataset",
+        "exp": ["historical", "ssp585"],
+    }
+    expected_message = (
+        "Unable to complete paths 'test-dataset/historical/{ensemble}', and "
+        "'test-dataset/ssp585/{ensemble}' because the facet 'ensemble' has "
+        "not been specified."
+    )
+    files = data_source.find_data(**facets)
+    assert not files
+    assert data_source.debug_info == expected_message
+
+
 def test_select_invalid_drs_structure(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(esmvalcore.cmor.table, "CMOR_TABLES", {})
     monkeypatch.setitem(

--- a/tests/unit/io/local/test_replace_tags.py
+++ b/tests/unit/io/local/test_replace_tags.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pytest
 
-from esmvalcore.io.local import MissingFacetError, _replace_tags
+from esmvalcore.io.local import (
+    _MissingFacetError,
+    _replace_tags,
+)
 
 VARIABLE = {
     "project": "CMIP6",
@@ -65,19 +68,20 @@ def test_replace_tags_missing_facet():
         "Unable to complete path 'tas_{missing}_*.nc' because the facet "
         "'missing' has not been specified."
     )
-    with pytest.raises(MissingFacetError, match=re.escape(expected_message)):
+    with pytest.raises(_MissingFacetError, match=re.escape(expected_message)):
         _replace_tags(paths, variable)
 
 
 def test_replace_tags_missing_facets():
     """Check that a MissingFacetError is raised if multiple facets are missing."""
-    paths = ["{short_name}_{missing}_{other}_*.nc"]
+    paths = ["{missing1}_{short_name}_{missing2}_{missing3}_*.nc"]
     variable = {"short_name": "tas"}
     expected_message = (
-        "Unable to complete path 'tas_{missing}_{other}_*.nc' because the facets "
-        "'missing', and 'other' have not been specified."
+        "Unable to complete path '{missing1}_tas_{missing2}_{missing3}_*.nc' "
+        "because the facets 'missing1', 'missing2', and 'missing3' have not "
+        "been specified."
     )
-    with pytest.raises(MissingFacetError, match=re.escape(expected_message)):
+    with pytest.raises(_MissingFacetError, match=re.escape(expected_message)):
         _replace_tags(paths, variable)
 
 

--- a/tests/unit/io/local/test_replace_tags.py
+++ b/tests/unit/io/local/test_replace_tags.py
@@ -1,11 +1,11 @@
 """Tests for `_replace_tags` in `esmvalcore.io.local`."""
 
+import re
 from pathlib import Path
 
 import pytest
 
-from esmvalcore.exceptions import RecipeError
-from esmvalcore.io.local import _replace_tags
+from esmvalcore.io.local import MissingFacetError, _replace_tags
 
 VARIABLE = {
     "project": "CMIP6",
@@ -58,13 +58,27 @@ def test_replace_tags_with_caps():
 
 
 def test_replace_tags_missing_facet():
-    """Check that a RecipeError is raised if a required facet is missing."""
+    """Check that a MissingFacetError is raised if a required facet is missing."""
     paths = ["{short_name}_{missing}_*.nc"]
     variable = {"short_name": "tas"}
-    with pytest.raises(RecipeError) as exc:
+    expected_message = (
+        "Unable to complete path 'tas_{missing}_*.nc' because the facet "
+        "'missing' has not been specified."
+    )
+    with pytest.raises(MissingFacetError, match=re.escape(expected_message)):
         _replace_tags(paths, variable)
 
-    assert "Dataset key 'missing' must be specified" in exc.value.message
+
+def test_replace_tags_missing_facets():
+    """Check that a MissingFacetError is raised if multiple facets are missing."""
+    paths = ["{short_name}_{missing}_{other}_*.nc"]
+    variable = {"short_name": "tas"}
+    expected_message = (
+        "Unable to complete path 'tas_{missing}_{other}_*.nc' because the facets "
+        "'missing', and 'other' have not been specified."
+    )
+    with pytest.raises(MissingFacetError, match=re.escape(expected_message)):
+        _replace_tags(paths, variable)
 
 
 def test_replace_tags_list_of_str():

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -1,0 +1,29 @@
+"""Tests for the (deprecated) esmvalcore.local module."""
+
+from pathlib import Path
+
+import pytest
+
+from esmvalcore.exceptions import RecipeError
+from esmvalcore.local import DataSource
+
+
+def test_get_glob_patterns_missing_facets() -> None:
+    """Test that get_glob_patterns raises when required facets are missing."""
+    local_data_source = DataSource(
+        name="test",
+        project="test",
+        priority=1,
+        rootpath=Path("/climate_data"),
+        dirname_template="{dataset}",
+        filename_template="{short_name}*nc",
+    )
+    facets = {
+        "short_name": "tas",
+    }
+    expected_message = (
+        "Unable to complete path '{dataset}' because the facet 'dataset' has "
+        "not been specified."
+    )
+    with pytest.raises(RecipeError, match=expected_message):
+        local_data_source.get_glob_patterns(**facets)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Do not raise an exception if a facet required by `esmvalcore.io.local.LocalDataSource` is missing, but log the problem and continue. Maybe the data can be found using some other data source and if not, the user will see the log message.

Closes #2995

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
