### PR TITLE
squeeze length-1 dimension awi-esm-1-1-lr sea ice variables

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -26,6 +26,11 @@
     },
     {
       "affiliation": "AWI, Germany",
+      "name": "Grusdt, Britta",
+      "orcid": "0000-0001-7938-3734"
+    },
+    {
+      "affiliation": "AWI, Germany",
       "name": "Koldunov, Nikolay",
       "orcid": "0000-0002-3365-8146"
     },

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,6 +29,11 @@ authors:
     orcid: "https://orcid.org/0000-0002-6887-4885"
   -
     affiliation: "AWI, Germany"
+    family-names: Grusdt
+    given-names: Britta
+    orcid: "https://orcid.org/0000-0001-7938-3734"
+  -
+    affiliation: "AWI, Germany"
     family-names: Koldunov
     given-names: Nikolay
     orcid: "https://orcid.org/0000-0002-3365-8146"

--- a/esmvalcore/cmor/_fixes/cmip6/awi_esm_1_1_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/awi_esm_1_1_lr.py
@@ -30,3 +30,39 @@ class AllVars(Fix):
             except AttributeError:
                 pass
         return cubes
+
+
+class FesomSeaIceScalar(Fix):
+    """Shared fix for FESOM sea-ice hemispheric scalar diagnostics.
+
+    AWI-ESM's sea-ice/ocean grid (FESOM) has a spurious length-1 'nodes' dimension that isn't part of the CMOR spec
+    (a scalar hemispheric integral over time only).
+    """
+
+    def fix_metadata(self, cubes):
+        """Squeeze out the spurious length-1 dimension named nodes."""
+        fixed_cubes = []
+        for cube in cubes:
+            if cube.coords("nodes"):
+                indices = [slice(None)] * cube.ndim
+                indices[cube.coord_dims("nodes")[0]] = 0
+                fixed_cubes.append(cube[tuple(indices)])
+            else:
+                fixed_cubes.append(cube)
+        return fixed_cubes
+
+
+class Siextentn(FesomSeaIceScalar):
+    """Fixes for siextentn."""
+
+
+class Siextents(FesomSeaIceScalar):
+    """Fixes for siextents."""
+
+
+class Siarean(FesomSeaIceScalar):
+    """Fixes for siarean."""
+
+
+class Siareas(FesomSeaIceScalar):
+    """Fixes for siareas."""

--- a/esmvalcore/cmor/_fixes/cmip6/awi_esm_1_1_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/awi_esm_1_1_lr.py
@@ -1,6 +1,15 @@
 """Fixes for AWI-ESM-1-1-LR model."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from esmvalcore.cmor._fixes.fix import Fix
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from iris.cube import Cube
 
 
 class AllVars(Fix):
@@ -39,7 +48,7 @@ class FesomSeaIceScalar(Fix):
     (a scalar hemispheric integral over time only).
     """
 
-    def fix_metadata(self, cubes):
+    def fix_metadata(self, cubes: Sequence[Cube]) -> list[Cube]:
         """Remove dimension of length 1 if it is either anonymous (without mapped coordinate) or called 'nodes'."""
         fixed_cubes = []
         for cube in cubes:

