### PR TITLE
add GHA workflow that runs tests and coverage only on fork PRs

### DIFF
--- a/.github/workflows/run-tests-fork.yml
+++ b/.github/workflows/run-tests-fork.yml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     # run action ONLY on a fork PR
     if: github.event.pull_request.head.repo.full_name != github.repository
     strategy:

--- a/.github/workflows/run-tests-fork.yml
+++ b/.github/workflows/run-tests-fork.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           frozen: true
-          environments: ${{ matrix.environment }}
+          environments: test-py314
       - name: Check dependencies are compatible
         run: pip check
       - name: Run tests

--- a/.github/workflows/run-tests-fork.yml
+++ b/.github/workflows/run-tests-fork.yml
@@ -25,7 +25,7 @@ jobs:
           - ubuntu-latest
         environment:
           - test-py314
-    name: ${{ matrix.os }} ${{ matrix.environment }}
+    name: ubuntu-latest test-py314
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/run-tests-fork.yml
+++ b/.github/workflows/run-tests-fork.yml
@@ -20,11 +20,6 @@ jobs:
     if: github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        environment:
-          - test-py314
     name: ubuntu-latest test-py314
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/run-tests-fork.yml
+++ b/.github/workflows/run-tests-fork.yml
@@ -1,0 +1,52 @@
+---
+name: Test and Cov Fork PR
+
+permissions: {}
+
+# runs only on a forked PR targeting ESMValCore main
+on:
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: pixi run bash -e {0}
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    # run action ONLY on a fork PR
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        environment:
+          # perhaps add test-r to be complete?
+          - test-py314
+    name: ${{ matrix.os }} ${{ matrix.environment }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+        with:
+          frozen: true
+          environments: ${{ matrix.environment }}
+      - name: Check dependencies are compatible
+        run: pip check
+      - name: Check code quality
+        run: pre-commit run -a
+      - name: Run tests
+        run: pytest -n 2 --durations=10 --cov --cov-branch --cov-report=xml
+      - uses: codecov/codecov-action@v7.0.0
+        with:
+          files: ./coverage.xml
+      - name: Check the command line interface
+        run: |
+          esmvaltool version
+          esmvaltool -- --help

--- a/.github/workflows/run-tests-fork.yml
+++ b/.github/workflows/run-tests-fork.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     # run action ONLY on a fork PR
     if: github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
     name: ubuntu-latest test-py314
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/run-tests-fork.yml
+++ b/.github/workflows/run-tests-fork.yml
@@ -23,9 +23,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
         environment:
-          # perhaps add test-r to be complete?
           - test-py314
     name: ${{ matrix.os }} ${{ matrix.environment }}
     steps:
@@ -39,14 +37,8 @@ jobs:
           environments: ${{ matrix.environment }}
       - name: Check dependencies are compatible
         run: pip check
-      - name: Check code quality
-        run: pre-commit run -a
       - name: Run tests
         run: pytest -n 2 --durations=10 --cov --cov-branch --cov-report=xml
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage.xml
-      - name: Check the command line interface
-        run: |
-          esmvaltool version
-          esmvaltool -- --help

--- a/.github/workflows/run-tests-fork.yml
+++ b/.github/workflows/run-tests-fork.yml
@@ -43,7 +43,7 @@ jobs:
         run: pre-commit run -a
       - name: Run tests
         run: pytest -n 2 --durations=10 --cov --cov-branch --cov-report=xml
-      - uses: codecov/codecov-action@v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage.xml
       - name: Check the command line interface


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #3181 

This is in response to @schlunma 's suggestion to have coverage reporting for forked PRs - which is in essence a very useful thing to have; given the token limitations described in the issue, this may be the only viable solution on the back of our current infrastructure, and not using some dodgy GH action from some bloke's repo; the only caveat is that this means the developer will have tests running in their fork PR, but I minimized the amount of testing done to only the latest Python. Note that we explicitly turn off tests in forked PRs in our regular GHAs so this is a bit of a U-turn.

Live testing via dummy forked PR https://github.com/ESMValGroup/ESMValCore/pull/3196 and this action behaves as per specs, flagging `_ducky.py` as missing coverage :duck: 

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
