### PR TITLE
Add mesh fix for CMIP6 ICON-ESM-LR conservative regridding

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -229,6 +229,11 @@
       "affiliation": "Climate Resource, Australia",
       "name": "Lewis, Jared",
       "orcid": "https://orcid.org/0000-0002-8155-8924"
+    },
+    {
+      "affiliation": "METU, Turkey",
+      "name": "Acar, Ali Osman",
+      "orcid": "0000-0002-9813-8387"
     }
   ],
   "description": "ESMValCore: A community tool for pre-processing data from Earth system models in CMIP and running analysis scripts.",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -233,6 +233,11 @@ authors:
     family-names: Lewis
     given-names: Jared
     orcid: "https://orcid.org/0000-0002-8155-8924"
+  -
+    affiliation: "METU, Turkey"
+    family-names: Acar
+    given-names: Ali Osman
+    orcid: "https://orcid.org/0000-0002-9813-8387"
 
 cff-version: 1.2.0
 date-released: 2026-06-30

--- a/esmvalcore/cmor/_fixes/cmip6/icon_esm_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/icon_esm_lr.py
@@ -1,10 +1,147 @@
 """Fixes for ICON-ESM-LR model."""
 
+import numpy as np
+from iris.coords import AuxCoord
+from iris.mesh import Connectivity, MeshXY
+
 from esmvalcore.cmor._fixes.fix import Fix
+from esmvalcore.iris_helpers import has_unstructured_grid
+
+# deduplicate decimals - round cartesian coords to merge
+# identical vertices (especially pole vertices)
+CARTESIAN_COORDINATE_DECIMALS = 12
 
 
 class AllVars(Fix):
-    """Fixes for all variables."""
+    """Adapt the native ICON mesh fix for ICON-ESM-LR outputs.
+
+    Like the native ICON fix (`esmvalcore.cmor._fixes.icon._base_fixes`).
+    this avoids ``MeshXY.from_coords`` because shared
+    polygon vertices would be duplicated. Since CMIP6 ICON-ESM-LR files don't
+    have ``vertex_of_cell``, recreate the connectivity from coordinate
+    bounds.
+    """
+
+    @staticmethod
+    def _can_create_mesh(cube):
+        # check if mesh is there
+        if cube.mesh is not None:
+            return False
+        # unstructured?
+        if not has_unstructured_grid(cube):
+            return False
+
+        lat = cube.coord("latitude")
+        lon = cube.coord("longitude")
+
+        # check bounds
+        if not lat.has_bounds() or not lon.has_bounds():
+            return False
+        if lat.bounds.shape != lon.bounds.shape:
+            return False
+        return lat.bounds.ndim == 2
+
+    @staticmethod
+    def _get_node_coords_and_connectivity(lat_bounds, lon_bounds):
+        """Build unique mesh nodes and face-node connectivity.
+
+        Cell vertices are converted to cartesian coordinates to
+        identify shared nodes. Duplicate vertices are
+        removed and a face-node connectivity array is generated.
+        """
+        lat_rad = np.deg2rad(lat_bounds)
+        lon_rad = np.deg2rad(lon_bounds)
+
+        cartesian = np.stack(
+            [
+                np.cos(lat_rad) * np.cos(lon_rad),
+                np.cos(lat_rad) * np.sin(lon_rad),
+                np.sin(lat_rad),
+            ],
+            axis=-1,
+        )
+
+        # round coords to avoid floating point diffs
+        rounded = np.round(
+            cartesian.reshape(-1, 3),
+            decimals=CARTESIAN_COORDINATE_DECIMALS,
+        )
+        # unique mesh nodes
+        unique_nodes, inverse = np.unique(
+            rounded,
+            axis=0,
+            return_inverse=True,
+        )
+
+        # we create face-node connectivity and back to lon/lat
+        connectivity = inverse.reshape(lat_bounds.shape)
+        norm = np.linalg.norm(unique_nodes, axis=1)
+        unit_nodes = unique_nodes / norm[:, np.newaxis]
+        node_lat = np.rad2deg(np.arcsin(unit_nodes[:, 2]))
+        node_lon = (
+            np.rad2deg(np.arctan2(unit_nodes[:, 1], unit_nodes[:, 0])) % 360.0
+        )
+
+        return node_lat, node_lon, connectivity
+
+    def _fix_unstructured_mesh(self, cube):
+        """Create and attach the Iris mesh.
+
+        Constructs node coordinates and face-node connectivity
+        from latitude longitude bounds and replaces the original
+        coordinate representation with Iris mesh coordinates.
+        """
+        if not self._can_create_mesh(cube):
+            return
+
+        lat = cube.coord("latitude")
+        lon = cube.coord("longitude")
+        mesh_dim = cube.coord_dims(lat)
+
+        # construct the face_node_connectivity from bounds
+        node_lat_points, node_lon_points, face_node_connectivity = (
+            self._get_node_coords_and_connectivity(lat.bounds, lon.bounds)
+        )
+
+        node_lat = AuxCoord(
+            node_lat_points,
+            standard_name="latitude",
+            long_name="node latitude",
+            var_name="nlat",
+            units=lat.units,
+        )
+        node_lon = AuxCoord(
+            node_lon_points,
+            standard_name="longitude",
+            long_name="node longitude",
+            var_name="nlon",
+            units=lon.units,
+        )
+
+        face_lat = lat.copy()
+        face_lon = lon.copy()
+        # Update face bounds using the deduplicated node coords.
+        face_lat.bounds = node_lat.points[face_node_connectivity]
+        face_lon.bounds = node_lon.points[face_node_connectivity]
+
+        # Same create mesh logic with native ICON fix (Iris mesh object).
+        connectivity = Connectivity(
+            indices=face_node_connectivity,
+            cf_role="face_node_connectivity",
+            start_index=0,
+            location_axis=0,
+        )
+        mesh = MeshXY(
+            topology_dimension=2,
+            node_coords_and_axes=[(node_lat, "y"), (node_lon, "x")],
+            face_coords_and_axes=[(face_lat, "y"), (face_lon, "x")],
+            connectivities=[connectivity],
+        )
+
+        cube.remove_coord("latitude")
+        cube.remove_coord("longitude")
+        for mesh_coord in mesh.to_MeshCoords("face"):
+            cube.add_aux_coord(mesh_coord, mesh_dim)
 
     def fix_metadata(self, cubes):
         """Rename ``var_name`` of latitude and longitude.
@@ -29,5 +166,6 @@ class AllVars(Fix):
             for std_name, var_name in varnames_to_change.items():
                 if cube.coords(std_name):
                     cube.coord(std_name).var_name = var_name
+            self._fix_unstructured_mesh(cube)
 
         return cubes

--- a/esmvalcore/cmor/_fixes/cmip6/icon_esm_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/icon_esm_lr.py
@@ -45,9 +45,12 @@ class AllVars(Fix):
     def _get_node_coords_and_connectivity(lat_bounds, lon_bounds):
         """Build unique mesh nodes and face-node connectivity.
 
