### PR TITLE
Ensure that input arrays to ``scipy.interpolate.interp1d`` functions are C-contiguous

### DIFF
--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -302,12 +302,12 @@ def cube_to_aux_coord(cube):
     )
 
 
-def ensure_c_contiguous_input(
-    func: Callable[[ArrayLike], ArrayLike],
-) -> Callable[[ArrayLike], ArrayLike]:
+def ensure_c_contiguous_input[T](
+    func: Callable[[np.ndarray], T],
+) -> Callable[[ArrayLike], T]:
     """Ensure that input to a function is C-contiguous (e.g., as expected by interp1d)."""
 
-    def wrapped_func(x: ArrayLike) -> ArrayLike:
+    def wrapped_func(x: ArrayLike) -> T:
         return func(np.ascontiguousarray(x))
 
     return wrapped_func

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -374,7 +374,7 @@ def get_bounds_cube(cubes, coord_var_name):
 
 
 @cache
-def get_pressure_to_altitude_func():
+def get_pressure_to_altitude_func() -> Callable[[ArrayLike], ArrayLike]:
     """Get function converting air pressure [Pa] to altitude [m].
 
     Returns

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -19,7 +19,10 @@ from scipy.interpolate import interp1d
 from esmvalcore.iris_helpers import date2num
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from iris.coords import Coord
+    from numpy.typing import ArrayLike
 
 logger = logging.getLogger(__name__)
 
@@ -299,24 +302,37 @@ def cube_to_aux_coord(cube):
     )
 
 
+def ensure_c_contiguous_input(
+    func: Callable[[ArrayLike], ArrayLike],
+) -> Callable[[ArrayLike], ArrayLike]:
+    """Ensure that input to a function is C-contiguous (e.g., as expected by interp1d)."""
+
+    def wrapped_func(x: ArrayLike) -> ArrayLike:
+        return func(x)
+
+    return wrapped_func
+
+
 @cache
-def get_altitude_to_pressure_func():
+def get_altitude_to_pressure_func() -> Callable[[ArrayLike], ArrayLike]:
     """Get function converting altitude [m] to air pressure [Pa].
 
     Returns
     -------
     callable
         Function that converts altitude to air pressure.
+
     """
     base_dir = os.path.dirname(os.path.abspath(__file__))
     source_file = os.path.join(base_dir, "us_standard_atmosphere.csv")
     data_frame = pd.read_csv(source_file, comment="#")
-    return interp1d(
+    interpolator = interp1d(
         data_frame["Altitude [m]"],
         data_frame["Pressure [Pa]"],
         kind="cubic",
         fill_value="extrapolate",
     )
+    return ensure_c_contiguous_input(interpolator)
 
 
 def get_bounds_cube(cubes, coord_var_name):
@@ -369,12 +385,13 @@ def get_pressure_to_altitude_func():
     base_dir = os.path.dirname(os.path.abspath(__file__))
     source_file = os.path.join(base_dir, "us_standard_atmosphere.csv")
     data_frame = pd.read_csv(source_file, comment="#")
-    return interp1d(
+    interpolator = interp1d(
         data_frame["Pressure [Pa]"],
         data_frame["Altitude [m]"],
         kind="cubic",
         fill_value="extrapolate",
     )
+    return ensure_c_contiguous_input(interpolator)
 
 
 def fix_bounds(cube, cubes, coord_var_names):

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -321,7 +321,6 @@ def get_altitude_to_pressure_func() -> Callable[[ArrayLike], ArrayLike]:
     -------
     callable
         Function that converts altitude to air pressure.
-
     """
     base_dir = os.path.dirname(os.path.abspath(__file__))
     source_file = os.path.join(base_dir, "us_standard_atmosphere.csv")

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -308,7 +308,7 @@ def ensure_c_contiguous_input(
     """Ensure that input to a function is C-contiguous (e.g., as expected by interp1d)."""
 
     def wrapped_func(x: ArrayLike) -> ArrayLike:
-        return func(x)
+        return func(np.ascontiguousarray(x))
 
     return wrapped_func
 

--- a/esmvalcore/cmor/_fixes/shared.py
+++ b/esmvalcore/cmor/_fixes/shared.py
@@ -314,7 +314,7 @@ def ensure_c_contiguous_input[T](
 
 
 @cache
-def get_altitude_to_pressure_func() -> Callable[[ArrayLike], ArrayLike]:
+def get_altitude_to_pressure_func() -> Callable[[ArrayLike], np.ndarray]:
     """Get function converting altitude [m] to air pressure [Pa].
 
     Returns
@@ -373,7 +373,7 @@ def get_bounds_cube(cubes, coord_var_name):
 
 
 @cache
-def get_pressure_to_altitude_func() -> Callable[[ArrayLike], ArrayLike]:
+def get_pressure_to_altitude_func() -> Callable[[ArrayLike], np.ndarray]:
     """Get function converting air pressure [Pa] to altitude [m].
 
     Returns

--- a/tests/integration/cmor/_fixes/test_shared.py
+++ b/tests/integration/cmor/_fixes/test_shared.py
@@ -1,5 +1,7 @@
 """Tests for shared functions for fixes."""
 
+from __future__ import annotations
+
 import dask.array as da
 import iris
 import iris.coords
@@ -22,6 +24,7 @@ from esmvalcore.cmor._fixes.shared import (
     add_scalar_typesea_coord,
     add_scalar_typesi_coord,
     cube_to_aux_coord,
+    ensure_c_contiguous_input,
     fix_bounds,
     fix_ocean_depth_coord,
     get_altitude_to_pressure_func,
@@ -786,3 +789,16 @@ def test_get_time_bounds_invalid_hr_fail(time_coord, freq):
     msg = f"For `n`-hourly data, `n` must be a divisor of 24, got '{freq}'"
     with pytest.raises(NotImplementedError, match=msg):
         get_time_bounds(time_coord, freq)
+
+
+def test_ensure_c_contiguous_input() -> None:
+    def identity[T](x: T) -> T:
+        return x
+
+    wrapped_identity = ensure_c_contiguous_input(identity)
+
+    f_arr = np.ones((2, 3), order="F")
+    assert f_arr.flags["C_CONTIGUOUS"] is False
+
+    c_arr = wrapped_identity(f_arr)
+    assert c_arr.flags["C_CONTIGUOUS"] is True


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Ensure that arrays used as input for interpolation functions created by [``scipy.interpolate.interp1d``](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html) are C-contiguous.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/3150

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
