### PR TITLE
Show warnings in logs

### DIFF
--- a/esmvalcore/config/config-logging.yml
+++ b/esmvalcore/config/config-logging.yml
@@ -12,7 +12,7 @@ formatters:
 filters:
   only_ours: # only keep events from known loggers
     (): esmvalcore.config._logging.FilterMultipleNames
-    names: [esmvalcore, esmvaltool, intake-esgf]
+    names: [esmvalcore, esmvaltool, intake-esgf, py.warnings]
     mode: allow
   only_cmor: # only events from CMOR check and generic fixes
     (): esmvalcore.config._logging.FilterMultipleNames

--- a/esmvalcore/local.py
+++ b/esmvalcore/local.py
@@ -21,7 +21,7 @@ from esmvalcore.config._config import (
     get_project_config,
     load_config_developer,
 )
-from esmvalcore.exceptions import RecipeError
+from esmvalcore.exceptions import ESMValCoreDeprecationWarning, RecipeError
 from esmvalcore.io.local import (
     LocalDataSource,
     LocalFile,
@@ -212,7 +212,7 @@ def find_files(
         "The function 'esmvalcore.local.find_files' is deprecated and will be removed "
         "in version 2.16.0. Please use 'esmvalcore.local.LocalDataSource.find_data'"
     )
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    warnings.warn(msg, ESMValCoreDeprecationWarning, stacklevel=2)
 
     facets = dict(facets)
     if "original_short_name" in facets:


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

We use `logging.captureWarnings` in our [logging configuration](https://github.com/ESMValGroup/ESMValCore/blob/8c8ce25eb396203c6b0460485f2e94082b4783f4/esmvalcore/config/_logging.py#L150) to show warnings emitted by the `warnings` module as logging messages. According to the [docs](https://docs.python.org/3/library/logging.html#logging.captureWarnings), this does the following:

> If capture is True, warnings issued by the [warnings](https://docs.python.org/3/library/warnings.html#module-warnings) module will be redirected to the logging system. Specifically, a warning will be formatted using [warnings.formatwarning()](https://docs.python.org/3/library/warnings.html#warnings.formatwarning) and the resulting string logged to a logger named **'py.warnings'** with a severity of [WARNING](https://docs.python.org/3/library/logging.html#logging.WARNING).

Note the logger name `py.warnings`. Since https://github.com/ESMValGroup/ESMValCore/pull/2765, we [only show messages from certain loggers](https://github.com/ESMValGroup/ESMValCore/blob/8c8ce25eb396203c6b0460485f2e94082b4783f4/esmvalcore/config/config-logging.yml#L13-L16). However, the `py.warnings` logger is missing here, which eventually leads to omitted warnings messages.

This PR adds this. In addition, one instance of a `DeprecationWarning` is changed to `ESMValCoreDeprecationWarning` to be consistent with other deprecations.

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes ESMValCore better and what problem it solves.

    Before you start, please read our contribution guidelines: https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes https://github.com/ESMValGroup/ESMValCore/issues/3213.

***

## [Before you get started](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#getting-started)

- [x] [☝ Create an issue](https://github.com/ESMValGroup/ESMValCore/issues) to discuss what you are going to do

## [Checklist](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#checklist-for-pull-requests)

It is the responsibility of the author to make sure the pull request is ready to review. The icons indicate whether the item will be subject to the [🛠 Technical][1] or [🧪 Scientific][2] review.

<!-- The next two lines turn the 🛠 and 🧪 below into hyperlinks -->
[1]: https://docs.esmvaltool.org/en/latest/community/review.html#technical-review
[2]: https://docs.esmvaltool.org/en/latest/community/review.html#scientific-review

- [x] [🧪][2] The new functionality is [relevant and scientifically sound](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#scientific-relevance)
- [x] [🛠][1] This pull request has a [descriptive title and labels](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-title-and-label)
- [x] [🛠][1] Code is written according to the [code quality guidelines](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#code-quality)
- [x] [🧪][2] and [🛠][1] [Documentation](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#documentation) is available
- [x] [🛠][1] [Unit tests](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#tests) have been added
- [x] [🛠][1] Changes are [backward compatible](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#backward-compatibility)
- [x] [🛠][1] Any changed [dependencies have been added or removed](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#dependencies) correctly
- [x] [🛠][1] The [list of authors](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#list-of-authors) is up to date
- [x] [🛠][1] All [checks below this pull request](https://docs.esmvaltool.org/projects/ESMValCore/en/latest/contributing.html#pull-request-checks) were successful

***

To help with the number pull requests:

- 🙏 We kindly ask you to [review](https://docs.esmvaltool.org/en/latest/community/review.html#review-of-pull-requests) two other [open pull requests](https://github.com/ESMValGroup/ESMValCore/pulls) in this repository