-        Cell vertices are converted to cartesian coordinates to
-        identify shared nodes. Duplicate vertices are
-        removed and a face-node connectivity array is generated.
+        Cell vertices are converted to cartesian coordinates before
+        deduplication so shared nodes can be identified reliably. This avoids
+        duplicate pole nodes, where the same physical point may be represented
+        by different longitude values. The unique nodes are then converted back
+        to longitude/latitude coordinates, and the inverse indices are used to
+        build the face-node connectivity.
         """
         lat_rad = np.deg2rad(lat_bounds)
         lon_rad = np.deg2rad(lon_bounds)
@@ -73,7 +76,8 @@ class AllVars(Fix):
             return_inverse=True,
         )
 
-        # we create face-node connectivity and back to lon/lat
+        # rounding can move the cartesian coords slightly away
+        # so normalize before converting the unique nodes back to lon/lat
         connectivity = inverse.reshape(lat_bounds.shape)
         norm = np.linalg.norm(unique_nodes, axis=1)
         unit_nodes = unique_nodes / norm[:, np.newaxis]
@@ -91,7 +95,6 @@ class AllVars(Fix):
         from latitude longitude bounds and replaces the original
         coordinate representation with Iris mesh coordinates.
         """
-
         lat = cube.coord("latitude")
         lon = cube.coord("longitude")
         mesh_dim = cube.coord_dims(lat)

