### PR TITLE
Fix sic units of HadREM3-GA7-05 with driver ICHEC-EC-EARTH

### DIFF
--- a/esmvalcore/cmor/_fixes/cordex/ichec_ec_earth/hadrem3_ga7_05.py
+++ b/esmvalcore/cmor/_fixes/cordex/ichec_ec_earth/hadrem3_ga7_05.py
@@ -1,7 +1,12 @@
 """Fixes for rcm HadREM3-GA7-05 driven by ICHEC-EC-EARTH."""
 
+from esmvalcore.cmor._fixes.cordex.cnrm_cerfacs_cnrm_cm5.hadrem3_ga7_05 import (
+    Sic as BaseSic,
+)
 from esmvalcore.cmor._fixes.cordex.cordex_fixes import (
     MOHCHadREM3GA705 as BaseFix,
 )
 
 AllVars = BaseFix
+
+Sic = BaseSic

--- a/tests/integration/cmor/_fixes/cordex/test_ichec_ec_earth.py
+++ b/tests/integration/cmor/_fixes/cordex/test_ichec_ec_earth.py
@@ -1,10 +1,12 @@
 """Tests for the fixes for driver ICHEC-EC-Earth."""
 
 import iris
+import numpy as np
 import pytest
 
 from esmvalcore.cmor._fixes.cordex.ichec_ec_earth import (
     cosmo_crclim_v1_1,
+    hadrem3_ga7_05,
     wrf381p,
 )
 from esmvalcore.cmor.fix import Fix
@@ -43,6 +45,28 @@ def test_get_hadrem3ga705_fix(short_name):
         extra_facets={"driver": "ICHEC-EC-Earth"},
     )
     assert isinstance(fix[0], Fix)
+
+
+def test_hadrem3_ga7_05_sic() -> None:
+    fixes = Fix.get_fixes(
+        "CORDEX",
+        "HadREM3-GA7-05",
+        "day",
+        "sic",
+        extra_facets={"driver": "CNRM-CERFACS-CNRM-CM5"},
+    )
+    assert any(isinstance(fix, hadrem3_ga7_05.Sic) for fix in fixes)
+
+    cube = iris.cube.Cube(
+        np.array([0.5], dtype=np.float32),
+        var_name="sic",
+        standard_name="sea_ice_area_fraction",
+        units="%",
+    )
+    fix = next(fix for fix in fixes if isinstance(fix, hadrem3_ga7_05.Sic))
+    result = fix.fix_metadata([cube])
+    assert result[0].units == "%"
+    np.testing.assert_allclose(result[0].data, [50.0])
 
 
 @pytest.mark.parametrize("short_name", ["pr", "tas"])


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Correct the units of sic from model HadREM3-GA7-05, the NetCDF attribute says the units are in %, but from the values it seems more likely that the units are a fraction.

Follow up to #3135

To test that this works as expected, run this code and observe that the maximum is almost 100%, as expected for data in percent, instead of almost 1%.

```python
In [1]: from esmvalcore.dataset import Dataset

In [2]: Dataset(
   ...:   project="CORDEX",
   ...:   institute="MOHC",
   ...:   dataset="HadREM3-GA7-05",
   ...:   rcm_version="v1",
   ...:   driver="ICHEC-EC-EARTH",
   ...:   domain="EUR-11",
   ...:   mip="day",
   ...:   exp="historical",
   ...:   ensemble="r12i1p1",
   ...:   short_name="sic",
   ...: ).load().lazy_data().max().compute()
Out[2]: np.float32(99.909836)
```

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
