### PR TITLE
Remove configuration option ``extra_facets_dir`` and do not read extra facets from  ``~/.esmvaltool/extra_facets/``

### DIFF
--- a/esmvalcore/_main.py
+++ b/esmvalcore/_main.py
@@ -40,8 +40,6 @@ from typing import TYPE_CHECKING
 
 import fire
 
-from esmvalcore.config._config import warn_if_old_extra_facets_exist
-
 if TYPE_CHECKING:
     from esmvalcore.config import Session
 
@@ -670,8 +668,6 @@ class ESMValTool:
         if cli_config_dir is not None:
             CFG.update_from_dirs([cli_config_dir])
         CFG.nested_update(kwargs)
-
-        warn_if_old_extra_facets_exist()
 
     @staticmethod
     def _create_session_dir(session):

--- a/esmvalcore/config/_config.py
+++ b/esmvalcore/config/_config.py
@@ -3,20 +3,18 @@
 
 from __future__ import annotations
 
-import collections.abc
 import logging
 import os
-import warnings
-from functools import lru_cache
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
 
 from esmvalcore.cmor.table import read_cmor_tables
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning, RecipeError
+from esmvalcore.exceptions import RecipeError
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from esmvalcore.typing import FacetValue
 
 logger = logging.getLogger(__name__)
@@ -24,64 +22,6 @@ logger = logging.getLogger(__name__)
 TASKSEP = os.sep
 
 CFG: dict[str, Any] = {}
