### PR TITLE
Updates to How to make a release

### DIFF
--- a/doc/how-to/how-to-make-a-release.rst
+++ b/doc/how-to/how-to-make-a-release.rst
@@ -13,12 +13,20 @@ Perform the steps listed below with two persons, to reduce the risk of error.
    The previous release manager ensures the current release manager has the
    required administrative permissions to make the release.
    Consider the following services:
-   `conda-forge <https://github.com/conda-forge/esmvalcore-feedstock>`__,
-   `DockerHub <https://hub.docker.com/orgs/esmvalgroup>`__,
-   `PyPI <https://pypi.org/project/ESMValCore/>`__, and
-   `readthedocs <https://readthedocs.org/dashboard/esmvalcore/users/>`__.
+   `esmvalcore-feedstock <https://github.com/conda-forge/esmvalcore-feedstock>`__ for
+   making the conda-forge package, and
+   `esmvaltool.dkrz.de <https://esmvaltool.dkrz.de>`__ for uploading recipe
+   runs for the ESMValTool release.
 
-   Also, permissions to create tags in the GitHub repository.
+   Ask someone with administrative permissions to add you to the
+   `@release-managers <https://github.com/orgs/ESMValGroup/teams/release-managers>`_
+   team because only members of this team have permission to create tags in the
+   GitHub repository.
+
+   If the automation fails, you may need access to the following services:
+   `PyPI <https://pypi.org/project/ESMValCore/>`__,
+   `DockerHub <https://hub.docker.com/orgs/esmvalgroup>`__,
+   `readthedocs <https://readthedocs.org/dashboard/esmvalcore/users/>`__.
 
 The release of ESMValCore is tied to the release of ESMValTool.
 The detailed steps can be found in the ESMValTool
@@ -72,6 +80,12 @@ Use the script
 to create create a draft of the release notes.
 This script uses the titles and labels of merged pull requests since the
 previous release.
+Ensure that any pull request labelled as
+`issue introduced since last release <https://github.com/ESMValGroup/ESMValCore/pulls?q=is%3Apr+label%3A%22issue+introduced+since+last+release%22+is%3Aclosed>`__
+is listed on the same line as the pull request that introduced the issue.
+This label is intended for pull requests that fix a mistake that is was
+introduced after the last release and therefore is not a bug that is present in
+any released version of the code.
 Open a discussion to allow members of the development team to nominate pull
 requests as highlights. Add the most voted pull requests as highlights at the
 beginning of changelog. After the highlights section, list any backward
@@ -86,35 +100,40 @@ Copy the result to the file ``doc/changelog.rst``.
 Make a pull request and get it merged into ``main``. If updated after release
 branch is created, cherry pick it into the release branch.
 
-4. Create a release branch
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-Create a branch off the ``main`` branch and push it to GitHub. This should be named
-in the format ``v2.1.x`` where ``2.1`` is the version number.
-Ask someone with administrative permissions to set up branch protection rules
-for it so only you and the person helping you with the release can push to it.
-
-5. Make the (pre-)release on GitHub
+4. Make the (pre-)release on GitHub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Do a final check that all tests on CircleCI and GitHub Actions completed
 successfully.
 Then click the
 `releases tab <https://github.com/ESMValGroup/ESMValCore/releases>`__
-and create the new release from the release branch (i.e. not from ``main``).
+and create the new release.
 
-Create a tag corresponding to the release candidate or final release,
-e.g. ``v2.1.0rc1`` or ``v2.1.0``. You can add a link to the relevant changelog in the
+Create a tag corresponding to the release candidate or final release, e.g.
+``v2.1.0rc1`` or ``v2.1.0``. You can add a link to the relevant changelog in the
 release notes.
-
-If this is the *first* release candidate, create the release and tag off the ``main`` branch.
-We do this to inform `setuptools-scm <https://setuptools-scm.readthedocs.io/>`__ about
-the version number so that it creates the correct version number in ``main``.
-Only the first release candidate tag ``main`` is sufficient for this automatic versioning.
 
 Tick the `This is a pre-release` box if working with a release candidate.
 