--- a/esmvalcore/cmor/_fixes/cmip6/icon_esm_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/icon_esm_lr.py
@@ -91,8 +91,6 @@ class AllVars(Fix):
         from latitude longitude bounds and replaces the original
         coordinate representation with Iris mesh coordinates.
         """
-        if not self._can_create_mesh(cube):
-            return
 
         lat = cube.coord("latitude")
         lon = cube.coord("longitude")
@@ -166,6 +164,7 @@ class AllVars(Fix):
             for std_name, var_name in varnames_to_change.items():
                 if cube.coords(std_name):
                     cube.coord(std_name).var_name = var_name
-            self._fix_unstructured_mesh(cube)
+            if self._can_create_mesh(cube):
+                self._fix_unstructured_mesh(cube)
 
         return cubes

--- a/tests/integration/cmor/_fixes/cmip6/test_icon_esm_lr.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_icon_esm_lr.py
@@ -1,5 +1,6 @@
 """Tests for the fixes of ICON-ESM-LR."""
 
+import numpy as np
 import pytest
 from iris.coords import AuxCoord
 from iris.cube import Cube, CubeList
@@ -95,3 +96,63 @@ def test_allvars_fix_metadata_no_lat_lon(cubes):
     fix = AllVars(None)
     out_cubes = fix.fix_metadata(cubes)
     assert cubes is out_cubes
+
+
+def test_allvars_fix_metadata_adds_mesh():
+    lat = AuxCoord(
+        [0.5, 0.5],
+        standard_name="latitude",
+        var_name="latitude",
+        units="degrees_north",
+        bounds=[[0.0, 0.0, 1.0], [0.0, 1.0, 1.0]],
+    )
+    lon = AuxCoord(
+        [0.5, 0.5],
+        standard_name="longitude",
+        var_name="longitude",
+        units="degrees_east",
+        bounds=[[0.0, 1.0, 0.0], [1.0, 1.0, 0.0]],
+    )
+    cube = Cube(
+        np.array([1.0, 2.0]),
+        var_name="tas",
+        aux_coords_and_dims=[(lat, 0), (lon, 0)],
+    )
+
+    AllVars(None).fix_metadata(CubeList([cube]))
+
+    assert cube.mesh is not None
+    assert cube.coords("latitude", mesh_coords=True)
+    assert cube.coords("longitude", mesh_coords=True)
+    assert cube.mesh.connectivity().shape == (2, 3)
+
+
+def test_allvars_fix_metadata_merges_pole_vertices():
+    """Ensure pole vertices are merged into a single mesh node.
+
+    there must be 4 nodes: North Pole, (0,0), (0,120), (0,240)
+    """
+    lat = AuxCoord(
+        [60.0, 60.0],
+        standard_name="latitude",
+        var_name="latitude",
+        units="degrees_north",
+        bounds=[[90.0, 0.0, 0.0], [90.0, 0.0, 0.0]],
+    )
+    lon = AuxCoord(
+        [60.0, 180.0],
+        standard_name="longitude",
+        var_name="longitude",
+        units="degrees_east",
+        bounds=[[0.0, 0.0, 120.0], [240.0, 120.0, 240.0]],
+    )
+    cube = Cube(
+        np.array([1.0, 2.0]),
+        var_name="tas",
+        aux_coords_and_dims=[(lat, 0), (lon, 0)],
+    )
+
+    AllVars(None).fix_metadata(CubeList([cube]))
+
+    node_lat = cube.mesh.coord(location="node", axis="y")
+    assert len(node_lat.points) == 4


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #3055

This PR fixes conservative regridding for CMIP6 ICON-ESM-LR data on its native unstructured grid. Some ICON-ESM-LR variables provide 1D latitude and longitude auxiliary coordinates with polygon bounds. When these variables are used with an ESMF conservative regridding scheme, `esmf_regrid` treats the source grid as a rectilinear grid and fails.

This follows the same principle as the native ICON fix: avoid Iris ``MeshXY.from_coords`` because it would create duplicate mesh nodes from shared polygon vertices. CMIP6 ICON-ESM-LR data do not provide the ICON ``vertex_of_cell`` connectivity, so the connectivity is reconstructed from the latitude and longitude polygon bounds instead.

I tested this with a reduced model only version of `ref/recipe_ref_cre.yml`
<details>
<summary>Model only test recipe</summary>

```yaml
documentation:
  title: ICON-ESM-LR cloud radiative effect regrid test
  description: >
    Reduced model-only version of ref/recipe_ref_cre.yml for testing
    conservative regridding of derived ICON-ESM-LR cloud radiative effects.
  authors:
    - bock_lisa
    - lauer_axel
  maintainer:
    - bock_lisa

datasets:
  - project: CMIP6
    activity: CMIP
    dataset: ICON-ESM-LR
    ensemble: r1i1p1f1
    institute: MPI-M
    exp: historical
    grid: gn
    mip: Amon

preprocessors:
  full_climatology:
    climate_statistics:
      period: full
    regrid:
      target_grid: 1x1
      scheme:
        reference: esmf_regrid.schemes:ESMFAreaWeighted
  zonal_mean:
    climate_statistics:
      period: full
    regrid:
      scheme:
        reference: esmf_regrid.schemes:ESMFAreaWeighted
      target_grid: 1x1
    zonal_statistics:
      operator: mean

diagnostics:
  plot_maps:
    description: Plot ICON-ESM-LR lwcre and swcre climatology maps.
    variables:
      lwcre:
        timerange: 1996/1996
        mip: Amon
        preprocessor: full_climatology
        derive: true
      swcre:
        timerange: 1996/1996
        mip: Amon
        preprocessor: full_climatology
        derive: true
    scripts:
      plot:
        script: monitor/multi_datasets.py
        plot_folder: "{plot_dir}"
        plot_filename: "{plot_type}_{real_name}_{dataset}_{mip}"
        plots:
          map:
            common_cbar: true
            x_pos_stats_avg: -0.1
            fontsize: 10

  plot_profiles:
    description: Plot ICON-ESM-LR lwcre and swcre zonal means.
    variables:
      lwcre:
        timerange: 1996/1996
        mip: Amon
        preprocessor: zonal_mean
        derive: true
      swcre:
        timerange: 1996/1996
        mip: Amon
        preprocessor: zonal_mean
        derive: true
    scripts:
      plot:
        script: monitor/multi_datasets.py
        plot_folder: "{plot_dir}"
        plot_filename: "{plot_type}_{real_name}_{dataset}_{mip}"
        plots:
          variable_vs_lat:
            legend_kwargs:
              loc: upper right
 ```

</details>

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
