### PR TITLE
Allow special unit conversion for evapotranspiration

### DIFF
--- a/doc/recipe/preprocessor.rst
+++ b/doc/recipe/preprocessor.rst
@@ -2591,8 +2591,16 @@ Currently, the following special conversions are supported:
 
 * ``precipitation_flux`` (``kg m-2 s-1``) --
   ``lwe_precipitation_rate`` (``mm day-1``)
+* ``water_evaporation_flux`` (``kg m-2 s-1``) --
+  ``lwe_water_evaporation_rate`` (``mm day-1``)
+* ``water_potential_evaporation_flux`` (``kg m-2 s-1``) --
+  ``None`` (``mm day-1``)
+* ``water_evapotranspiration_flux`` (``kg m-2 s-1``) --
+  ``None`` (``mm day-1``)
 * ``equivalent_thickness_at_stp_of_atmosphere_ozone_content`` (``m``) --
   ``equivalent_thickness_at_stp_of_atmosphere_ozone_content`` (``DU``)
+* ``surface_air_pressure`` (``Pa``) --
+  ``atmosphere_mass_of_air_per_unit_area`` (``kg m-2``)
 
 .. hint::
    Names in the list correspond to ``standard_names`` of the input data.

--- a/esmvalcore/iris_helpers.py
+++ b/esmvalcore/iris_helpers.py
@@ -410,6 +410,10 @@ _SPECIAL_UNIT_CONVERSIONS: list[list[tuple[str | None, str]]] = [
         ("lwe_water_evaporation_rate", "mm s-1"),
     ],
     [
+        ("water_evapotranspiration_flux", "kg m-2 s-1"),
+        (None, "mm s-1"),  # no standard_name for evapotranspiration
+    ],
+    [
         ("water_potential_evaporation_flux", "kg m-2 s-1"),
         (None, "mm s-1"),  # no standard_name for potential evaporation rate
     ],

--- a/esmvalcore/preprocessor/_units.py
+++ b/esmvalcore/preprocessor/_units.py
@@ -44,6 +44,8 @@ def convert_units(cube: Cube, units: str | Unit) -> Cube:
       ``lwe_water_evaporation_rate`` (``mm day-1``)
     * ``water_potential_evaporation_flux`` (``kg m-2 s-1``) --
       ``None`` (``mm day-1``)
+    * ``water_evapotranspiration_flux`` (``kg m-2 s-1``) --
+      ``None`` (``mm day-1``)
     * ``equivalent_thickness_at_stp_of_atmosphere_ozone_content`` (``m``) --
       ``equivalent_thickness_at_stp_of_atmosphere_ozone_content`` (``DU``)
     * ``surface_air_pressure`` (``Pa``) --

--- a/tests/unit/preprocessor/_units/test_convert_units.py
+++ b/tests/unit/preprocessor/_units/test_convert_units.py
@@ -121,6 +121,18 @@ class TestConvertUnits(tests.Test):
             [[0.0, 86400.0], [172800.0, 259200.0]],
         )
 
+    def test_convert_water_evapotranspiration_flux(self):
+        """Test special conversion of water_evapotranspiration_flux."""
+        self.arr.standard_name = "water_evapotranspiration_flux"
+        self.arr.units = "kg m-2 s-1"
+        result = convert_units(self.arr, "mm day-1")
+        self.assertEqual(result.standard_name, None)
+        self.assertEqual(result.units, "mm day-1")
+        np.testing.assert_allclose(
+            result.data,
+            [[0.0, 86400.0], [172800.0, 259200.0]],
+        )
+
     def test_convert_rate_without_standard_name(self):
         """Test conversion of a flux without a standard name."""
         self.arr.units = "mm s-1"


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

Evapotranspiration is commonly used in `mm day-1`, but CMOR specifies it in `kg m-2 s-1`.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Link to documentation: https://esmvaltool--3182.org.readthedocs.build/projects/ESMValCore/en/3182/recipe/preprocessor.html#unit-conversion

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
