### PR TITLE
Mention the branding suffix in the error message when no entry can be found in CMOR tables

### DIFF
--- a/esmvalcore/cmor/table.py
+++ b/esmvalcore/cmor/table.py
@@ -78,21 +78,27 @@ def _update_cmor_facets(facets: Facets) -> None:
     project: str = facets["project"]  # type: ignore[assignment]
     mip: str = facets["mip"]  # type: ignore[assignment]
     short_name: str = facets["short_name"]  # type: ignore[assignment]
+    branding_suffix: str | None = facets.get("branding_suffix")  # type: ignore[assignment]
     derive: bool = facets.get("derive", False)  # type: ignore[assignment]
     table = CMOR_TABLES.get(project)
     if table:
         table_entry = table.get_variable(
             mip,
             short_name,
-            branding_suffix=facets.get("branding_suffix"),  # type: ignore[arg-type]
+            branding_suffix=branding_suffix,
             derived=derive,
         )
     else:
         table_entry = None
     if table_entry is None:
         msg = (
-            f"Unable to load CMOR table (project) '{project}' for variable "
-            f"'{short_name}' with mip '{mip}'"
+            f"Variable '{short_name}' "
+            + (
+                f"with branding suffix '{branding_suffix}' "
+                if branding_suffix
+                else ""
+            )
+            + f"not available in table '{mip}' of project '{project}'"
         )
         raise RecipeError(msg)
     facets["original_short_name"] = table_entry.short_name

--- a/esmvalcore/preprocessor/_other.py
+++ b/esmvalcore/preprocessor/_other.py
@@ -130,7 +130,7 @@ def _get_var_info(
                 if branding_suffix
                 else ""
             )
-            + f"not available for table '{mip}' of project '{project}'"
+            + f"not available in table '{mip}' of project '{project}'"
         )
         raise ValueError(msg)
     return var_info

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -2472,7 +2472,7 @@ def test_landmask_no_fx(tmp_path, patched_failing_datafinder, session):
         assert dataset.supplementaries == []
 
 
-def test_wrong_project(tmp_path, patched_datafinder, session):
+def test_wrong_branding_suffix(tmp_path, patched_datafinder, session):
     content = dedent("""
         preprocessors:
           preproc:
@@ -2484,7 +2484,8 @@ def test_wrong_project(tmp_path, patched_datafinder, session):
               tos:
                 preprocessor: preproc
                 project: CMIP7
-                mip: Omon
+                mip: ocean
+                branding_suffix: wrong
                 exp: historical
                 start_year: 2000
                 end_year: 2005
@@ -2493,10 +2494,7 @@ def test_wrong_project(tmp_path, patched_datafinder, session):
                   - {dataset: CanESM2}
             scripts: null
         """)
-    msg = (
-        "Unable to load CMOR table (project) 'CMIP7' for variable 'tos' "
-        "with mip 'Omon'"
-    )
+    msg = "Variable 'tos' with branding suffix 'wrong' not available in table 'ocean' of project 'CMIP7'"
     with pytest.raises(RecipeError) as wrong_proj:
         get_recipe(tmp_path, content, session)
     assert str(wrong_proj.value) == msg
@@ -3922,7 +3920,7 @@ def test_align_metadata_invalid_name(tmp_path, patched_datafinder, session):
             scripts: null
         """)
     msg = (
-        "align_metadata failed: Variable 'zzz' not available for table 'Amon' "
+        "align_metadata failed: Variable 'zzz' not available in table 'Amon' "
         "of project 'CMIP6'. Set `strict=False` to ignore this."
     )
     with pytest.raises(RecipeError) as exc:

--- a/tests/unit/preprocessor/_other/test_other.py
+++ b/tests/unit/preprocessor/_other/test_other.py
@@ -80,7 +80,7 @@ def test_align_metadata_invalid_project():
 
 def test_align_metadata_invalid_short_name_strict():
     cube = Cube(0.0, units="1")
-    msg = "Variable 'zzz' not available for table 'Amon' of project 'CMIP6'"
+    msg = "Variable 'zzz' not available in table 'Amon' of project 'CMIP6'"
     with pytest.raises(ValueError, match=msg):
         align_metadata(cube, "CMIP6", "Amon", "zzz")
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Mention the branding suffix in the error message when no entry can be found in CMOR tables.

As suggested in https://github.com/ESMValGroup/ESMValCore/pull/2946#issuecomment-4475312352


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
