### PR TITLE
Support automatic addition of supplementary variables for CORDEX

### DIFF
--- a/esmvalcore/_recipe/to_datasets.py
+++ b/esmvalcore/_recipe/to_datasets.py
@@ -252,7 +252,10 @@ def _append_missing_supplementaries(
 
             supplementary_facets: Facets = {
                 facet: "*"
-                for facet in FACETS.get(project, ["mip"])
+                for facet in (
+                    *tuple(FACETS.get(project, [])),
+                    "mip",
+                )
                 if facet not in _CMOR_KEYS + tuple(INHERITED_FACETS)
             }
             for key in ("frequency", "version"):

--- a/esmvalcore/io/esgf/facets.py
+++ b/esmvalcore/io/esgf/facets.py
@@ -58,7 +58,6 @@ FACETS = {
         "exp": "experiment",
         "frequency": "time_frequency",
         "institute": "institute",
-        "product": "product",
         "short_name": "variable",
     },
     "obs4MIPs": {


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Idea to improve a bit on #3031

Recipe for testing this with CORDEX data:
```yaml
documentation:
  title: |
    Example recipe that loads CORDEX-CMIP5 datasets.
  description: |
    This is an example recipe that loads CORDEX-CMIP5 datasets.
    It computes the climatology for surface temperature (ts).
  authors:
    - andela_bouwe
  maintainer:
    - andela_bouwe

preprocessors:
  ts_pp:
    custom_order: true
    climate_statistics:
      period: full
      operator: mean
    mask_landsea:
      mask_out: sea

datasets:
  - dataset: CCLM4-8-17
    driver: ICHEC-EC-EARTH
    ensemble: r12i1p1
    institute: CLMcom
    rcm_version: v1

diagnostics:
  bias:
    variables:
      ts:
        project: CORDEX
        mip: day
        domain: EUR-11
        exp: historical
        timerange: 2003/2005
        preprocessor: ts_pp
    scripts:
      plot:
        plot_folder: '{plot_dir}'
        plot_filename: '{plot_type}_{real_name}_{alias}_{mip}'
        facet_used_for_labels: 'alias'
        script: monitor/multi_datasets.py
        plots:
          map:
            show_stats: false
```

To check that it works correctly, ensure that the sea is masked in the resulting plot.

Link to documentation: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/recipe/overview.html#automatic-definition-of-supplementary-variables

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
