### PR TITLE
[DNM] Investigate CircleCI Flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ workflows:
   commit:
     jobs:
       - test
+      - test_with_upstream_developments
 
   nightly:
     triggers:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import warnings
 from copy import deepcopy
-from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from esmvalcore.config import Session
 
 
-@lru_cache
+# @lru_cache
 def _load_default_config():
     """Create a configuration object with default values."""
     with warnings.catch_warnings():


### PR DESCRIPTION
As reported by @bouweandela in #3069 

- my take is there is a caching issue on CircleCI since we don't see those tests fail on GHA - but alas, the test with upstream dev pkgs is not run there (on GHA)