### PR TITLE
Add support for variable ``hfbasin`` to ICON-XPP CMORizer

### DIFF
--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -7,11 +7,12 @@ import logging
 import os
 import shutil
 import warnings
+from dataclasses import dataclass, fields
 from datetime import datetime, timedelta
 from pathlib import Path
 from shutil import copyfileobj
 from tempfile import NamedTemporaryFile
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlparse
 
 import iris
@@ -1128,3 +1129,53 @@ class NegateData(IconFix):
         """Fix data."""
         cube.data = -cube.core_data()
         return cube
+
+
+@dataclass(frozen=True, kw_only=True)
+class BasinToVariableMapping:
+    atlantic_arctic_ocean: str
+    indian_pacific_ocean: str
+    global_ocean: str
+
+
+class OceanBasinVariable(IconFix):
+    """Fixes for variables that use an ocean basin coordinate."""
+
+    basin_to_var: ClassVar[BasinToVariableMapping]
+
+    def fix_metadata(self, cubes: CubeList) -> CubeList:
+        """Fix metadata."""
+        preprocessed_cubes = CubeList([])
+        basin_coord = AuxCoord(
+            "placeholder",
+            standard_name="region",
+            long_name="ocean basin",
+            var_name="basin",
+        )
+        for basin_field in fields(self.basin_to_var):
+            basin = basin_field.name
+            basin_var_name = getattr(self.basin_to_var, basin)
+            cube = self.get_cube(cubes, var_name=basin_var_name)
+            cube.var_name = self.vardef.short_name
+            cube.attributes.locals = {}
+
+            # Remove longitude coordinate (with length 1)
+            cube = cube[..., 0]
+            cube.remove_coord("longitude")
+
+            # Add scalar basin coordinate
+            cube.add_aux_coord(basin_coord.copy(basin), ())
+            preprocessed_cubes.append(cube)
+
+        final_cube = preprocessed_cubes.merge_cube()
+
+        # Swap time and basin coordinates
+        final_cube.transpose([1, 0, 2, 3])
+
+        # By default, merge_cube() sorts the coordinate alphabetically (i.e.,
+        # atlantic_arctic_ocean -> global_ocean -> indian_pacific_ocean). Thus,
+        # we need to restore the desired order (atlantic_arctic_ocean ->
+        # indian_pacific_ocean -> global_ocean).
+        final_cube = final_cube[:, [0, 2, 1], ...]
+
+        return CubeList([final_cube])

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -1169,8 +1169,9 @@ class OceanBasinVariable(IconFix):
 
         final_cube = preprocessed_cubes.merge_cube()
 
-        # Swap time and basin coordinates
-        final_cube.transpose([1, 0, 2, 3])
+        # Dimension order should be (time, basin, ...)
+        new_order = [1, 0, *range(2, final_cube.ndim)]
+        final_cube.transpose(new_order)
 
         # By default, merge_cube() sorts the coordinate alphabetically (i.e.,
         # atlantic_arctic_ocean -> global_ocean -> indian_pacific_ocean). Thus,

--- a/esmvalcore/cmor/_fixes/icon/_base_fixes.py
+++ b/esmvalcore/cmor/_fixes/icon/_base_fixes.py
@@ -1157,6 +1157,8 @@ class OceanBasinVariable(IconFix):
             basin_var_name = getattr(self.basin_to_var, basin)
             cube = self.get_cube(cubes, var_name=basin_var_name)
             cube.var_name = self.vardef.short_name
+            cube.standard_name = None
+            cube.long_name = None
             cube.attributes.locals = {}
 
             # Remove longitude coordinate (with length 1)

--- a/esmvalcore/cmor/_fixes/icon/icon_xpp.py
+++ b/esmvalcore/cmor/_fixes/icon/icon_xpp.py
@@ -2,11 +2,16 @@
 
 import logging
 
-from iris.coords import AuxCoord
 from iris.cube import CubeList
 from scipy import constants
 
