### PR TITLE
Modify ERA5 fixes to support data produced by the new GRIB to netcdf converter version of ECMWF

### DIFF
--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -555,11 +555,8 @@ class AllVars(Fix):
             coord.points = coord.core_points().astype("float64")
             # For now, remove "stored_direction" attribute introduced by the
             # new netCDF converter from ECMWF for ERA5 data if missing.
-            if (
-                coord.name() == "latitude"
-                and "stored_direction" in coord.attributes
-            ):
-                coord.attributes.pop("stored_direction")
+            if coord.name() == "latitude":
+                coord.attributes.pop("stored_direction", None)
             if (
                 not coord.has_bounds()
                 and len(coord.core_points()) > 1

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -516,7 +516,7 @@ class Zg(Fix):
 class AllVars(Fix):
     """Fixes for all variables."""
 
-    def _fix_coordinates(  # noqa: C901
+    def _fix_coordinates(  # noqa: C901,PLR0912
         self,
         cube,
     ):
@@ -553,6 +553,13 @@ class AllVars(Fix):
             coord.var_name = coord_def.out_name
             coord.long_name = coord_def.long_name
             coord.points = coord.core_points().astype("float64")
+            # For now, remove "stored_direction" attribute introduced by the
+            # new netCDF converter from ECMWF for ERA5 data if missing.
+            if (
+                coord.name() == "latitude"
+                and "stored_direction" in coord.attributes
+            ):
+                coord.attributes.pop("stored_direction")
             if (
                 not coord.has_bounds()
                 and len(coord.core_points()) > 1

--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 
 import numpy as np
+from cf_units import Unit
 from iris.cube import CubeList
 from iris.util import reverse
 
@@ -540,7 +541,12 @@ class AllVars(Fix):
                 ]
             coord = cube.coord(axis=axis)
             if axis == "T":
-                coord.convert_units("days since 1850-1-1 00:00:00.0")
+                coord.convert_units(
+                    Unit(
+                        "days since 1850-1-1 00:00:00.0",
+                        calendar=coord.units.calendar,
+                    ),
+                )
             if axis in ("X", "Y", "Z"):
                 coord.convert_units(coord_def.units)
             coord.standard_name = coord_def.standard_name

--- a/tests/integration/cmor/_fixes/native6/test_era5.py
+++ b/tests/integration/cmor/_fixes/native6/test_era5.py
@@ -72,6 +72,17 @@ def _era5_latitude():
     )
 
 
+def _era5_latitude_w_direction():
+    return DimCoord(
+        np.array([90.0, 0.0, -90.0]),
+        standard_name="latitude",
+        long_name="latitude",
+        var_name="latitude",
+        units=Unit("degrees"),
+        attributes={"stored_direction": "decreasing"},
+    )
+
+
 def _era5_longitude():
     return DimCoord(
         np.array([0, 180, 359.75]),
@@ -1577,3 +1588,38 @@ def test_unstructured_grid(unstructured_grid_cubes):
     assert lon.bounds is None
 
     assert fixed_cube.attributes["GRIB_PARAM"] == "(1, 1)"
+
+
+@pytest.fixture
+def cube_latitude_w_direction():
+    """Sample cube with latitude coordinate with direction."""
+    time = DimCoord(
+        [-31, 0, 31],
+        standard_name="time",
+        units="days since 1850-01-01",
+    )
+    cube = Cube(
+        _era5_data("mon"),
+        standard_name="air_temperature",
+        units="K",
+        dim_coords_and_dims=[
+            (time, 0),
+            (_era5_latitude_w_direction(), 1),
+            (_era5_longitude(), 2),
+        ],
+    )
+    return CubeList([cube])
+
+
+def test_latitude_w_direction(cube_latitude_w_direction):
+    """Test removal of latitude stored_direction attribute."""
+    fixed_cubes = fix_metadata(
+        cube_latitude_w_direction,
+        "tas",
+        "native6",
+        "era5",
+        "Amon",
+    )
+    assert len(fixed_cubes) == 1
+    fixed_cube = fixed_cubes[0]
+    assert fixed_cube.coord("latitude") == _cmor_latitude()


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

ECMWF is now using a different netCDF converter for the ERA5 GRIB files available on the CDS and ADS systems. These changes notably involve modifications in the coordinates (notably time and latitude) that can lead to errors when using newly downloaded ERA5 data. The detailed description of the modifications can be found on the ECMWF Confluence page [here](https://confluence.ecmwf.int/display/CKB/GRIB+to+netCDF+conversion+on+new+CDS+and+ADS+systems).

This PR aims to tackle two identified issues:

- The time coordinate unit and calendar have been changed from `"hours since 1900-01-01 00:00:00.0, gregorian"` to `"seconds since 1970-01-01, proleptic_gregorian"` which leads to an error when converting the time unit in the ERA5 `_fix_coordinates` method.
    - This is solved by including the calendar in the target unit for the time conversion.
- The latitude coordinate metadata has been changed to include the `stored_direction` which leads to an error when trying to concatenate data files from the legacy and the new version because of differing metadata in the iris cubes.
    - This is solved by removing this attribute in cubes downloaded with the legacy version of the converter. If the direction of the coordinate is erroneous, it will be fixed by [`esmvalcore.cmor._fixes.fix._fix_coord_direction`](https://github.com/ESMValGroup/ESMValCore/blob/main/esmvalcore/cmor/_fixes/fix.py#L825-L830)

Closes #3026 

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
