### PR TITLE
Update the ``lwp`` derive preprocessor function so it handles CORDEX data correctly

### DIFF
--- a/esmvalcore/preprocessor/_derive/lwp.py
+++ b/esmvalcore/preprocessor/_derive/lwp.py
@@ -9,6 +9,46 @@ from ._baseclass import DerivedVariableBase
 logger = logging.getLogger(__name__)
 
 
+LWP_ONLY_DATASETS = [
+    # CMIP5 models
+    {"project_id": "CMIP5", "model_id": "CCSM4"},
+    {"project_id": "CMIP5", "model_id": "CESM1-CAM5-1-FV2"},
+    {"project_id": "CMIP5", "model_id": "CESM1-CAM5"},
+    {"project_id": "CMIP5", "model_id": "CMCC-CESM"},
+    {"project_id": "CMIP5", "model_id": "CMCC-CM"},
+    {"project_id": "CMIP5", "model_id": "CMCC-CMS"},
+    {"project_id": "CMIP5", "model_id": "CSIRO-Mk3-6-0"},
+    {"project_id": "CMIP5", "model_id": "GISS-E2-1-G"},
+    {"project_id": "CMIP5", "model_id": "GISS-E2-1-H"},
+    {"project_id": "CMIP5", "model_id": "IPSL-CM5A-MR"},
+    {"project_id": "CMIP5", "model_id": "IPSL-CM5A-LR"},
+    {"project_id": "CMIP5", "model_id": "IPSL-CM5B-LR"},
+    {"project_id": "CMIP5", "model_id": "IPSL-CM5A-MR"},
+    {"project_id": "CMIP5", "model_id": "MIROC-ESM"},
+    {"project_id": "CMIP5", "model_id": "MIROC-ESM-CHEM"},
+    {"project_id": "CMIP5", "model_id": "MIROC-ESM"},
+    {"project_id": "CMIP5", "model_id": "MPI-ESM-LR"},
+    {"project_id": "CMIP5", "model_id": "MPI-ESM-MR"},
+    {"project_id": "CMIP5", "model_id": "MPI-ESM-P"},
+    # CMIP6 models
+    {"mip_era": "CMIP6", "source_id": "AWI-ESM-1-1-LR"},
+    {"mip_era": "CMIP6", "source_id": "CAMS-CSM1-0"},
+    {"mip_era": "CMIP6", "source_id": "FGOALS-f3-L"},
+    {"mip_era": "CMIP6", "source_id": "IPSL-CM6A-LR"},
+    {"mip_era": "CMIP6", "source_id": "MPI-ESM-1-2-HAM"},
+    {"mip_era": "CMIP6", "source_id": "MPI-ESM1-2-HR"},
+    {"mip_era": "CMIP6", "source_id": "MPI-ESM1-2-LR"},
+    {"mip_era": "CMIP6", "source_id": "SAM0-UNICON"},
+    # CORDEX-CMIP5 models
+    {"project_id": "CORDEX", "model_id": "SMHI-RCA4"},
+    {
+        "project_id": "CORDEX",
+        "model_id": "CLMcom-CCLM4-8-17",
+        "driving_model_id": "MOHC-HadGEM2-ES",
+    },
+]
+
+
 class DerivedVariable(DerivedVariableBase):
     """Derivation of variable `lwp`."""
 
@@ -35,62 +75,19 @@ class DerivedVariable(DerivedVariableBase):
         clwvi_cube = cubes.extract_cube(NameConstraint(var_name="clwvi"))
         clivi_cube = cubes.extract_cube(NameConstraint(var_name="clivi"))
 
-        # CMIP5 and CMIP6 have different global attributes that we use
-        # to determine model name and project name:
-        #   - CMIP5: model_id and project_id
-        #   - CMIP6: source_id and mip_era
-        project = clwvi_cube.attributes.get("project_id")
-        if project:
-            dataset = clwvi_cube.attributes.get("model_id")
-            # some CMIP6 models define both, project_id and source_id but
-            # no model_id --> also try source_id to find model name
-            if not dataset:
-                dataset = clwvi_cube.attributes.get("source_id")
-        else:
-            project = clwvi_cube.attributes.get("mip_era")
-            dataset = clwvi_cube.attributes.get("source_id")
-
         # Should we check that the model_id/project_id are the same on both
         # cubes?
 
