### PR TITLE
Add support for freshly downloaded ERA5 hourly data

### DIFF
--- a/esmvalcore/cmor/_fixes/native6/era5.py
+++ b/esmvalcore/cmor/_fixes/native6/era5.py
@@ -33,7 +33,9 @@ def fix_hourly_time_coordinate(cube, frequency):
     # variables from ERA5 may lead to some differences.
     if frequency.startswith("1hr"):
         time = cube.coord(axis="T")
-        if str(time.units).startswith("hours since"):
+        if str(time.units).startswith("seconds since"):
+            shift = 1800.0
+        elif str(time.units).startswith("hours since"):
             shift = 0.5
         elif str(time.units).startswith("days since"):
             shift = 1.0 / 48.0

--- a/tests/integration/cmor/_fixes/native6/test_era5.py
+++ b/tests/integration/cmor/_fixes/native6/test_era5.py
@@ -51,7 +51,7 @@ def test_fix_accumulated_units_fail():
     time = DimCoord(
         [0, 1, 2],
         standard_name="time",
-        units=Unit("days hour 1900-01-01"),
+        units=Unit("days since 1900-01-01"),
     )
     cube = Cube(
         [1, 6, 3],

--- a/tests/integration/cmor/_fixes/native6/test_era5.py
+++ b/tests/integration/cmor/_fixes/native6/test_era5.py
@@ -371,8 +371,6 @@ def clt_era5_hourly():
             (_era5_longitude(), 2),
         ],
     )
-    # Test time units of newly downloaded ERA5 data (2026-05-20)
-    cube.coord("time").convert_units("seconds since 1970-01-01")
     return CubeList([cube])
 
 
@@ -410,6 +408,8 @@ def evspsbl_era5_hourly():
             (_era5_longitude(), 2),
         ],
     )
+    # Test time units of newly downloaded ERA5 data (2026-05-20)
+    cube.coord("time").convert_units("seconds since 1970-01-01")
     return CubeList([cube])
 
 

--- a/tests/integration/cmor/_fixes/native6/test_era5.py
+++ b/tests/integration/cmor/_fixes/native6/test_era5.py
@@ -51,7 +51,7 @@ def test_fix_accumulated_units_fail():
     time = DimCoord(
         [0, 1, 2],
         standard_name="time",
-        units=Unit("days since 1900-01-01"),
+        units=Unit("days hour 1900-01-01"),
     )
     cube = Cube(
         [1, 6, 3],
@@ -371,6 +371,8 @@ def clt_era5_hourly():
             (_era5_longitude(), 2),
         ],
     )
+    # Test time units of newly downloaded ERA5 data (2026-05-20)
+    cube.coord("time").convert_units("seconds since 1970-01-01")
     return CubeList([cube])
 
 


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Freshly downloaded hourly ERA5 data uses the time units `seconds since 1970-01-01`, which is currently not supported.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