-Note that the release branch remains intact and you should continue any work on the release
-on that branch.
+If this is the *first* release candidate, create the release and tag off the
+``main`` branch. We do this to inform
+`setuptools-scm <https://setuptools-scm.readthedocs.io/>`_ about the release,
+so that it increases the version number in ``main``. All subsequent release
+candidates and the final release are created off the release branch.
+
+5. Create a release branch
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a branch off the first release candidate tag and push it to GitHub.
+This step only needs to be performed once for every minor release.
+For the ``v2.1`` release, the command to create the release branch would be:
+``git checkout -b v2.1.x tags/v2.1.0rc1``, where ``v2.1.0rc1`` is the tag of the
+first release candidate.
+Release branches must be named ``vX.Y.x`` where ``X`` is the major and ``Y`` is
+the minor version number of the release to ensure setuptools-scm_ provides the
+correct version number for the release.
+Ask someone with administrative permissions to set up branch protection rules
+for it so only you and the person helping you with the release can push to it.
 
 6. Create and upload the PyPI package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/how-to/how-to-make-a-release.rst
+++ b/doc/how-to/how-to-make-a-release.rst
@@ -17,7 +17,7 @@ Perform the steps listed below with two persons, to reduce the risk of error.
    `DockerHub <https://hub.docker.com/orgs/esmvalgroup>`__,
    `PyPI <https://pypi.org/project/ESMValCore/>`__, and
    `readthedocs <https://readthedocs.org/dashboard/esmvalcore/users/>`__.
-   
+
    Also, permissions to create tags in the GitHub repository.
 
 The release of ESMValCore is tied to the release of ESMValTool.

--- a/doc/how-to/how-to-make-a-release.rst
+++ b/doc/how-to/how-to-make-a-release.rst
@@ -106,10 +106,11 @@ Create a tag corresponding to the release candidate or final release,
 e.g. ``v2.1.0rc1`` or ``v2.1.0``. You can add a link to the relevant changelog in the
 release notes.
 
-If this is the **first** release candidate, create the release and tag off the `main` branch. 
+If this is the *first* release candidate, create the release and tag off the ``main`` branch.
 We do this to inform `setuptools-scm <https://setuptools-scm.readthedocs.io/>`__ about
-the version number so that it creates the correct version number in `main`.
-Only the first release candidate tag `main` is sufficient for this automatic versioning.
+the version number so that it creates the correct version number in ``main``.
+Only the first release candidate tag ``main`` is sufficient for this automatic versioning.
+
 Tick the `This is a pre-release` box if working with a release candidate.
 
 Note that the release branch remains intact and you should continue any work on the release

--- a/doc/how-to/how-to-make-a-release.rst
+++ b/doc/how-to/how-to-make-a-release.rst
@@ -17,6 +17,8 @@ Perform the steps listed below with two persons, to reduce the risk of error.
    `DockerHub <https://hub.docker.com/orgs/esmvalgroup>`__,
    `PyPI <https://pypi.org/project/ESMValCore/>`__, and
    `readthedocs <https://readthedocs.org/dashboard/esmvalcore/users/>`__.
+   
+   Also, permissions to create tags in the GitHub repository.
 
 The release of ESMValCore is tied to the release of ESMValTool.
 The detailed steps can be found in the ESMValTool
@@ -52,24 +54,18 @@ follow these steps:
 
 All tests should pass before making a release (branch).
 