-from ._base_fixes import AllVarsBase, IconFix, NegateData
+from ._base_fixes import (
+    AllVarsBase,
+    BasinToVariableMapping,
+    IconFix,
+    NegateData,
+    OceanBasinVariable,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,49 +62,14 @@ Hfls = NegateData
 Hfss = NegateData
 
 
-class Msftmz(IconFix):
+class Msftmz(OceanBasinVariable):
     """Fixes for ``msftmz``."""
 
-    def fix_metadata(self, cubes: CubeList) -> CubeList:
-        """Fix metadata."""
-        preprocessed_cubes = CubeList([])
-        basin_coord = AuxCoord(
-            "placeholder",
-            standard_name="region",
-            long_name="ocean basin",
-            var_name="basin",
-        )
-        var_names = {
-            "atlantic_moc": "atlantic_arctic_ocean",
-            "pacific_moc": "indian_pacific_ocean",
-            "global_moc": "global_ocean",
-        }
-        for var_name, basin in var_names.items():
-            cube = self.get_cube(cubes, var_name=var_name)
-            cube.var_name = "msftmz"
-            cube.long_name = None
-            cube.attributes.locals = {}
-
-            # Remove longitude coordinate (with length 1)
-            cube = cube[..., 0]
-            cube.remove_coord("longitude")
-
-            # Add scalar basin coordinate
-            cube.add_aux_coord(basin_coord.copy(basin), ())
-            preprocessed_cubes.append(cube)
-
-        msftmz_cube = preprocessed_cubes.merge_cube()
-
-        # Swap time and basin coordinates
-        msftmz_cube.transpose([1, 0, 2, 3])
-
-        # By default, merge_cube() sorts the coordinate alphabetically (i.e.,
-        # atlantic_arctic_ocean -> global_ocean -> indian_pacific_ocean). Thus,
-        # we need to restore the desired order (atlantic_arctic_ocean ->
-        # indian_pacific_ocean -> global_ocean).
-        msftmz_cube = msftmz_cube[:, [0, 2, 1], ...]
-
-        return CubeList([msftmz_cube])
+    basin_to_var = BasinToVariableMapping(
+        atlantic_arctic_ocean="atlantic_moc",
+        indian_pacific_ocean="pacific_moc",
+        global_ocean="global_moc",
+    )
 
 
 Rlut = NegateData

--- a/esmvalcore/cmor/_fixes/icon/icon_xpp.py
+++ b/esmvalcore/cmor/_fixes/icon/icon_xpp.py
@@ -56,6 +56,16 @@ class Gpp(IconFix):
         return cubes
 
 
+class Hfbasin(OceanBasinVariable):
+    """Fixes for ``hfbasin``."""
+
+    basin_to_var = BasinToVariableMapping(
+        atlantic_arctic_ocean="atlantic_hfbasin",
+        indian_pacific_ocean="pacific_hfbasin",
+        global_ocean="global_hfbasin",
+    )
+
+
 Hfls = NegateData
 
 

--- a/esmvalcore/cmor/_fixes/native6/oras5.py
+++ b/esmvalcore/cmor/_fixes/native6/oras5.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import dask.array as da
 import iris
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 class Oras5Fix(IconFix):
     """Base class for all ORAS5 fixes."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize ORAS5 fix."""
         super().__init__(*args, **kwargs)
         self._horizontal_grids: dict[str, CubeList] = {}

--- a/esmvalcore/config/configurations/defaults/extra_facets_icon.yml
+++ b/esmvalcore/config/configurations/defaults/extra_facets_icon.yml
@@ -141,6 +141,7 @@ projects:
           amoc: {var_type: oce_moc}
 
           # 2D ocean variables
+          hfbasin: {var_type: oce_moc, lat_var: lat}
           hfds: {raw_name: HeatFlux_Total, var_type: oce_dbg}
           mlotst: {raw_name: mld, var_type: oce_dbg}
           siconc: {raw_name: conc, var_type: oce_ice, raw_units: '1'}

--- a/esmvalcore/typing.py
+++ b/esmvalcore/typing.py
@@ -8,13 +8,13 @@ import dask.array as da
 import numpy as np
 from iris.cube import Cube
 
-FacetValue = str | Sequence[str] | int | float
+type FacetValue = str | Sequence[str] | int | float
 """Type describing a single facet."""
 
-Facets = dict[str, FacetValue]
+type Facets = dict[str, FacetValue]
 """Type describing a collection of facets."""
 
-NetCDFAttr = str | int | float | Iterable
+type NetCDFAttr = str | int | float | Iterable
 """Type describing netCDF attributes.
 
 `NetCDF attributes
@@ -22,5 +22,5 @@ NetCDFAttr = str | int | float | Iterable
 be strings, numbers or sequences.
 """
 
-DataType = np.ndarray | da.Array | Cube
+type DataType = np.ndarray | da.Array | Cube
 """Type describing data."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ xfail_strict = true
 [tool.coverage.run]
 parallel = true
 source = ["esmvalcore"]
+omit = [
+    "typing.py",
+]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,6 @@ xfail_strict = true
 [tool.coverage.run]
 parallel = true
 source = ["esmvalcore"]
-omit = [
-    "typing.py",
-]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/integration/cmor/_fixes/icon/test_icon_xpp.py
+++ b/tests/integration/cmor/_fixes/icon/test_icon_xpp.py
@@ -17,6 +17,7 @@ from esmvalcore.cmor._fixes.icon.icon_xpp import (
     Clwvi,
     Evspsbl,
     Gpp,
+    Hfbasin,
     Hfls,
     Hfss,
     Msftmz,
@@ -643,6 +644,54 @@ def test_gpp_fix(cubes_regular_grid):
                 [2.0 * 44.0095 / 1000, 3.0 * 44.0095 / 1000],
             ],
         ],
+    )
+
+
+# Test hfbasin (for extra fix)
+
+
+def test_get_hfbasin_fix():
+    """Test getting of fix."""
+    fix = Fix.get_fixes("ICON", "ICON-XPP", "Omon", "hfbasin")
+    assert fix == [Hfbasin(None), AllVars(None), GenericFix(None)]
+
+
+def test_hfbasin_fix(cubes_regular_grid):
+    """Test fix."""
+    cube = cubes_regular_grid[0][..., [0]]
+    cube.coord("latitude").var_name = "lat"
+    cubes = CubeList([cube.copy() * 0.0, cube.copy() * 1.0, cube.copy() * 2.0])
+    cubes[0].var_name = "atlantic_hfbasin"
+    cubes[0].long_name = "atlantic northward ocean heat transport"
+    cubes[0].units = "W"
+    cubes[1].var_name = "global_hfbasin"
+    cubes[1].long_name = "global northward ocean heat transport"
+    cubes[1].units = "W"
+    cubes[2].var_name = "pacific_hfbasin"
+    cubes[2].long_name = "indopacific northward ocean heat transport"
+    cubes[2].units = "W"
+
+    fixed_cubes = fix_metadata(cubes, "Omon", "hfbasin")
+
+    assert len(fixed_cubes) == 1
+    cube = fixed_cubes[0]
+    assert cube.var_name == "hfbasin"
+    assert cube.standard_name == "northward_ocean_heat_transport"
+    assert cube.long_name == "Northward Ocean Heat Transport"
+
+    assert cube.units == "W"
+    assert "positive" not in cube.attributes
+    assert "invalid_units" not in cube.attributes
+
+    np.testing.assert_equal(
+        cube.coord("region").points,
+        ["atlantic_arctic_ocean", "indian_pacific_ocean", "global_ocean"],
+    )
+
+    assert cube.shape == (1, 3, 2)
+    np.testing.assert_allclose(
+        cube.data,
+        [[[0.0, 0.0], [0.0, 4.0], [0.0, 2.0]]],
     )
 
 

--- a/tests/integration/test_typing.py
+++ b/tests/integration/test_typing.py
@@ -1,0 +1,1 @@
+import esmvalcore.typing  # noqa: F401 (see github.com/ESMValGroup/ESMValCore/pull/3188)


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

This PR adds support for variable [``hfbasin``](https://github.com/ESMValGroup/ESMValCore/blob/dd9768e47c3153a476c3627700e6c4c6e202d7e9/esmvalcore/cmor/tables/cmip6/Tables/CMIP6_Omon.json#L1835-L1852) to ICON-XPP CMORizer.

Recipe to test this:

```yml
---
documentation:
  title: Ocean transport diagnostics.
  description: >
    Example recipe for three ocean-transport diagnostics, evaluated on a single
    CMIP6 model:

    - Northward ocean heat transport in the Atlantic-Arctic basin (hfbasin),
      as a latitude profile.
    - Antarctic Circumpolar Current (ACC) transport through the Drake Passage
      (mfo), as a time series.
    - Sea surface height gradient magnitude (zos), a proxy for the Gulf Stream
      separation bias, as a map.

    The first two use standard preprocessors with the monitor plot script; the
    SSH gradient uses the dedicated ocean/diagnostic_ssh_gradient.py script.
  authors:
    - debeire_kevin
  maintainer:
    - debeire_kevin
  references:
    - demora2018gmd

datasets:
  - {project: ICON, dataset: ICON-XPP, exp: historical-202510p1, timerange: 19950101/20141231}

preprocessors:
  oht_profile:
    custom_order: true
    extract_named_regions:
      regions: atlantic_arctic_ocean
    climate_statistics:
      operator: mean
      period: full
    convert_units:
      units: PW  # udunits: 1 PW = 1e15 W

diagnostics:
  ocean_heat_transport:
    description: Northward ocean heat transport in the Atlantic-Arctic basin (hfbasin).
    themes:
      - phys
    realms:
      - ocean
    variables:
      hfbasin:
        mip: Omon
        preprocessor: oht_profile
    scripts:
      plot:
        script: monitor/multi_datasets.py
        plot_folder: '{plot_dir}'
        plot_filename: '{plot_type}_{real_name}_{dataset}_{mip}'
        group_variables_by: variable_group
        facet_used_for_labels: dataset
        plots:
          variable_vs_lat: {}
```

Required data source:

```yml
projects:
  ICON:
    data:
      icon:
        type: esmvalcore.io.local.LocalDataSource
        rootpath: /work/bd0854/b380103/dwd_icon_data
        dirname_template: "{exp}"
        filename_template: "{exp}_{var_type}*.nc"
```

Example output: https://swift.dkrz.de/v1/dkrz_4eefb34f-8803-415a-bd70-9c455db9a403/esmvaltool_output/hfbasin/index.html. This looks very similar to the [MPI-ESM example plot](https://docs.esmvaltool.org/en/latest/recipes/recipe_ocean_transport.html#example-plots).


<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