-
-# TODO: remove in v2.15.0
-USER_EXTRA_FACETS = Path.home() / ".esmvaltool" / "extra_facets"
-
-
-# TODO: remove in v2.15.0
-def _deep_update(dictionary, update):
-    for key, value in update.items():
-        if isinstance(value, collections.abc.Mapping):
-            dictionary[key] = _deep_update(dictionary.get(key, {}), value)
-        else:
-            dictionary[key] = value
-    return dictionary
-
-
-# TODO: remove in v2.15.0
-@lru_cache
-def load_extra_facets(
-    project: str,
-    extra_facets_dir: tuple[Path],
-) -> dict[str, dict[str, Any]]:
-    """Load deprecated extra facets."""
-    warn_if_old_extra_facets_exist()
-    config: dict[str, dict[str, Any]] = {}
-    config_paths = [Path.home() / ".esmvaltool" / "extra_facets"]
-    config_paths.extend([Path(p) for p in extra_facets_dir])
-    for config_path in config_paths:
-        config_file_paths = config_path.glob(f"{project.lower()}-*.yml")
-        for config_file_path in sorted(config_file_paths):
-            logger.debug("Loading extra facets from %s", config_file_path)
-            with config_file_path.open(encoding="utf-8") as config_file:
-                config_piece = yaml.safe_load(config_file)
-            if config_piece:
-                _deep_update(config, config_piece)
-    return config
-
-
-# TODO: remove in v2.15.0
-def warn_if_old_extra_facets_exist() -> None:
-    """Warn user if deprecated dask configuration file exists."""
-    if USER_EXTRA_FACETS.exists() and not os.environ.get(
-        "ESMVALTOOL_USE_NEW_EXTRA_FACETS_CONFIG",
-    ):
-        deprecation_msg = (
-            "Usage of extra facets located in ~/.esmvaltool/extra_facets has "
-            "been deprecated in ESMValCore version 2.13.0 and is scheduled "
-            "for removal in version 2.15.0. Please use the configuration "
-            "option `extra_facets` instead (see "
-            "https://github.com/ESMValGroup/ESMValCore/pull/2747 for "
-            "details). To silent this warning and ignore deprecated extra "
-            "facets, set the environment variable "
-            "ESMVALTOOL_USE_NEW_EXTRA_FACETS_CONFIG=1."
-        )
-        warnings.warn(
-            deprecation_msg,
-            ESMValCoreDeprecationWarning,
-            stacklevel=2,
-        )
 
 
 def load_config_developer(

--- a/esmvalcore/config/_config_validators.py
+++ b/esmvalcore/config/_config_validators.py
@@ -360,20 +360,6 @@ def validate_diagnostics(
     return validated_diagnostics
 
 
-# TODO: remove in v2.15.0
-def validate_extra_facets_dir(value):
-    """Validate extra_facets_dir."""
-    if isinstance(value, tuple):
-        msg = (
-            "Specifying `extra_facets_dir` as tuple has been deprecated in "
-            "ESMValCore version 2.13.0 and is scheduled for removal in "
-            "version 2.15.0. Please use a list instead."
-        )
-        warnings.warn(msg, ESMValCoreDeprecationWarning, stacklevel=2)
-        value = list(value)
-    return validate_pathlist(value)
-
-
 def validate_cmor_tables(value: dict) -> None:
     """Validate the CMOR table configuration."""
     # This has the side-effect of updating `esmvalcore.cmor.tables.CMOR_TABLES`.
@@ -454,8 +440,6 @@ _validators = {
     "skip_nonexistent": validate_bool,
     # From recipe
     "write_ncl_interface": validate_bool,
-    # TODO: remove in v2.15.0
-    "extra_facets_dir": validate_extra_facets_dir,
 }
 
 
@@ -485,44 +469,6 @@ def _handle_deprecation(
     # This function is called by the deprecation functions, which are called by
     # ValidatedConfig.__setitem__, so the calling site is 4 levels away.
     warnings.warn(deprecation_msg, ESMValCoreDeprecationWarning, stacklevel=4)
-
-
-# TODO: remove in v2.15.0
-def deprecate_extra_facets_dir(
-    validated_config: ValidatedConfig,
-    value: str | Path,
-    validated_value: str | Path,
-) -> None:
-    """Deprecate ``extra_facets_dir`` option.
-
-    Parameters
-    ----------
-    validated_config:
-        ``ValidatedConfig`` instance which will be modified in place.
-    value:
-        Raw input value for ``extra_facets_dir`` option.
-    validated_value:
-        Validated value for ``extra_facets_dir`` option.
-
-    """
-    validated_config  # noqa: B018
-    value  # noqa: B018
-    validated_value  # noqa: B018
-    option = "extra_facets_dir"
-    deprecated_version = "2.13.0"
-    remove_version = "2.15.0"
-    more_info = (
-        " Please use the option `extra_facets` instead (see "
-        "https://github.com/ESMValGroup/ESMValCore/pull/2747 for details)."
-    )
-    if os.environ.get("ESMVALTOOL_USE_NEW_EXTRA_FACETS_CONFIG"):
-        more_info += (
-            " Since the environment variable "
-            "ESMVALTOOL_USE_NEW_EXTRA_FACETS_CONFIG is set, "
-            "`extra_facets_dir` is ignored. To silent this warning, omit "
-            "`extra_facets_dir`."
-        )
-    _handle_deprecation(option, deprecated_version, remove_version, more_info)
 
 
 def deprecate_rootpath(
@@ -669,7 +615,6 @@ def deprecate_config_developer_file(
 # Example usage: see removed files in
 # https://github.com/ESMValGroup/ESMValCore/pull/2213
 _deprecators: dict[str, Callable] = {
-    "extra_facets_dir": deprecate_extra_facets_dir,  # TODO: remove in v2.15.0
     "drs": deprecate_drs,  # TODO: remove in v2.16.0
     "rootpath": deprecate_rootpath,  # TODO: remove in v2.16.0
     "download_dir": deprecate_download_dir,  # TODO: remove in v2.16.0
@@ -682,6 +627,5 @@ _deprecators: dict[str, Callable] = {
 # Example usage: see removed files in
 # https://github.com/ESMValGroup/ESMValCore/pull/2213
 _deprecated_options_defaults: dict[str, Any] = {
-    "extra_facets_dir": [],  # TODO: remove in v2.15.0
     "download_dir": "~/climate_data",  # TODO: remove in v2.16.0
 }

--- a/esmvalcore/dataset.py
+++ b/esmvalcore/dataset.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import fnmatch
 import logging
-import os
 import pprint
 import re
 import textwrap
@@ -26,7 +25,6 @@ from esmvalcore.cmor.table import (
     get_tables,
 )
 from esmvalcore.config import CFG
-from esmvalcore.config._config import load_extra_facets
 from esmvalcore.config._data_sources import _get_data_sources
 from esmvalcore.exceptions import InputFilesNotFound, RecipeError
 from esmvalcore.io.local import _dates_to_timerange
@@ -694,29 +692,6 @@ class Dataset:
                 )
                 for var in variables:
                     facets = raw_extra_facets[dataset_name][mip][var]
-                    extra_facets.update(facets)
-
-        # Add deprecated user-defined extra facets
-        # TODO: remove in v2.15.0
-        if os.environ.get("ESMVALTOOL_USE_NEW_EXTRA_FACETS_CONFIG"):
-            return extra_facets
-        project_details = load_extra_facets(
-            self.facets["project"],
-            tuple(self.session["extra_facets_dir"]),
-        )
-        dataset_names = self._pattern_filter(project_details, self["dataset"])  # type: ignore[arg-type]
-        for dataset_name in dataset_names:
-            mips = self._pattern_filter(
-                project_details[dataset_name],
-                self["mip"],  # type: ignore[arg-type]
-            )
-            for mip in mips:
-                variables = self._pattern_filter(
-                    project_details[dataset_name][mip],
-                    self["short_name"],  # type: ignore[arg-type]
-                )
-                for var in variables:
-                    facets = project_details[dataset_name][mip][var]
                     extra_facets.update(facets)
 
         return extra_facets

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -7,15 +7,12 @@ import pytest
 import yaml
 
 import esmvalcore.cmor.table
-import esmvalcore.config._config
 from esmvalcore.cmor.check import CheckLevels
 from esmvalcore.config import CFG, _config, _config_validators
 from esmvalcore.config._config import (
-    _deep_update,
     get_ignored_warnings,
-    load_extra_facets,
 )
-from esmvalcore.exceptions import ESMValCoreDeprecationWarning, RecipeError
+from esmvalcore.exceptions import RecipeError
 
 BUILTIN_CONFIG_DIR = Path(esmvalcore.config.__file__).parent.joinpath(
     "configurations",
@@ -46,28 +43,6 @@ def test_builtin_config_files_have_description(config_file: Path) -> None:
     # Add a basic check that the description is meaningful
     assert len(description) > 15
     assert description.endswith(".")
-
-
-TEST_DEEP_UPDATE = [
-    ([{}], {}),
-    ([{"a": 1, "b": 2}, {"a": 3}], {"a": 3, "b": 2}),
-    (
-        [
-            {"a": {"b": 1, "c": {"d": 2}}, "e": {"f": 4, "g": 5}},
-            {"a": {"b": 2, "c": 3}},
-        ],
-        {"a": {"b": 2, "c": 3}, "e": {"f": 4, "g": 5}},
-    ),
-]
-
-
-# TODO: remove in v2.15.0
-@pytest.mark.parametrize(("dictionaries", "expected_merged"), TEST_DEEP_UPDATE)
-def test_deep_update(dictionaries, expected_merged):
-    merged = dictionaries[0]
-    for update in dictionaries[1:]:
-        merged = _deep_update(merged, update)
-    assert expected_merged == merged
 
 
 BASE_PATH = importlib_files("tests") / "sample_data" / "extra_facets"
@@ -120,31 +95,6 @@ TEST_LOAD_EXTRA_FACETS = [
         },
     ),
 ]
-
-
-# TODO: Remove in v2.15.0
-@pytest.mark.parametrize(
-    ("project", "extra_facets_dir", "expected"),
-    TEST_LOAD_EXTRA_FACETS,
-)
-def test_load_extra_facets(project, extra_facets_dir, expected):
-    extra_facets = load_extra_facets(project, extra_facets_dir)
-    assert extra_facets == expected
-
-
-# TODO: Remove in v2.15.0
-def test_load_extra_facets_deprecation(tmp_path, monkeypatch):
-    monkeypatch.setattr(
-        esmvalcore.config._config,
-        "USER_EXTRA_FACETS",
-        tmp_path,
-    )
-    msg = (
-        r"Usage of extra facets located in ~/.esmvaltool/extra_facets has "
-        r"been deprecated"
-    )
-    with pytest.warns(ESMValCoreDeprecationWarning, match=msg):
-        load_extra_facets("PROJECT", ())
 
 
 def test_get_project_config(mocker):

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -7,12 +7,10 @@ import yaml
 import esmvalcore
 import esmvalcore.cmor.table
 from esmvalcore import __version__ as current_version
-from esmvalcore.config import CFG
 from esmvalcore.config._config_validators import (
     ValidationError,
     _handle_deprecation,
     _listify_validator,
-    deprecate_extra_facets_dir,
     validate_bool,
     validate_bool_or_none,
     validate_check_level,
@@ -362,23 +360,3 @@ def test_validate_config_developer(tmp_path, monkeypatch):
 
     # Restore original config-developer file
     validate_config_developer(None)
-
-
-# TODO: remove in v2.15.0
-def test_extra_facets_dir_tuple_deprecated(monkeypatch):
-    """Test extra_facets_dir."""
-    with pytest.warns(ESMValCoreDeprecationWarning):
-        monkeypatch.setitem(CFG, "extra_facets_dir", ("/extra/facets",))
-    assert CFG["extra_facets_dir"] == [Path("/extra/facets")]
-
-
-# TODO: remove in v2.15.0
-def test_deprecate_extra_facets_dir(monkeypatch):
-    """Test deprecate_extra_facets_dir."""
-    monkeypatch.setenv("ESMVALTOOL_USE_NEW_EXTRA_FACETS_CONFIG", "1")
-    msg = (
-        r"Since the environment variable "
-        r"ESMVALTOOL_USE_NEW_EXTRA_FACETS_CONFIG is set"
-    )
-    with pytest.warns(ESMValCoreDeprecationWarning, match=msg):
-        deprecate_extra_facets_dir({}, "value", "validated_value")

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -2012,69 +2012,6 @@ def test_load_fail(session):
         dataset.load()
 
 
-# TODO: Remove in v2.15.0
-def test_get_deprecated_extra_facets(tmp_path, monkeypatch):
-    dataset = Dataset(
-        project="CMIP5",
-        mip="Amon",
-        dataset="ACCESS1-3",
-        short_name="test",
-    )
-    extra_facets_file = tmp_path / f"{dataset['project'].lower()}-test.yml"
-    extra_facets_file.write_text(
-        textwrap.dedent("""
-            {dataset}:
-              {mip}:
-                {short_name}:
-                  key: value
-                  institute: new-institute
-            """)
-        .strip()
-        .format(**dataset.facets),
-    )
-    monkeypatch.setitem(CFG, "extra_facets_dir", [str(tmp_path)])
-
-    extra_facets = dataset._get_extra_facets()
-
-    assert extra_facets == {
-        "product": ["output1", "output2"],
-        "key": "value",
-        "institute": "new-institute",
-    }
-
-
-# TODO: Remove in v2.15.0
-def test_get_extra_facets_ignore_deprecated_facets(tmp_path, monkeypatch):
-    monkeypatch.setenv("ESMVALTOOL_USE_NEW_EXTRA_FACETS_CONFIG", "1")
-
-    dataset = Dataset(
-        project="CMIP5",
-        mip="Amon",
-        dataset="ACCESS1-3",
-        short_name="test",
-    )
-    extra_facets_file = tmp_path / f"{dataset['project'].lower()}-test.yml"
-    extra_facets_file.write_text(
-        textwrap.dedent("""
-            {dataset}:
-              {mip}:
-                {short_name}:
-                  key: value
-                  institute: new-institute
-            """)
-        .strip()
-        .format(**dataset.facets),
-    )
-    monkeypatch.setitem(CFG, "extra_facets_dir", [str(tmp_path)])
-
-    extra_facets = dataset._get_extra_facets()
-
-    assert extra_facets == {
-        "product": ["output1", "output2"],
-        "institute": ["CSIRO-BOM"],
-    }
-
-
 def test_get_extra_facets(monkeypatch):
     raw_extra_facets = {
         "not_TEST-MODEL": {


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

See https://github.com/ESMValGroup/ESMValCore/pull/2747: The configuration option ``extra_facets_dir`` and reaading extra facets from  ``~/.esmvaltool/extra_facets/`` has been deprecated in ESMValCore v2.13.0 and is scheduled for removal in v2.15.0.

## Backwards-incompatible change <a href="#backward-incompatible" id="backward-incompatible">#</a>

### Usage of extra facets files located at `~/.esmvaltool/extra_facets/`

Please use the configuration option `extra_facets` instead. For example, instead of

```yml
# content of ~/.esmvaltool/extra_facets/cmip6-mapping.yml
CMIP6-MODEL:
  Amon:
    tas:
      extra_facet_key: extra_facet_value
```

use the [configuration option](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/quickstart/configure.html#specify-configuration-for-esmvaltool-command-line-tool):

```yml
projects:
  CMIP6:
    extra_facets:
      CMIP6-MODEL:
        Amon:
          tas:
            extra_facet_key: extra_facet_value
```

### Usage of the configuration option `extra_facets_dir`

Please use the configuration option `extra_facets` instead. For example, instead of using `--extra_facets_dir=/path/to/extra_facets/` with the file

```yml
# content of /path/to/extra_facets/cmip6-mapping.yml
CMIP6-MODEL:
  Amon:
    tas:
      extra_facet_key: extra_facet_value
```

use the [configuration option](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/quickstart/configure.html#specify-configuration-for-esmvaltool-command-line-tool):

```yml
projects:
  CMIP6:
    extra_facets:
      CMIP6-MODEL:
        Amon:
          tas:
            extra_facet_key: extra_facet_value
```

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/3136.


***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [ ] [🛠][1] ~Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)~
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