-2. Create a release branch
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-Create a branch off the ``main`` branch and push it to GitHub.
-Ask someone with administrative permissions to set up branch protection rules
-for it so only you and the person helping you with the release can push to it.
-
-3. Increase the version number
+2. Increase the version number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The version number is automatically generated from the information provided by
-git using [setuptools-scm](https://pypi.org/project/setuptools-scm/), but a
+git using `setuptools-scm <https://pypi.org/project/setuptools-scm/>`__, but a
 static version number is stored in ``CITATION.cff``.
 Make sure to update the version number and release date in ``CITATION.cff``.
 See https://semver.org for more information on choosing a version number.
-Make a pull request and get it merged into ``main`` and cherry pick it into
-the release branch.
+Make a pull request and get it merged into ``main``. If updated after release
+branch is created, cherry pick it into the release branch.
 
-4. Add release notes
+3. Add release notes
 ~~~~~~~~~~~~~~~~~~~~
 Use the script
 :ref:`esmvaltool/utils/draft_release_notes.py <draft_release_notes.py>`
@@ -87,9 +83,15 @@ may include, as well as a brief description on how to upgrade a deprecated featu
 Review the results, and if anything needs changing, change it on GitHub and
 re-run the script until the changelog looks acceptable.
 Copy the result to the file ``doc/changelog.rst``.
-Make a pull request and get it merged into ``main`` and cherry pick it into
-the release branch.
+Make a pull request and get it merged into ``main``. If updated after release
+branch is created, cherry pick it into the release branch.
 
+4. Create a release branch
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Create a branch off the ``main`` branch and push it to GitHub. This should be named
+in the format ``v2.1.x`` where ``2.1`` is the version number.
+Ask someone with administrative permissions to set up branch protection rules
+for it so only you and the person helping you with the release can push to it.
 
 5. Make the (pre-)release on GitHub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -100,39 +102,20 @@ Then click the
 `releases tab <https://github.com/ESMValGroup/ESMValCore/releases>`__
 and create the new release from the release branch (i.e. not from ``main``).
 
-Create a tag and tick the `This is a pre-release` box if working with a release candidate.
+Create a tag corresponding to the release candidate or final release,
+e.g. ``v2.1.0rc1`` or ``v2.1.0``. You can add a link to the relevant changelog in the
+release notes.
 
-6. Mark the release in the main branch
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When the (pre-)release is tagged, it is time to merge the release branch back into `main`.
-We do this for two reasons, namely, one, to mark the point up to which commits in `main`
-have been considered for inclusion into the present release, and, two, to inform
-setuptools-scm about the version number so that it creates the correct version number in
-`main`.
-However, unlike in a normal merge, we do not want to integrate any of the changes from the
-release branch into main.
-This is because all changes that should be in both branches, i.e. bug fixes, originate from
-`main` anyway and the only other changes in the release branch relate to the release itself.
-To take this into account, we perform the merge in this case on the command line using `the
-ours merge strategy <https://git-scm.com/docs/merge-strategies#Documentation/merge-strategies.txt-ours-1>`__
-(``git merge -s ours``), not to be confused with the ``ours`` option to the ort merge strategy
-(``git merge -X ours``).
-For details about merge strategies, see the above-linked page.
-To execute the merge use following sequence of steps
-
-.. code-block:: bash
-
-   git fetch
-   git checkout main
-   git pull
-   git merge -s ours v2.1.x
-   git push
+If this is the **first** release candidate, create the release and tag off the `main` branch. 
+We do this to inform `setuptools-scm <https://setuptools-scm.readthedocs.io/>`__ about
+the version number so that it creates the correct version number in `main`.
+Only the first release candidate tag `main` is sufficient for this automatic versioning.
+Tick the `This is a pre-release` box if working with a release candidate.
 
 Note that the release branch remains intact and you should continue any work on the release
 on that branch.
 
-7. Create and upload the PyPI package
+6. Create and upload the PyPI package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The package is automatically uploaded to the
@@ -146,7 +129,7 @@ If the automatic build and upload has failed for some reason, do it manually by
 following these instructions:
 
 -  Check out the tag corresponding to the release,
-   e.g. ``git checkout tags/v2.1.0``
+   e.g. ``git checkout tags/v2.1.0``
 -  Make sure your current working directory is clean by checking the output
    of ``git status`` and by running ``git clean -xdf`` to remove any files
    ignored by git.
@@ -165,7 +148,7 @@ following these instructions:
 You can read more about this in
 `Packaging Python Projects <https://packaging.python.org/tutorials/packaging-projects/>`__.
 
-8. Create the Conda package
+7. Create the Conda package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``esmvalcore`` package is published on the `conda-forge conda channel
@@ -194,7 +177,7 @@ conda-forge some time later.
 Contact the feedstock maintainers if you want to become a maintainer yourself.
 
 
-9. Check the Docker images
+8. Check the Docker images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There is one main Docker container images available for ESMValCore on

--- a/doc/how-to/how-to-make-a-release.rst
+++ b/doc/how-to/how-to-make-a-release.rst
@@ -70,7 +70,7 @@ git using `setuptools-scm <https://pypi.org/project/setuptools-scm/>`__, but a
 static version number is stored in ``CITATION.cff``.
 Make sure to update the version number and release date in ``CITATION.cff``.
 See https://semver.org for more information on choosing a version number.
-Make a pull request and get it merged into ``main``. If updated after release
+Make a pull request and get it merged into ``main``. If updated after the release
 branch is created, cherry pick it into the release branch.
 
 3. Add release notes
@@ -87,7 +87,7 @@ Copy the result to the file ``doc/changelog.rst``.
 Ensure that any pull request labelled as
 `issue introduced since last release <https://github.com/ESMValGroup/ESMValCore/pulls?q=is%3Apr+label%3A%22issue+introduced+since+last+release%22+is%3Aclosed>`__
 is listed on the same line as the pull request that introduced the issue.
-This label is intended for pull requests that fix a mistake that is was
+This label is intended for pull requests that fix a mistake that was
 introduced after the last release and therefore is not a bug that is present in
 any released version of the code.
 
@@ -95,12 +95,12 @@ Open a discussion to allow members of the development team to nominate pull
 requests as highlights. Add the most voted pull requests as highlights at the
 beginning of changelog. After the highlights section, list any backward
 incompatible changes that the release may include. The
-:ref:`backward compatibility policy<esmvaltool:backward-compatibility-policy>`.
+:ref:`backward compatibility policy<esmvaltool:backward-compatibility-policy>`
 lists the information that should be provided by the developer of any backward
 incompatible change. Make sure to also list any deprecations that the release
 may include, as well as a brief description on how to upgrade a deprecated feature.
 
-Make a pull request and get it merged into ``main``. If updated after release
+Make a pull request and get it merged into ``main``. If updated after the release
 branch is created, cherry pick it into the release branch.
 
 4. Make the (pre-)release on GitHub
@@ -137,8 +137,6 @@ Release branches must be named ``vX.Y.x`` where ``X`` is the major and ``Y`` is
 the minor version number of the release to ensure setuptools-scm_ provides the
 correct version number for the release.
 
-Ask someone with administrative permissions to set up branch protection rules
-for it so only you and the person helping you with the release can push to it.
 
 6. Create and upload the PyPI package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/how-to/how-to-make-a-release.rst
+++ b/doc/how-to/how-to-make-a-release.rst
@@ -79,13 +79,18 @@ Use the script
 :ref:`esmvaltool/utils/draft_release_notes.py <draft_release_notes.py>`
 to create create a draft of the release notes.
 This script uses the titles and labels of merged pull requests since the
-previous release.
+previous release date.
+Review the results, and if anything needs changing, change it on GitHub and
+re-run the script until the changelog looks acceptable.
+Copy the result to the file ``doc/changelog.rst``.
+
 Ensure that any pull request labelled as
 `issue introduced since last release <https://github.com/ESMValGroup/ESMValCore/pulls?q=is%3Apr+label%3A%22issue+introduced+since+last+release%22+is%3Aclosed>`__
 is listed on the same line as the pull request that introduced the issue.
 This label is intended for pull requests that fix a mistake that is was
 introduced after the last release and therefore is not a bug that is present in
 any released version of the code.
+
 Open a discussion to allow members of the development team to nominate pull
 requests as highlights. Add the most voted pull requests as highlights at the
 beginning of changelog. After the highlights section, list any backward
@@ -94,9 +99,7 @@ incompatible changes that the release may include. The
 lists the information that should be provided by the developer of any backward
 incompatible change. Make sure to also list any deprecations that the release
 may include, as well as a brief description on how to upgrade a deprecated feature.
-Review the results, and if anything needs changing, change it on GitHub and
-re-run the script until the changelog looks acceptable.
-Copy the result to the file ``doc/changelog.rst``.
+
 Make a pull request and get it merged into ``main``. If updated after release
 branch is created, cherry pick it into the release branch.
 
@@ -129,9 +132,11 @@ This step only needs to be performed once for every minor release.
 For the ``v2.1`` release, the command to create the release branch would be:
 ``git checkout -b v2.1.x tags/v2.1.0rc1``, where ``v2.1.0rc1`` is the tag of the
 first release candidate.
+
 Release branches must be named ``vX.Y.x`` where ``X`` is the major and ``Y`` is
 the minor version number of the release to ensure setuptools-scm_ provides the
 correct version number for the release.
+
 Ask someone with administrative permissions to set up branch protection rules
 for it so only you and the person helping you with the release can push to it.
 


### PR DESCRIPTION
Updates to the release doc.

Addressing some of the steps in https://github.com/ESMValGroup/ESMValCore/issues/2897#issuecomment-3558199775

Though leaving some parts and haven't merged with ESMValTool content so won't close it.

Link to documentation: https://esmvaltool--3174.org.readthedocs.build/projects/ESMValCore/en/3174/how-to/how-to-make-a-release.html