### PR TITLE
Avoid a crash when running ``esmvaltool config show`` with Python 3.14

### DIFF
--- a/esmvalcore/_task.py
+++ b/esmvalcore/_task.py
@@ -17,7 +17,7 @@ import textwrap
 import threading
 import time
 from copy import deepcopy
-from pathlib import Path, PosixPath
+from pathlib import Path
 from shutil import which
 
 import dask
@@ -29,15 +29,6 @@ from ._citation import _write_citation_files
 from ._provenance import TrackedFile, get_task_provenance
 from .config._dask import get_distributed_client
 from .config._diagnostics import DIAGNOSTICS, TAGS
-
-
-def path_representer(dumper, data):
-    """For printing pathlib.Path objects in yaml files."""
-    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
-
-
-yaml.representer.SafeRepresenter.add_representer(Path, path_representer)
-yaml.representer.SafeRepresenter.add_representer(PosixPath, path_representer)
 
 logger = logging.getLogger(__name__)
 

--- a/esmvalcore/config/__init__.py
+++ b/esmvalcore/config/__init__.py
@@ -17,7 +17,7 @@ import contextlib
 from pathlib import Path, PosixPath
 
 import iris
-import yaml
+import yaml.representer
 
 from esmvalcore.config._config_object import CFG, Config, Session
 
@@ -37,7 +37,10 @@ for attr, value in {
 
 
 # Add a representer for pathlib objects to the YAML library.
-def path_representer(dumper, data):
+def path_representer(
+    dumper: yaml.representer.SafeRepresenter,
+    data: Path | PosixPath,
+) -> yaml.representer.ScalarNode:
     """For printing pathlib.Path objects in yaml files."""
     return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
 

--- a/esmvalcore/config/__init__.py
+++ b/esmvalcore/config/__init__.py
@@ -14,8 +14,10 @@
 """
 
 import contextlib
+from pathlib import Path, PosixPath
 
 import iris
+import yaml
 
 from esmvalcore.config._config_object import CFG, Config, Session
 
@@ -32,3 +34,13 @@ for attr, value in {
 }.items():
     with contextlib.suppress(AttributeError):
         setattr(iris.FUTURE, attr, value)
+
+
+# Add a representer for pathlib objects to the YAML library.
+def path_representer(dumper, data):
+    """For printing pathlib.Path objects in yaml files."""
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
+
+
+yaml.representer.SafeRepresenter.add_representer(Path, path_representer)
+yaml.representer.SafeRepresenter.add_representer(PosixPath, path_representer)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/3062

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [ ] [🛠][1] ~[Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added~ -> will do this in the `pixi` branch to avoid another merge conflict
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
