### PR TITLE
Add support for specifying the output directory from the command line

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -224,6 +224,11 @@
       "affiliation": "SMHI, Sweden",
       "name": "Lenhardt, Julien",
       "orcid": "https://orcid.org/0000-0002-9949-3989"
+    },
+    {
+      "affiliation": "Climate Resource, Australia",
+      "name": "Lewis, Jared",
+      "orcid": "https://orcid.org/0000-0002-8155-8924"
     }
   ],
   "description": "ESMValCore: A community tool for pre-processing data from Earth system models in CMIP and running analysis scripts.",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -228,6 +228,11 @@ authors:
     family-names: Lenhardt
     given-names: Julien
     orcid: "https://orcid.org/0000-0002-9949-3989"
+  -
+    affiliation: "Climate Resource, Australia"
+    family-names: Lewis
+    given-names: Jared
+    orcid: "https://orcid.org/0000-0002-8155-8924"
 
 cff-version: 1.2.0
 date-released: 2026-03-10

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -607,7 +607,7 @@ class ESMValTool:
         for project, version in self._extra_packages.items():
             print(f"{project}: {version}")  # noqa: T201
 
-    def run(self, recipe, **kwargs):
+    def run(self, recipe, session_name=None, **kwargs):
         """Execute an ESMValTool recipe.
 
         `esmvaltool run` executes the given recipe. To see a list of available
@@ -617,6 +617,17 @@ class ESMValTool:
         A list of possible flags is given here:
         https://docs.esmvaltool.org/projects/ESMValCore/en/latest/quickstart/configure.html#configuration-options
 
+        Parameters
+        ----------
+        recipe:
+            Path to the recipe to run.
+        session_name:
+            Name of the session output subdirectory (relative to the configured ``output_dir``).
+            When given, this value is used instead of the default ``<recipe.stem>_<timestamp>``.
+
+            If the given name already exists, a suffix is added to the session name to avoid overwriting existing data.
+        **kwargs:
+            Command line arguments to override configuration parameters.
         """
         from .config import CFG
         from .exceptions import InvalidConfigParameter
@@ -651,6 +662,8 @@ class ESMValTool:
 
         CFG["resume_from"] = parse_resume(CFG["resume_from"], recipe)
         session = CFG.start_session(recipe.stem)
+        if session_name is not None:
+            session.session_name = str(session_name)
 
         self._run(recipe, session, cli_config_dir)
 

--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -626,8 +626,6 @@ class ESMValTool:
             When given, this value is used instead of the default ``<recipe.stem>_<timestamp>``.
 
             If the given name already exists, a suffix is added to the session name to avoid overwriting existing data.
-        **kwargs:
-            Command line arguments to override configuration parameters.
         """
         from .config import CFG
         from .exceptions import InvalidConfigParameter

--- a/tests/unit/main/test_esmvaltool.py
+++ b/tests/unit/main/test_esmvaltool.py
@@ -96,6 +96,44 @@ def test_run_command_line_config(mocker, cfg, argument, value, tmp_path):
     assert session[argument] == value
 
 
+def test_run_session_name(mocker, cfg, tmp_path):
+    """Check that `session_name` overrides the auto-generated name."""
+    mocker.patch.object(esmvalcore.config, "CFG", cfg)
+    session = cfg.start_session.return_value
+
+    program = ESMValTool()
+    recipe_file = "/path/to/recipe_test.yml"
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    mocker.patch.object(program, "_get_recipe", return_value=Path(recipe_file))
+    mocker.patch.object(program, "_run")
+
+    program.run(recipe_file, session_name="result", config_dir=config_dir)
+
+    assert session.session_name == "result"
+    # Check that the session name is not passed to the cfg
+    for call in cfg.nested_update.call_args_list:
+        assert "session_name" not in call.args[0]
+
+
+def test_run_no_session_name(mocker, cfg, tmp_path):
+    """Check that the session name is left untouched by default."""
+    mocker.patch.object(esmvalcore.config, "CFG", cfg)
+
+    program = ESMValTool()
+    recipe_file = "/path/to/recipe_test.yml"
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    mocker.patch.object(program, "_get_recipe", return_value=Path(recipe_file))
+    mocker.patch.object(program, "_run")
+
+    program.run(recipe_file, config_dir=config_dir)
+
+    assert "session_name" not in cfg.start_session.return_value.__dict__
+
+
 @pytest.mark.parametrize("search_data", ["quick", "complete"])
 def test_run(mocker, session, search_data):
     session["search_data"] = search_data


### PR DESCRIPTION
## Description

Adds support for a `--session_name` CLI argument to allow users to specify the session name.
This allows the ability to write results to a fixed and known directory.

Closes #3100

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