-        bad_datasets = [
-            "CCSM4",  # CMIP5 models
-            "CESM1-CAM5-1-FV2",
-            "CESM1-CAM5",
-            "CMCC-CESM",
-            "CMCC-CM",
-            "CMCC-CMS",
-            "CSIRO-Mk3-6-0",
-            "GISS-E2-1-G",
-            "GISS-E2-1-H",
-            "IPSL-CM5A-MR",
-            "IPSL-CM5A-LR",
-            "IPSL-CM5B-LR",
-            "IPSL-CM5A-MR",
-            "MIROC-ESM",
-            "MIROC-ESM-CHEM",
-            "MIROC-ESM",
-            "MPI-ESM-LR",
-            "MPI-ESM-MR",
-            "MPI-ESM-P",
-            "AWI-ESM-1-1-LR",  # CMIP6 models
-            "CAMS-CSM1-0",
-            "FGOALS-f3-L",
-            "IPSL-CM6A-LR",
-            "MPI-ESM-1-2-HAM",
-            "MPI-ESM1-2-HR",
-            "MPI-ESM1-2-LR",
-            "SAM0-UNICON",
-        ]
-        affected_projects = ["CMIP5", "CMIP5_ETHZ", "CMIP6"]
-        if project in affected_projects and dataset in bad_datasets:
-            logger.info(
-                "Assuming that variable clwvi from %s dataset %s "
-                "contains only liquid water",
-                project,
-                dataset,
-            )
-            lwp_cube = clwvi_cube
+        for dataset in LWP_ONLY_DATASETS:
+            if all(
+                clwvi_cube.attributes.get(k) == v for k, v in dataset.items()
+            ):
+                logger.info(
+                    "Assuming that variable clwvi from %s contains only liquid water",
+                    ", ".join(f"{k}={v}" for k, v in dataset.items()),
+                )
+                lwp_cube = clwvi_cube
+                break
         else:
             lwp_cube = clwvi_cube - clivi_cube
 

--- a/tests/unit/preprocessor/_derive/test_lwp.py
+++ b/tests/unit/preprocessor/_derive/test_lwp.py
@@ -1,0 +1,40 @@
+"""Test derivation of `lwcre`."""
+
+import numpy as np
+import pytest
+from iris.cube import Cube, CubeList
+
+from esmvalcore.preprocessor._derive import lwp
+
+
+@pytest.mark.parametrize("special", [True, False])
+def test_lwp_calculation(special: bool) -> None:
+    """Test calculation of `lwp`."""
+    derived_var = lwp.DerivedVariable()
+    attrs = {
+        "project_id": "CORDEX",
+        "model_id": "CLMcom-CCLM4-8-17",
+    }
+    if special:
+        attrs["driving_model_id"] = "MOHC-HadGEM2-ES"
+        expected_data = 2
+    else:
+        expected_data = 1
+    cubes = CubeList(
+        [
+            Cube(
+                np.array([2]),
+                var_name="clwvi",
+                units="kg m-2",
+                attributes=attrs,
+            ),
+            Cube(
+                np.array([1]),
+                var_name="clivi",
+                units="kg m-2",
+                attributes=attrs,
+            ),
+        ],
+    )
+    result = derived_var.calculate(cubes)
+    np.testing.assert_equal(result.data, expected_data)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

As recommended by @axel-lauer: Update the ``lwp`` derive preprocessor function so it handles CORDEX data correctly.

When computing the minimum values of `lwp` in https://github.com/ESMValGroup/ESMValTool/pull/4199, the models added here have values below zero.

To check that this works as expected, the following code can be used:
```python
In [1]: from esmvalcore.dataset import Dataset

In [2]: from esmvalcore.preprocessor import derive

In [3]: import dask

In [4]: datasets = [Dataset(
   ...:   project="CORDEX",
   ...:   institute="CLMcom",
   ...:   dataset="CCLM4-8-17",
   ...:   rcm_version="v1",
   ...:   driver="MOHC-HadGEM2-ES",
   ...:   domain="EUR-11",
   ...:   mip="day",
   ...:   exp="historical",
   ...:   ensemble="r1i1p1",
   ...:   short_name=short_name,
   ...: ) for short_name in ["clivi", "clwvi"]]

In [5]: cubes = [dataset.load() for dataset in datasets]

In [6]: result = derive(cubes, short_name="lwp", standard_name="atmosphere_mass_content_of_cloud_liquid_water", long_name="Liquid Water Path", units="kg m-2")

In [7]: data = result.lazy_data()

In [8]: dask.compute(data.min(), data.mean(), data.max())
Out[8]: (np.float32(0.0), np.float32(3.963309e-05), np.float32(0.0032352395))

```

Observe that the minimum value with this pull request is zero instead of -1.3 kg/m-2.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
