### PR TITLE
Drop range related attributes on load

### DIFF
--- a/esmvalcore/preprocessor/_io.py
+++ b/esmvalcore/preprocessor/_io.py
@@ -42,6 +42,28 @@ VARIABLE_KEYS = {
 }
 
 
+def _drop_range_attributes(cube: Cube) -> Cube:
+    """Drop range related attributes from cube and its components."""
+    drop_attrs = (
+        "actual_range",
+        "valid_max",
+        "valid_min",
+        "valid_range",
+    )
+    cube = cube.copy()
+    for attr in drop_attrs:
+        cube.attributes.pop(attr, None)
+        for coord in cube.dim_coords:
+            coord.attributes.pop(attr, None)
+        for aux_coord in cube.aux_coords:
+            aux_coord.attributes.pop(attr, None)
+        for cell_measure in cube.cell_measures():
+            cell_measure.attributes.pop(attr, None)
+        for ancillary_variable in cube.ancillary_variables():
+            ancillary_variable.attributes.pop(attr, None)
+    return cube
+
+
 def load(
     file: str
     | Path
@@ -133,7 +155,9 @@ def load(
             )
             warnings.warn(warn_msg, ESMValCoreLoadWarning, stacklevel=2)
 
-    return cubes
+    # Drop range related attributes as these are likely to be
+    # invalidated by preprocessing the data.
+    return CubeList(_drop_range_attributes(cube) for cube in cubes)
 
 
 def _load_zarr(

--- a/tests/integration/preprocessor/_io/test_load.py
+++ b/tests/integration/preprocessor/_io/test_load.py
@@ -39,7 +39,7 @@ def test_load(tmp_path, sample_cube):
     assert_array_equal(sample_cube.coord("latitude").points, [1, 2])
 
 
-def test_load_with_valid_max(tmp_path: Path, sample_cube: Cube) -> None:
+def test_load_with_range_attrs(tmp_path: Path, sample_cube: Cube) -> None:
     """Test loading multiple files."""
     sample_cube.attributes["valid_max"] = 1
     ancillary_var = AncillaryVariable(
@@ -50,7 +50,7 @@ def test_load_with_valid_max(tmp_path: Path, sample_cube: Cube) -> None:
     ancillary_var.attributes["valid_max"] = 1
     sample_cube.add_ancillary_variable(ancillary_var, data_dims=[0])
     cell_measure = CellMeasure([1, 1], standard_name="cell_area", units="m2")
-    cell_measure.attributes["valid_max"] = 1
+    cell_measure.attributes["valid_min"] = 1
     sample_cube.add_cell_measure(cell_measure, data_dims=[0])
     temp_file = tmp_path / "cube.nc"
     iris.save(sample_cube, temp_file)
@@ -64,6 +64,12 @@ def test_load_with_valid_max(tmp_path: Path, sample_cube: Cube) -> None:
         sample_cube.data,
         np.ma.array([1, 2], mask=[False, True]),
     )
+    assert "valid_max" not in sample_cube.ancillary_variables()[0].attributes
+    assert_array_equal(
+        sample_cube.ancillary_variables()[0].data,
+        np.ma.array([0, 1.1], mask=[False, True]),
+    )
+    assert "valid_min" not in sample_cube.cell_measures()[0].attributes
 
 
 def test_load_grib():

--- a/tests/integration/preprocessor/_io/test_load.py
+++ b/tests/integration/preprocessor/_io/test_load.py
@@ -9,7 +9,7 @@ import ncdata
 import numpy as np
 import pytest
 import xarray as xr
-from iris.coords import DimCoord
+from iris.coords import AncillaryVariable, CellMeasure, DimCoord
 from iris.cube import Cube, CubeList
 
 from esmvalcore.exceptions import ESMValCoreLoadWarning
@@ -39,9 +39,19 @@ def test_load(tmp_path, sample_cube):
     assert_array_equal(sample_cube.coord("latitude").points, [1, 2])
 
 
-def test_load_with_valid_max(tmp_path, sample_cube):
+def test_load_with_valid_max(tmp_path: Path, sample_cube: Cube) -> None:
     """Test loading multiple files."""
     sample_cube.attributes["valid_max"] = 1
+    ancillary_var = AncillaryVariable(
+        [0, 1.1],
+        standard_name="land_area_fraction",
+        units="%",
+    )
+    ancillary_var.attributes["valid_max"] = 1
+    sample_cube.add_ancillary_variable(ancillary_var, data_dims=[0])
+    cell_measure = CellMeasure([1, 1], standard_name="cell_area", units="m2")
+    cell_measure.attributes["valid_max"] = 1
+    sample_cube.add_cell_measure(cell_measure, data_dims=[0])
     temp_file = tmp_path / "cube.nc"
     iris.save(sample_cube, temp_file)
 

--- a/tests/integration/preprocessor/_io/test_load.py
+++ b/tests/integration/preprocessor/_io/test_load.py
@@ -39,6 +39,23 @@ def test_load(tmp_path, sample_cube):
     assert_array_equal(sample_cube.coord("latitude").points, [1, 2])
 
 
+def test_load_with_valid_max(tmp_path, sample_cube):
+    """Test loading multiple files."""
+    sample_cube.attributes["valid_max"] = 1
+    temp_file = tmp_path / "cube.nc"
+    iris.save(sample_cube, temp_file)
+
+    cubes = load(temp_file)
+
+    assert len(cubes) == 1
+    sample_cube = cubes[0]
+    assert "valid_max" not in sample_cube.attributes
+    assert_array_equal(
+        sample_cube.data,
+        np.ma.array([1, 2], mask=[False, True]),
+    )
+
+
 def test_load_grib():
     """Test loading a grib file."""
     grib_path = (


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Drop value range-related attributes on load because they are very likely to be invalidated by any preprocessor function that is applied afterwards. They are not needed anymore after loading because they have already been interpreted.

This should fix the issue reported in ESMValGroup/ESMValTool#4434

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