--- a/esmvalcore/cmor/_fixes/cmip6/awi_esm_1_1_lr.py
+++ b/esmvalcore/cmor/_fixes/cmip6/awi_esm_1_1_lr.py
@@ -40,12 +40,24 @@ class FesomSeaIceScalar(Fix):
     """
 
     def fix_metadata(self, cubes):
-        """Squeeze out the spurious length-1 dimension named nodes."""
+        """Remove dimension of length 1 if it is either anonymous (without mapped coordinate) or called 'nodes'."""
         fixed_cubes = []
         for cube in cubes:
+            mask_remove = [
+                cube.shape[dim] == 1 and not cube.coords(dimensions=dim)
+                for dim in range(cube.ndim)
+            ]
             if cube.coords("nodes"):
-                indices = [slice(None)] * cube.ndim
-                indices[cube.coord_dims("nodes")[0]] = 0
+                dim = cube.coord_dims("nodes")[
+                    0
+                ]  # assumes single coordinate 'nodes'
+                if cube.shape[dim] == 1:
+                    mask_remove[dim] = True
+
+            if any(mask_remove):
+                indices = [
+                    0 if remove else slice(None) for remove in mask_remove
+                ]
                 fixed_cubes.append(cube[tuple(indices)])
             else:
                 fixed_cubes.append(cube)

--- a/tests/integration/cmor/_fixes/cmip6/test_awi_esm_1_1_lr.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_awi_esm_1_1_lr.py
@@ -33,16 +33,22 @@ def sea_ice_scalar_cubes(request):
         var_name=var_name,
         dim_coords_and_dims=[(time_coord, 0)],
     )
-    nodes_coord = iris.coords.DimCoord(
+    cube_anonymous_dim = iris.cube.Cube(
+        np.ones((1, 3)),
+        var_name=var_name,
+        dim_coords_and_dims=[(time_coord, 1)],
+    )
+    nodes_coord = iris.coords.AuxCoord(
         np.arange(1),
         var_name="nodes",
     )
-    cube_bad = iris.cube.Cube(
+    cube_aux_nodes = iris.cube.Cube(
         np.ones((1, 3)),
         var_name=var_name,
-        dim_coords_and_dims=[(time_coord, 1), (nodes_coord, 0)],
+        dim_coords_and_dims=[(time_coord, 1)],
+        aux_coords_and_dims=[(nodes_coord, 0)],
     )
-    return iris.cube.CubeList([cube_ok, cube_bad])
+    return iris.cube.CubeList([cube_ok, cube_anonymous_dim, cube_aux_nodes])
 
 
 def test_get_tas_fix():

--- a/tests/integration/cmor/_fixes/cmip6/test_awi_esm_1_1_lr.py
+++ b/tests/integration/cmor/_fixes/cmip6/test_awi_esm_1_1_lr.py
@@ -1,11 +1,17 @@
 """Tests for the fixes of AWI-ESM-1-1-LR."""
 
 import iris
+import numpy as np
 import pytest
 
-from esmvalcore.cmor._fixes.cmip6.awi_esm_1_1_lr import AllVars
+from esmvalcore.cmor._fixes.cmip6.awi_esm_1_1_lr import (
+    AllVars,
+    FesomSeaIceScalar,
+)
 from esmvalcore.cmor._fixes.fix import GenericFix
 from esmvalcore.cmor.fix import Fix
+
+SEA_ICE_SCALAR_VARS = ["siextentn", "siextents", "siarean", "siareas"]
 
 
 @pytest.fixture
@@ -15,9 +21,39 @@ def sample_cubes():
     return iris.cube.CubeList([ta_cube, tas_cube])
 
 
+@pytest.fixture(params=SEA_ICE_SCALAR_VARS)
+def sea_ice_scalar_cubes(request):
+    var_name = request.param
+    time_coord = iris.coords.DimCoord(
+        np.arange(3),  # random small number of timesteps
+        standard_name="time",
+    )
+    cube_ok = iris.cube.Cube(
+        np.ones((3,)),
+        var_name=var_name,
+        dim_coords_and_dims=[(time_coord, 0)],
+    )
+    nodes_coord = iris.coords.DimCoord(
+        np.arange(1),
+        var_name="nodes",
+    )
+    cube_bad = iris.cube.Cube(
+        np.ones((1, 3)),
+        var_name=var_name,
+        dim_coords_and_dims=[(time_coord, 1), (nodes_coord, 0)],
+    )
+    return iris.cube.CubeList([cube_ok, cube_bad])
+
+
 def test_get_tas_fix():
     fix = Fix.get_fixes("CMIP6", "AWI-ESM-1-1-LR", "Amon", "tas")
     assert fix == [AllVars(None), GenericFix(None)]
+
+
+@pytest.mark.parametrize("short_name", SEA_ICE_SCALAR_VARS)
+def test_get_sea_ice_scalar_fixes(short_name):
+    fixes = Fix.get_fixes("CMIP6", "AWI-ESM-1-1-LR", "SImon", short_name)
+    assert fixes == [FesomSeaIceScalar(None), AllVars(None), GenericFix(None)]
 
 
 def test_allvars_fix_metadata(sample_cubes):
@@ -42,3 +78,9 @@ def test_allvars_no_need_tofix_metadata(sample_cubes):
             cube.attributes["parent_time_units"]
             == "days since 0001-01-01 00:00:00"
         )
+
+
+def test_sea_ice_scalar_fix_metadata(sea_ice_scalar_cubes):
+    out_cubes = FesomSeaIceScalar(None).fix_metadata(sea_ice_scalar_cubes)
+    for cube in out_cubes:
+        assert cube.ndim == 1


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Removes length-1 dimension 'nodes' for model awi_esm_1_1_lr for sea ice variables (sea ice extent north + south and sea ice area north + south) which is expected to have only a time dimension.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #issue_number

Link to documentation:

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [ ] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
