### PR TITLE
Use correct ICON filename template

### DIFF
--- a/doc/quickstart/find_data.rst
+++ b/doc/quickstart/find_data.rst
@@ -461,7 +461,7 @@ output.
 The default naming conventions for input directories and files for ICON are
 
 * input directories: ``{exp}``, ``{exp}/outdata``, or ``{exp}/output``
-* input files: ``{exp}_{var_type}*.nc``
+* input files: ``{exp}_{var_type}_*.nc``
 
 as configured in:
 

--- a/esmvalcore/config-developer.yml
+++ b/esmvalcore/config-developer.yml
@@ -184,7 +184,7 @@ ICON:
       - '{exp}/outdata'
       - '{exp}/output'
   input_file:
-    default: '{exp}_{var_type}*.nc'
+    default: '{exp}_{var_type}_*.nc'
   output_file: '{project}_{dataset}_{exp}_{var_type}_{mip}_{short_name}'
   cmor_type: 'CMIP6'
   cmor_default_table_prefix: 'CMIP6_'

--- a/esmvalcore/config/configurations/data-native-icon.yml
+++ b/esmvalcore/config/configurations/data-native-icon.yml
@@ -6,7 +6,7 @@ projects:
         type: esmvalcore.io.local.LocalDataSource
         rootpath: ~/climate_data
         dirname_template: "{exp}"
-        filename_template: "{exp}_{var_type}*.nc"
+        filename_template: "{exp}_{var_type}_*.nc"
         ignore_warnings:
           - message: "Failed to create 'height' dimension coordinate: The 'height' DimCoord bounds array must be strictly monotonic."
             module: iris

--- a/tests/integration/io/data_finder.yml
+++ b/tests/integration/io/data_finder.yml
@@ -1285,7 +1285,7 @@ get_input_filelist:
       - amip/amip_atm_2d_ml_20000301T000000Z.nc
 
   - dirname_template: "{exp}"
-    filename_template: "{exp}_{var_type}*.nc"
+    filename_template: "{exp}_{var_type}_*.nc"
     variable:
       variable_group: test
       short_name: tas
@@ -1344,7 +1344,7 @@ get_input_filelist:
       - amip/outdata/amip_var_20000501T000000Z.nc
 
   - dirname_template: "{exp}"
-    filename_template: "{exp}_{var_type}*.nc"
+    filename_template: "{exp}_{var_type}_*.nc"
     variable:
       variable_group: test
       short_name: tas

--- a/tests/integration/io/data_finder.yml
+++ b/tests/integration/io/data_finder.yml
@@ -1279,7 +1279,7 @@ get_input_filelist:
       - amip/outdata
       - amip/output
     file_patterns:
-      - amip_atm_2d_ml*.nc
+      - amip_atm_2d_ml_*.nc
     found_files:
       - amip/amip_atm_2d_ml_20000201T000000Z.nc
       - amip/amip_atm_2d_ml_20000301T000000Z.nc
@@ -1306,7 +1306,7 @@ get_input_filelist:
     dirs:
       - amip
     file_patterns:
-      - amip_atm_2d_ml*.nc
+      - amip_atm_2d_ml_*.nc
     found_files:
       - amip/amip_atm_2d_ml_20000201T000000Z.nc
       - amip/amip_atm_2d_ml_20000301T000000Z.nc
@@ -1337,7 +1337,7 @@ get_input_filelist:
       - amip/outdata
       - amip/output
     file_patterns:
-      - amip_var*.nc
+      - amip_var_*.nc
     found_files:
       - amip/amip_var_20000301T000000Z.nc
       - amip/outdata/amip_var_20000401T000000Z.nc
@@ -1365,7 +1365,7 @@ get_input_filelist:
     dirs:
       - amip
     file_patterns:
-      - amip_var*.nc
+      - amip_var_*.nc
     found_files:
       - amip/amip_var_20000301T000000Z.nc
 

--- a/tests/integration/recipe/test_recipe.py
+++ b/tests/integration/recipe/test_recipe.py
@@ -2625,7 +2625,9 @@ def test_representative_dataset_regular_var(
     datasets = _representative_datasets(dataset)
     assert len(datasets) == 1
     filename = datasets[0].files[0]
-    assert filename.name == "atm_amip-rad_R2B4_r1i1p1f1_atm_2d_ml_1990-1999.nc"
+    assert (
+        filename.name == "atm_amip-rad_R2B4_r1i1p1f1_atm_2d_ml__1990-1999.nc"
+    )
 
 
 @pytest.mark.parametrize("force_derivation", [True, False])


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

The current filename template for ICON is: `{exp}_{var_type}*.nc`, while actual files written by the ICON model use `{exp}_{var_type}_*.nc` (note the additional underscore).

The first might cause issues if multiple var types start with the same string, e.g., `var_type="atm_2d"` will find files

- `amip_atm_2d_19000101.nc`
- `amip_atm_2dml_19000101.nc`

but the second one actually uses a different var type (`atm_2dml`).

Since the associated configuration file is not loaded by default, I would argue that this change is backwards-compatible. Only users who actively copy the new configuration file will get the new behavior.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

***

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
